### PR TITLE
Hook config up!

### DIFF
--- a/config/100-deployment.yaml
+++ b/config/100-deployment.yaml
@@ -16,6 +16,21 @@ metadata:
   # This contains the passphrase to use for the pgp private key
   # pgp.passphrase:
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chains-config
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+    pipeline.tekton.dev/release: "devel"
+    version: "devel"
+data:
+  artifacts.taskrun.formats.enabled: tekton 
+  artifacts.taskrun.storage.enabled: tekton
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -16,6 +16,7 @@ package controller
 import (
 	"context"
 
+	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/chains/pkg/signing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -38,6 +39,7 @@ type Reconciler struct {
 	TaskRunSigner     signing.Signer
 	KubeClientSet     kubernetes.Interface
 	PipelineClientSet versioned.Interface
+	ConfigStore       *config.ConfigStore
 }
 
 // handleTaskRun handles a changed or created TaskRun.


### PR DESCRIPTION
This commit hooks up the configstore object for backends and payload formats!

The only supported ones are still Tekton, but this will make it easier to add more.