### PR TITLE
Cleanup format strings by using custom types.

### DIFF
--- a/pkg/signing/formats/format.go
+++ b/pkg/signing/formats/format.go
@@ -18,11 +18,13 @@ import "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 // Payloader is an interface to generate a chains Payload from a TaskRun
 type Payloader interface {
 	CreatePayload(tr *v1beta1.TaskRun) (interface{}, error)
-	Type() string
+	Type() PayloadType
 }
 
+type PayloadType string
+
 const (
-	PayloadTypeTekton = "tekton"
+	PayloadTypeTekton PayloadType = "tekton"
 )
 
 // AllPayloadTypes is a list of all valid Payload types.

--- a/pkg/signing/formats/tekton.go
+++ b/pkg/signing/formats/tekton.go
@@ -24,6 +24,6 @@ func (i *Tekton) CreatePayload(tr *v1beta1.TaskRun) (interface{}, error) {
 	return tr.Status, nil
 }
 
-func (i *Tekton) Type() string {
+func (i *Tekton) Type() PayloadType {
 	return PayloadTypeTekton
 }

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -84,8 +84,8 @@ func (ts *TaskRunSigner) SignTaskRun(tr *v1beta1.TaskRun) error {
 	return MarkSigned(tr, ts.Pipelineclientset)
 }
 
-func generatePayloads(logger *zap.SugaredLogger, tr *v1beta1.TaskRun) map[string]interface{} {
-	payloads := map[string]interface{}{}
+func generatePayloads(logger *zap.SugaredLogger, tr *v1beta1.TaskRun) map[formats.PayloadType]interface{} {
+	payloads := map[formats.PayloadType]interface{}{}
 	for _, payloader := range formats.AllPayloadTypes {
 		payload, err := payloader.CreatePayload(tr)
 		if err != nil {

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/chains/pkg/signing/formats"
 	"github.com/tektoncd/chains/pkg/signing/storage"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -196,17 +197,17 @@ func setupMocks(backends []*mockBackend) func() {
 }
 
 type mockBackend struct {
-	storedPayloads map[string]interface{}
+	storedPayloads map[formats.PayloadType]interface{}
 	shouldErr      bool
 }
 
 // StorePayload implements the Payloader interface.
-func (b *mockBackend) StorePayload(payload interface{}, payloadType string, tr *v1beta1.TaskRun) error {
+func (b *mockBackend) StorePayload(payload interface{}, payloadType formats.PayloadType, tr *v1beta1.TaskRun) error {
 	if b.shouldErr {
 		return errors.New("mock error storing")
 	}
 	if b.storedPayloads == nil {
-		b.storedPayloads = map[string]interface{}{}
+		b.storedPayloads = map[formats.PayloadType]interface{}{}
 	}
 	b.storedPayloads[payloadType] = payload
 	return nil

--- a/pkg/signing/storage/storage.go
+++ b/pkg/signing/storage/storage.go
@@ -14,6 +14,7 @@ limitations under the License.
 package storage
 
 import (
+	"github.com/tektoncd/chains/pkg/signing/formats"
 	"github.com/tektoncd/chains/pkg/signing/storage/tekton"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -22,7 +23,7 @@ import (
 
 // Backend is an interface to store a chains Payload
 type Backend interface {
-	StorePayload(payload interface{}, payloadType string, tr *v1beta1.TaskRun) error
+	StorePayload(payload interface{}, payloadType formats.PayloadType, tr *v1beta1.TaskRun) error
 	Type() string
 }
 

--- a/pkg/signing/storage/tekton/tekton.go
+++ b/pkg/signing/storage/tekton/tekton.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/tektoncd/chains/pkg/patch"
+	"github.com/tektoncd/chains/pkg/signing/formats"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
@@ -44,8 +45,8 @@ func NewStorageBackend(ps versioned.Interface, logger *zap.SugaredLogger) *Backe
 	}
 }
 
-// StorePayload implements the Payloader interface.
-func (b *Backend) StorePayload(payload interface{}, payloadType string, tr *v1beta1.TaskRun) error {
+// StorePayload implements the Payloader interface
+func (b *Backend) StorePayload(payload interface{}, payloadType formats.PayloadType, tr *v1beta1.TaskRun) error {
 	b.logger.Infof("Storing payload type %s on TaskRun %s/%s", payloadType, tr.Namespace, tr.Name)
 
 	jsonPayload, err := json.Marshal(payload)


### PR DESCRIPTION
This makes the map[string]foo stuff a little easier to understand and gives us
some validation around which format types exist.