### PR TITLE
Only store the TaskRun.Status for Tekton payload types.

### DIFF
--- a/pkg/signing/formats/tekton.go
+++ b/pkg/signing/formats/tekton.go
@@ -15,13 +15,13 @@ package formats
 
 import "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
-// Tekton is a formatter that just captures the TaskRun with no modifications.
+// Tekton is a formatter that just captures the TaskRun Status with no modifications.
 type Tekton struct {
 }
 
 // CreatePayload implements the Payloader interface.
 func (i *Tekton) CreatePayload(tr *v1beta1.TaskRun) (interface{}, error) {
-	return tr, nil
+	return tr.Status, nil
 }
 
 func (i *Tekton) Type() string {

--- a/pkg/signing/formats/tekton_test.go
+++ b/pkg/signing/formats/tekton_test.go
@@ -28,7 +28,7 @@ func TestTekton_CreatePayload(t *testing.T) {
 		{
 			name: "tr",
 			tr: &v1beta1.TaskRun{
-				Spec: v1beta1.TaskRunSpec{},
+				Status: v1beta1.TaskRunStatus{},
 			},
 		},
 	}
@@ -41,7 +41,7 @@ func TestTekton_CreatePayload(t *testing.T) {
 				return
 			}
 			// This payloader just returns the taskrun unmodified.
-			if !reflect.DeepEqual(got, tt.tr) {
+			if !reflect.DeepEqual(got, tt.tr.Status) {
 				t.Errorf("Tekton.CreatePayload() = %v, want %v", got, tt.tr)
 			}
 		})


### PR DESCRIPTION
This prevents infinite cycles - storing the metadata can mutate the payload itself.