### PR TITLE
Add and wire up the signing interfaces.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,8 +18,11 @@ import (
 	"flag"
 
 	tkcontroller "github.com/tektoncd/chains/pkg/controller"
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/taskrun"
+	"github.com/tektoncd/pipeline/pkg/reconciler"
 	"k8s.io/client-go/tools/cache"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -44,8 +47,14 @@ func main() {
 			// TODO: store and use the cmw
 			logger := logging.FromContext(ctx)
 			taskRunInformer := taskruninformer.Get(ctx)
+			kubeclientset := kubeclient.Get(ctx)
+			pipelineclientset := pipelineclient.Get(ctx)
 
 			c := &tkcontroller.Reconciler{
+				Base: &reconciler.Base{
+					KubeClientSet:     kubeclientset,
+					PipelineClientSet: pipelineclientset,
+				},
 				Logger:        logger,
 				TaskRunLister: taskRunInformer.Lister(),
 			}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -4,11 +4,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/tektoncd/chains/pkg/signing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	informers "github.com/tektoncd/pipeline/pkg/client/informers/externalversions/pipeline/v1beta1"
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	faketaskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/taskrun/fake"
+	"github.com/tektoncd/pipeline/pkg/reconciler"
+	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	logtesting "knative.dev/pkg/logging/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
@@ -65,4 +71,93 @@ func setupData(ctx context.Context, t *testing.T, trs []*v1beta1.TaskRun) inform
 	}
 	c.ClearActions()
 	return tri
+}
+
+func TestReconciler_handleTaskRun(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		tr         *v1beta1.TaskRun
+		shouldSign bool
+	}{
+		{
+			name: "complete, already signed",
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{signing.ChainsAnnotation: "true"},
+				},
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1beta1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					}},
+			},
+			shouldSign: false,
+		},
+		{
+			name: "complete, not already signed",
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1beta1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					}},
+			},
+			shouldSign: true,
+		},
+		{
+			name: "not complete, not already signed",
+			tr: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1beta1.Status{
+						Conditions: []apis.Condition{},
+					}},
+			},
+			shouldSign: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock out SignTaskRun
+			m, cleanup := setupMocks()
+			defer cleanup()
+			ctx, _ := rtesting.SetupFakeContext(t)
+			c := fakepipelineclient.Get(ctx)
+
+			r := &Reconciler{
+				Base: &reconciler.Base{
+					PipelineClientSet: c,
+				},
+				Logger: logtesting.TestLogger(t),
+			}
+			if err := r.handleTaskRun(ctx, tt.tr); err != nil {
+				t.Errorf("Reconciler.handleTaskRun() error = %v", err)
+			}
+			if m.signed != tt.shouldSign {
+				t.Errorf("Reconciler.handleTaskRun() signed = %v, wanted %v", m.signed, tt.shouldSign)
+			}
+		})
+	}
+}
+
+func setupMocks() (*mockSigner, func()) {
+	m := &mockSigner{}
+	oldSigner := signing.SignTaskRun
+	signing.SignTaskRun = m.mockSignTaskRun
+	return m, func() {
+		signing.SignTaskRun = oldSigner
+	}
+}
+
+type mockSigner struct {
+	signed bool
+}
+
+func (m *mockSigner) mockSignTaskRun(logger *zap.SugaredLogger, ps versioned.Interface, tr *v1beta1.TaskRun) error {
+	m.signed = true
+	return nil
 }

--- a/pkg/signing/formats/format.go
+++ b/pkg/signing/formats/format.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package formats
+
+import "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+// Payloader is an interface to generate a chains Payload from a TaskRun
+type Payloader interface {
+	CreatePayload(tr *v1beta1.TaskRun) (interface{}, error)
+	Type() string
+}
+
+const (
+	PayloadTypeTekton = "tekton"
+)
+
+// AllPayloadTypes is a list of all valid Payload types.
+var AllPayloadTypes = []Payloader{
+	&Tekton{},
+}

--- a/pkg/signing/formats/tekton.go
+++ b/pkg/signing/formats/tekton.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package formats
+
+import "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+// Tekton is a formatter that just captures the TaskRun with no modifications.
+type Tekton struct {
+}
+
+// CreatePayload implements the Payloader interface.
+func (i *Tekton) CreatePayload(tr *v1beta1.TaskRun) (interface{}, error) {
+	return tr, nil
+}
+
+func (i *Tekton) Type() string {
+	return PayloadTypeTekton
+}

