### PR TITLE
Remove sbwsg and dibyom from list of owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,4 @@ approvers:
 - font
 - lukehinds
 - mpeters
-- dibyom
-- sbwsg
 - skelterjohn


### PR DESCRIPTION
Original commit comment on the owners file says:

    This contains the initial approvers from
    https://docs.google.com/document/d/1dJjNTOXsT_dMZIX4i5iRw10fRQZBQqUP8YmbN2AwhAA/edit

That ain't me.