### PR TITLE
Use patch instead of update to mutate annotations.

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -1,0 +1,21 @@
+package patch
+
+import "encoding/json"
+
+// GetAnnotationsPatch returns patch bytes that can be used with kubectl patch
+func GetAnnotationsPatch(newAnnotations map[string]string) ([]byte, error) {
+	p := patch{
+		Metadata: metadata{
+			Annotations: newAnnotations,
+		},
+	}
+	return json.Marshal(p)
+}
+
+// These are used to get proper json formatting
+type patch struct {
+	Metadata metadata `json:"metadata,omitempty"`
+}
+type metadata struct {
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -1,0 +1,49 @@
+package patch
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetAnnotationsPatch(t *testing.T) {
+	tests := []struct {
+		name           string
+		newAnnotations map[string]string
+		want           string
+		wantErr        bool
+	}{
+		{
+			name:           "empty",
+			newAnnotations: map[string]string{},
+			want:           `{"metadata":{}}`,
+		},
+		{
+			name: "one",
+			newAnnotations: map[string]string{
+				"foo": "bar",
+			},
+			want: `{"metadata":{"annotations":{"foo":"bar"}}}`,
+		},
+		{
+			name: "many",
+			newAnnotations: map[string]string{
+				"foo": "bar",
+				"baz": "bat",
+			},
+			want: `{"metadata":{"annotations":{"baz":"bat","foo":"bar"}}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetAnnotationsPatch(tt.newAnnotations)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAnnotationsPatch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			gotStr := string(got)
+			if !reflect.DeepEqual(gotStr, tt.want) {
+				t.Errorf("GetAnnotationsPatch() = %v, want %v", gotStr, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -157,6 +157,11 @@ func TestTaskRunSigner_SignTaskRun(t *testing.T) {
 				t.Errorf("TaskRunSigner.SignTaskRun() error = %v", err)
 			}
 
+			// Fetch a new TR!
+			tr, err := ps.TektonV1beta1().TaskRuns(tr.Namespace).Get(tr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("error fetching fake taskrun: %v", err)
+			}
 			// Check it is marked as signed
 			if !IsSigned(tr) {
 				t.Errorf("TaskRun %s/%s should be marked as signed, was not", tr.Namespace, tr.Name)
@@ -198,7 +203,7 @@ type mockBackend struct {
 // StorePayload implements the Payloader interface.
 func (b *mockBackend) StorePayload(payload interface{}, payloadType string, tr *v1beta1.TaskRun) error {
 	if b.shouldErr {
-		return errors.New("error storing")
+		return errors.New("mock error storing")
 	}
 	if b.storedPayloads == nil {
 		b.storedPayloads = map[string]interface{}{}


### PR DESCRIPTION
This helps prevent some race conditions, where we try to update an object
when simultaneous updates are happening. They eventually work themselves out
because we continue to retry, but this helps speed things along.