### PR TITLE
Tweak the golang-ci config

### DIFF
--- a/.golang-ci.yaml
+++ b/.golang-ci.yaml
@@ -1,0 +1,28 @@
+linters-settings:
+  linters:
+    disable-all: true
+    enable:
+    - errcheck
+    - gofmt
+    - goimports
+    - gosec
+    - gocritic
+    - golint
+  output:
+    uniq-by-line: false
+  issues:
+    exclude-rules:
+    - path: _test\.go
+      linters:
+      - errcheck
+      - gosec
+    max-issues-per-linter: 0
+    max-same-issues: 0
+  run:
+    issues-exit-code: 1
+    build-tags:
+    - e2e
+    skip-dirs:
+    - vendor
+    timeout: 10m
+    modules-download-mode: vendor

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -32,7 +32,7 @@ source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scri
 function post_build_tests() {
   header "running golangci-lint"
   # deadline of 5m, and show all the issues
-  golangci-lint -j 1 --color=never run
+  golangci-lint --color=never run
 }
 
 # We use the default build, unit and integration test runners.


### PR DESCRIPTION
This adds a golang-ci.yaml, borrowed from tektoncd/pipeline as a starting
point. It also increases parallelization to the default (12), rather than 1.

This should fix the timeout issues we're seeing in presubmits.