### PR TITLE
Add boilerplate repo documentation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to Tekton Chains
+
+Welcome to the Tekton Chains project! Thanks for considering contributing to
+our project and we hope you'll enjoy it :D
+
+**All contributors must comply with
+[the code of conduct](./code-of-conduct.md).**
+
+To get started developing, see our [DEVELOPMENT.md](./DEVELOPMENT.md).
+
+In [the community repo](https://github.com/tektoncd/community) you'll
+find info on:
+
+- [Contacting other contributors](https://github.com/tektoncd/community/blob/master/contact.md)
+- [Development standards](https://github.com/tektoncd/community/blob/master/standards.md) around
+  [principles](https://github.com/tektoncd/community/blob/master/standards.md#principles),
+  [commit messages](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
+  and [code](https://github.com/tektoncd/community/blob/master/standards.md#coding-standards)
+- [Processes](https://github.com/tektoncd/community/blob/master/process.md) like
+  [finding something to work on](https://github.com/tektoncd/community/blob/master/process.md#finding-something-to-work-on),
+  [proposing features](https://github.com/tektoncd/community/blob/master/process.md#proposing-features),
+  [reviews](https://github.com/tektoncd/community/blob/master/process.md#reviews)
+  and [becoming an OWNER](https://github.com/tektoncd/community/blob/master/process.md#owners)
+
+You can find details on our automation infrastructure in
+[the plumbing repo](https://github.com/tektoncd/plumbing).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,75 @@
+# Developing
+
+## Getting started
+
+1. Create [a GitHub account](https://github.com/join)
+1. Setup
+   [GitHub access via SSH](https://help.github.com/articles/connecting-to-github-with-ssh/)
+1. [Create and checkout a repo fork](#checkout-your-fork)
+1. Set up your [shell environment](#environment-setup)
+1. Install [requirements](#requirements)
+1. [Set up a Kubernetes cluster](#kubernetes-cluster)
+
+Then you can [iterate](#iterating).
+
+### Checkout your fork
+
+The Go tools require that you clone the repository to the
+`src/github.com/tektoncd/chains` directory in your
+[`GOPATH`](https://github.com/golang/go/wiki/SettingGOPATH).
+
+To check out this repository:
+
+1. Create your own
+   [fork of this repo](https://help.github.com/articles/fork-a-repo/)
+1. Clone it to your machine:
+
+```shell
+mkdir -p ${GOPATH}/src/github.com/tektoncd
+cd ${GOPATH}/src/github.com/tektoncd
+git clone git@github.com:${YOUR_GITHUB_USERNAME}/chains.git
+cd cli
+git remote add upstream git@github.com:tektoncd/chains.git
+git remote set-url --push upstream no_push
+```
+
+_Adding the `upstream` remote sets you up nicely for regularly
+[syncing your fork](https://help.github.com/articles/syncing-a-fork/)._
+
+### Requirements
+
+You must install these tools:
+
+1. [`go`](https://golang.org/doc/install): The language Tekton
+   Chains is built in
+1. [`git`](https://help.github.com/articles/set-up-git/): For source control
+1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+   (optional): For interacting with your kube cluster
+
+## Kubernetes cluster
+
+Docker for Desktop using an edge version has been proven to work for both
+developing and running Pipelines. Your Kubernetes version must be 1.11 or later.
+
+To setup a cluster with GKE:
+
+1. [Install required tools and setup GCP project](https://github.com/knative/docs/blob/master/docs/install/Knative-with-GKE.md#before-you-begin)
+   (You may find it useful to save the ID of the project in an environment
+   variable (e.g. `PROJECT_ID`).
+1. [Create a GKE cluster](https://github.com/knative/docs/blob/master/docs/install/Knative-with-GKE.md#creating-a-kubernetes-cluster)
+
+Note that
+[the `--scopes` argument to `gcloud container cluster create`](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create#--scopes)
+controls what GCP resources the cluster's default service account has access to;
+for example to give the default service account full access to your GCR
+registry, you can add `storage-full` to your `--scopes` arg.
+
+## Environment Setup
+
+To build the Tekton Chains project, you'll need to set `GO111MODULE=on`
+environment variable to force `go` to use [go
+modules](https://github.com/golang/go/wiki/Modules#quick-start).
+
+## Iterating
+
+Coming soon!

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# chains
+# Tekton Chains
 Supply Chain Security in Tekton Pipelines
+
+## Getting Started
+
+Tekton Chains is currently experimental, and does not have any published releases.
+Stay tuned for getting started information!
+
+## Want to contribute
+
+We are so excited to have you!
+
+See [./CONTRIBUTING.md] for an overview of our processes
+See [./DEVELOPMENT.md] for how to get started
+See [./ROADMAP.md] for the current roadmap
+Look at our good first issues and our help wanted issues
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,3 @@
+# Tekton Chains Roadmap
+
+COMING SOON

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at
+tekton-code-of-conduct@googlegroups.com. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
This commit adds boilerplate documentation required for all Tekton
projects. The DEVELOPMENT.md and ROADMAP.md are mostly blank, but
will be filled in once we get started.