### PR TITLE
Add and wire up a storage interface.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 
 	tkcontroller "github.com/tektoncd/chains/pkg/controller"
+	"github.com/tektoncd/chains/pkg/signing"
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/taskrun"
 	"github.com/tektoncd/pipeline/pkg/reconciler"
@@ -57,6 +58,10 @@ func main() {
 				},
 				Logger:        logger,
 				TaskRunLister: taskRunInformer.Lister(),
+				TaskRunSigner: &signing.TaskRunSigner{
+					Pipelineclientset: pipelineclientset,
+					Logger:            logger,
+				},
 			}
 			impl := controller.NewImpl(c, c.Logger, controllerName)
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -30,6 +30,7 @@ type Reconciler struct {
 	*reconciler.Base
 	Logger        *zap.SugaredLogger
 	TaskRunLister informers.TaskRunLister
+	TaskRunSigner signing.Signer
 }
 
 // handleTaskRun handles a changed or created TaskRun.
@@ -46,7 +47,7 @@ func (r *Reconciler) handleTaskRun(ctx context.Context, tr *v1beta1.TaskRun) err
 		return nil
 	}
 
-	if err := signing.SignTaskRun(r.Logger, r.PipelineClientSet, tr); err != nil {
+	if err := r.TaskRunSigner.SignTaskRun(tr); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -15,6 +15,7 @@ package signing
 
 import (
 	"github.com/tektoncd/chains/pkg/signing/formats"
+	"github.com/tektoncd/chains/pkg/signing/storage"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
@@ -24,6 +25,15 @@ const (
 	// ChainsAnnotation is the standard annotation to indicate a TR has been signed.
 	ChainsAnnotation = "chains.tekton.dev/signed"
 )
+
+type Signer interface {
+	SignTaskRun(tr *v1beta1.TaskRun) error
+}
+
+type TaskRunSigner struct {
+	Logger            *zap.SugaredLogger
+	Pipelineclientset versioned.Interface
+}
 
 // IsSigned determines whether a TaskRun has already been signed.
 func IsSigned(tr *v1beta1.TaskRun) bool {
@@ -46,28 +56,38 @@ func MarkSigned(tr *v1beta1.TaskRun, ps versioned.Interface) error {
 	return nil
 }
 
-// SignTaskRun signs a TaskRun, and marks it as signed.
-// Use var for mocking
-var SignTaskRun = func(logger *zap.SugaredLogger, ps versioned.Interface, tr *v1beta1.TaskRun) error {
-	// First sign the overall TaskRun with all the configured payloads
-	payloads := generatePayloads(logger, tr)
-	logger.Infof("Generated payloads: %v for %s/%s", payloads, tr.Namespace, tr.Name)
+// Set this as a var for mocking.
+var getBackends = storage.InitializeBackends
 
-	// TODO: Store those payloads in all the configured storage systems.
+// SignTaskRun signs a TaskRun, and marks it as signed.
+func (ts *TaskRunSigner) SignTaskRun(tr *v1beta1.TaskRun) error {
+	// First sign the overall TaskRun with all the configured payloads
+	payloads := generatePayloads(ts.Logger, tr)
+	ts.Logger.Infof("Generated payloads: %v for %s/%s", payloads, tr.Namespace, tr.Name)
+
+	backends := getBackends(ts.Pipelineclientset, ts.Logger)
+	for _, b := range backends {
+		for payloadType, payload := range payloads {
+			if err := b.StorePayload(payload, payloadType, tr); err != nil {
+				ts.Logger.Errorf("error storing payloadType %s on storageBackend %s for taskRun %s/%s", payloadType, b.Type(), tr.Namespace, tr.Name)
+				// continue and store others
+			}
+		}
+	}
 
 	// Now mark the TaskRun as signed
-	return MarkSigned(tr, ps)
+	return MarkSigned(tr, ts.Pipelineclientset)
 }
 
-func generatePayloads(logger *zap.SugaredLogger, tr *v1beta1.TaskRun) []interface{} {
-	payloads := []interface{}{}
+func generatePayloads(logger *zap.SugaredLogger, tr *v1beta1.TaskRun) map[string]interface{} {
+	payloads := map[string]interface{}{}
 	for _, payloader := range formats.AllPayloadTypes {
 		payload, err := payloader.CreatePayload(tr)
 		if err != nil {
 			logger.Errorf("Error creating payload of type %s for %s/%s", payloader, tr.Namespace, tr.Name)
 			continue
 		}
-		payloads = append(payloads, payload)
+		payloads[payloader.Type()] = payload
 	}
 	return payloads
 }

--- a/pkg/signing/storage/storage.go
+++ b/pkg/signing/storage/storage.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"github.com/tektoncd/chains/pkg/signing/storage/tekton"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.uber.org/zap"
+)
+
+// Backend is an interface to store a chains Payload
+type Backend interface {
+	StorePayload(payload interface{}, payloadType string, tr *v1beta1.TaskRun) error
+	Type() string
+}
+
+// InitializeBackends creates and initializes every configured storage backend.
+func InitializeBackends(ps versioned.Interface, logger *zap.SugaredLogger) []Backend {
+	backends := []Backend{}
+
+	// Add one entry here for every storage backend type.
+	backends = append(backends, tekton.NewStorageBackend(ps, logger))
+
+	return backends
+}

--- a/pkg/signing/storage/tekton/tekton.go
+++ b/pkg/signing/storage/tekton/tekton.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tekton
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.uber.org/zap"
+)
+
+const (
+	StorageBackendTekton = "tekton"
+	PayloadAnnotation    = "chains.tekton.dev/payload"
+)
+
+// Tekton is a storage backend that stores signed payloads in the TaskRun metadata as an annotation.
+// It is stored as base64 encoded JSON.
+type Backend struct {
+	pipelienclientset versioned.Interface
+	logger            *zap.SugaredLogger
+}
+
+// NewStorageBackend returns a new Tekton StorageBackend
+func NewStorageBackend(ps versioned.Interface, logger *zap.SugaredLogger) *Backend {
+	return &Backend{
+		pipelienclientset: ps,
+		logger:            logger,
+	}
+}
+
+// StorePayload implements the Payloader interface.
+func (b *Backend) StorePayload(payload interface{}, payloadType string, tr *v1beta1.TaskRun) error {
+	b.logger.Infof("Storing payload type %s on TaskRun %s/%s", payloadType, tr.Namespace, tr.Name)
+	if tr.ObjectMeta.Annotations == nil {
+		tr.ObjectMeta.Annotations = map[string]string{}
+	}
+
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	textPayload := base64.StdEncoding.EncodeToString(jsonPayload)
+
+	tr.ObjectMeta.Annotations[PayloadAnnotation] = textPayload
+	if _, err := b.pipelienclientset.TektonV1beta1().TaskRuns(tr.Namespace).Update(tr); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *Backend) Type() string {
+	return StorageBackendTekton
+}

--- a/pkg/signing/storage/tekton/tekton_test.go
+++ b/pkg/signing/storage/tekton/tekton_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tekton
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logtesting "knative.dev/pkg/logging/testing"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestBackend_StorePayload(t *testing.T) {
+	// The Tekton storage backend JSON serializes, base64 encodes, and attaches the result as an annotation
+
+	tests := []struct {
+		name    string
+		payload interface{}
+		wantErr bool
+	}{
+		{
+			name: "simple",
+			payload: mockPayload{
+				A: "foo",
+				B: 3,
+			},
+		},
+		{
+			name: "json error",
+			// chans can't be marshaled
+			payload: make(chan int),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			c := fakepipelineclient.Get(ctx)
+			tr := &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			}
+			if _, err := c.TektonV1beta1().TaskRuns(tr.Namespace).Create(tr); err != nil {
+				t.Errorf("error setting up fake taskrun: %v", err)
+			}
+
+			b := &Backend{
+				pipelienclientset: c,
+				logger:            logtesting.TestLogger(t),
+			}
+			if err := b.StorePayload(tt.payload, "mockpayload", tr); (err != nil) != tt.wantErr {
+				t.Errorf("Backend.StorePayload() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// The rest is invalid if we wanted an error
+			if tt.wantErr {
+				return
+			}
+
+			// Now get the updated taskrun
+			tr, err := c.TektonV1beta1().TaskRuns(tr.Namespace).Get(tr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("error getting updated taskrun: %v", err)
+			}
+
+			// Reverse all the decodings
+			payload := tr.ObjectMeta.Annotations[PayloadAnnotation]
+			jsonString, err := base64.StdEncoding.DecodeString(payload)
+			if err != nil {
+				t.Errorf("error base64 decoding: %v", err)
+			}
+			mp := mockPayload{}
+			if err := json.Unmarshal([]byte(jsonString), &mp); err != nil {
+				t.Errorf("error json decoding: %v", err)
+			}
+
+			// Compare to the input
+			if diff := cmp.Diff(tt.payload, mp); diff != "" {
+				t.Errorf("unexpected payload: (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
+// Just a simple struct to serialize
+type mockPayload struct {
+	A string
+	B int
+}


### PR DESCRIPTION
This adds a storage interface to store signed payloads. Right now
the only supported backend is "Tekton", which stores them in the
annotations field of a Tekton k8s object.