--- a/pkg/signing/formats/tekton_test.go
+++ b/pkg/signing/formats/tekton_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package formats
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+func TestTekton_CreatePayload(t *testing.T) {
+	tests := []struct {
+		name string
+		tr   *v1beta1.TaskRun
+	}{
+		{
+			name: "tr",
+			tr: &v1beta1.TaskRun{
+				Spec: v1beta1.TaskRunSpec{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Tekton{}
+			got, err := i.CreatePayload(tt.tr)
+			if err != nil {
+				t.Errorf("Tekton.CreatePayload() error = %v", err)
+				return
+			}
+			// This payloader just returns the taskrun unmodified.
+			if !reflect.DeepEqual(got, tt.tr) {
+				t.Errorf("Tekton.CreatePayload() = %v, want %v", got, tt.tr)
+			}
+		})
+	}
+}

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"github.com/tektoncd/chains/pkg/signing/formats"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.uber.org/zap"
+)
+
+const (
+	// ChainsAnnotation is the standard annotation to indicate a TR has been signed.
+	ChainsAnnotation = "chains.tekton.dev/signed"
+)
+
+// IsSigned determines whether a TaskRun has already been signed.
+func IsSigned(tr *v1beta1.TaskRun) bool {
+	signature, ok := tr.ObjectMeta.Annotations[ChainsAnnotation]
+	if !ok {
+		return false
+	}
+	return signature == "true"
+}
+
+// MarkSigned marks a TaskRun as signed.
+func MarkSigned(tr *v1beta1.TaskRun, ps versioned.Interface) error {
+	if tr.ObjectMeta.Annotations == nil {
+		tr.ObjectMeta.Annotations = map[string]string{}
+	}
+	tr.ObjectMeta.Annotations[ChainsAnnotation] = "true"
+	if _, err := ps.TektonV1beta1().TaskRuns(tr.Namespace).Update(tr); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SignTaskRun signs a TaskRun, and marks it as signed.
+// Use var for mocking
+var SignTaskRun = func(logger *zap.SugaredLogger, ps versioned.Interface, tr *v1beta1.TaskRun) error {
+	// First sign the overall TaskRun with all the configured payloads
+	payloads := generatePayloads(logger, tr)
+	logger.Infof("Generated payloads: %v for %s/%s", payloads, tr.Namespace, tr.Name)
+
+	// TODO: Store those payloads in all the configured storage systems.
+
+	// Now mark the TaskRun as signed
+	return MarkSigned(tr, ps)
+}
+
+func generatePayloads(logger *zap.SugaredLogger, tr *v1beta1.TaskRun) []interface{} {
+	payloads := []interface{}{}
+	for _, payloader := range formats.AllPayloadTypes {
+		payload, err := payloader.CreatePayload(tr)
+		if err != nil {
+			logger.Errorf("Error creating payload of type %s for %s/%s", payloader, tr.Namespace, tr.Name)
+			continue
+		}
+		payloads = append(payloads, payload)
+	}
+	return payloads
+}

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestMarkSigned(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	// Create a TR for testing
+	c := fakepipelineclient.Get(ctx)
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-taskrun",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: "foo",
+			},
+		},
+	}
+	if _, err := c.TektonV1beta1().TaskRuns(tr.Namespace).Create(tr); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now mark it as signed.
+	if err := MarkSigned(tr, c); err != nil {
+		t.Errorf("MarkSigned() error = %v", err)
+	}
+
+	// Now check the signature.
+	signed, err := c.TektonV1beta1().TaskRuns(tr.Namespace).Get(tr.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Get() error = %v", err)
+	}
+	if _, ok := signed.Annotations[ChainsAnnotation]; !ok {
+		t.Error("Taskrun not signed.")
+	}
+}
+
+func TestIsSigned(t *testing.T) {
+	tests := []struct {
+		name       string
+		annotation string
+		want       bool
+	}{
+		{
+			name:       "signed",
+			want:       true,
+			annotation: "true",
+		},
+		{
+			name:       "signed with other string",
+			want:       false,
+			annotation: "baz",
+		},
+		{
+			name:       "not signed",
+			want:       false,
+			annotation: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ChainsAnnotation: tt.annotation,
+					},
+				},
+			}
+			got := IsSigned(tr)
+			if got != tt.want {
+				t.Errorf("IsSigned() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This defines an interface to convert a TaskRun to a payload format. Right
now the only supported format is just native Tekton (a passthrough of the TaskRun).
We can add other formats, like InToto and Grafeas next.

This also adds a few other small functions so we can wire this up to the controller:
- MarkSigned, to mark the TaskRun as signed.
- IsSigned, to tell if the TaskRun has already been signed.

Note: Payloads are not currently stored anywhere.