### PR TITLE
Small refactor of storage backend interfaces.

### DIFF
--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -70,10 +70,10 @@ func (ts *TaskRunSigner) SignTaskRun(tr *v1beta1.TaskRun) error {
 	payloads := generatePayloads(ts.Logger, tr)
 	ts.Logger.Infof("Generated payloads: %v for %s/%s", payloads, tr.Namespace, tr.Name)
 
-	backends := getBackends(ts.Pipelineclientset, ts.Logger)
+	backends := getBackends(ts.Pipelineclientset, ts.Logger, tr)
 	for _, b := range backends {
 		for payloadType, payload := range payloads {
-			if err := b.StorePayload(payload, payloadType, tr); err != nil {
+			if err := b.StorePayload(payload, payloadType); err != nil {
 				ts.Logger.Errorf("error storing payloadType %s on storageBackend %s for taskRun %s/%s: %v", payloadType, b.Type(), tr.Namespace, tr.Name, err)
 				// continue and store others
 			}

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -184,7 +184,7 @@ func TestTaskRunSigner_SignTaskRun(t *testing.T) {
 
 func setupMocks(backends []*mockBackend) func() {
 	oldGet := getBackends
-	getBackends = func(ps versioned.Interface, logger *zap.SugaredLogger) []storage.Backend {
+	getBackends = func(ps versioned.Interface, logger *zap.SugaredLogger, _ *v1beta1.TaskRun) []storage.Backend {
 		newBackends := []storage.Backend{}
 		for _, m := range backends {
 			newBackends = append(newBackends, m)
@@ -202,7 +202,7 @@ type mockBackend struct {
 }
 
 // StorePayload implements the Payloader interface.
-func (b *mockBackend) StorePayload(payload interface{}, payloadType formats.PayloadType, tr *v1beta1.TaskRun) error {
+func (b *mockBackend) StorePayload(payload interface{}, payloadType formats.PayloadType) error {
 	if b.shouldErr {
 		return errors.New("mock error storing")
 	}

--- a/pkg/signing/storage/storage.go
+++ b/pkg/signing/storage/storage.go
@@ -23,16 +23,16 @@ import (
 
 // Backend is an interface to store a chains Payload
 type Backend interface {
-	StorePayload(payload interface{}, payloadType formats.PayloadType, tr *v1beta1.TaskRun) error
+	StorePayload(payload interface{}, payloadType formats.PayloadType) error
 	Type() string
 }
 
 // InitializeBackends creates and initializes every configured storage backend.
-func InitializeBackends(ps versioned.Interface, logger *zap.SugaredLogger) []Backend {
+func InitializeBackends(ps versioned.Interface, logger *zap.SugaredLogger, tr *v1beta1.TaskRun) []Backend {
 	backends := []Backend{}
 
 	// Add one entry here for every storage backend type.
-	backends = append(backends, tekton.NewStorageBackend(ps, logger))
+	backends = append(backends, tekton.NewStorageBackend(ps, logger, tr))
 
 	return backends
 }

--- a/pkg/signing/storage/tekton/tekton_test.go
+++ b/pkg/signing/storage/tekton/tekton_test.go
@@ -65,8 +65,9 @@ func TestBackend_StorePayload(t *testing.T) {
 			b := &Backend{
 				pipelienclientset: c,
 				logger:            logtesting.TestLogger(t),
+				tr:                tr,
 			}
-			if err := b.StorePayload(tt.payload, "mockpayload", tr); (err != nil) != tt.wantErr {
+			if err := b.StorePayload(tt.payload, "mockpayload"); (err != nil) != tt.wantErr {
 				t.Errorf("Backend.StorePayload() error = %v, wantErr %v", err, tt.wantErr)
 			}
 


### PR DESCRIPTION
The TaskRun is actually a parameter to the Tekton storage backend,
other backends may not need this to store a payload. Payloads may actually
be attached to artifacts, not TaskRuns.