### PR TITLE
Add boilerplate for the signing secrets.

### DIFF
--- a/config/100-deployment.yaml
+++ b/config/100-deployment.yaml
@@ -1,4 +1,21 @@
-
+apiVersion: v1
+kind: Secret
+metadata:
+  name: signing-secrets
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+    pipeline.tekton.dev/release: "devel"
+    version: "devel"
+# The data is populated at install time.
+data:
+  # This contains the private key to use for PGP signing
+  # pgp.private-key:
+  # This contains the passphrase to use for the pgp private key
+  # pgp.passphrase:
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,6 +50,8 @@ spec:
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging
+        - name: signing-secrets
+          mountPath: /etc/signing-secrets
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -44,3 +63,6 @@ spec:
       - name: config-logging
         configMap:
           name: config-logging
+      - name: signing-secrets
+        secret:
+          secretName: signing-secrets


### PR DESCRIPTION
This creates a secret that is injected into the deployment to hold signing
materials. It will hold two fields for now:
- pgp.private-key
- pgp.passphrase

These should be self explanatory. Nesting under the "pgp" namespace will
give us flexibility to add other types (x509, etc.) later.