### PR TITLE
Add a "Key" method to the signable interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ home-is-set-rwhzs   True        Succeeded   105s        100s
 Next, retrieve the signature and payload from the object (they are stored as base64-encoded annotations):
 
 ```shell
-$ kubectl get taskrun home-is-set-rwhzs -o=json | jq  -r '.metadata.annotations["chains.tekton.dev/payload-tekton"]' | base64 --decode > payload
-$ kubectl get taskrun home-is-set-rwhzs -o=json | jq  -r '.metadata.annotations["chains.tekton.dev/signature-tekton"]' | base64 --decode > signature
+$ kubectl get taskrun home-is-set-rwhzs -o=json | jq  -r '.metadata.annotations["chains.tekton.dev/payload-taskrun"]' | base64 --decode > payload
+$ kubectl get taskrun home-is-set-rwhzs -o=json | jq  -r '.metadata.annotations["chains.tekton.dev/signature-taskrun"]' | base64 --decode > signature
 ```
 
 Finally, we can check the signature:

--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -24,11 +24,18 @@ type Signable interface {
 	ExtractObjects(tr *v1beta1.TaskRun) []interface{}
 	StorageBackend(cfg config.Config) string
 	PayloadFormat(cfg config.Config) formats.PayloadType
+	Key(obj interface{}) string
 	Type() string
 }
 
 type TaskRunArtifact struct {
 	Logger *zap.SugaredLogger
+}
+
+func (ta *TaskRunArtifact) Key(obj interface{}) string {
+	// Return something unique within the scope of the TaskRun.
+	// In this case the taskrun is unique, so we don't need anything else.
+	return "taskrun"
 }
 
 func (ta *TaskRunArtifact) ExtractObjects(tr *v1beta1.TaskRun) []interface{} {

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -119,7 +119,7 @@ func (ts *TaskRunSigner) SignTaskRun(tr *v1beta1.TaskRun) error {
 				if b.Type() != signableType.StorageBackend(cfg) {
 					continue
 				}
-				if err := b.StorePayload(signed, signature, configuredPayloadType); err != nil {
+				if err := b.StorePayload(signed, signature, signableType.Key(obj)); err != nil {
 					ts.Logger.Error(err)
 					merr = multierror.Append(merr, err)
 				}

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/tektoncd/chains/pkg/config"
-	"github.com/tektoncd/chains/pkg/signing/formats"
 	"github.com/tektoncd/chains/pkg/signing/storage"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -222,7 +221,7 @@ type mockBackend struct {
 }
 
 // StorePayload implements the Payloader interface.
-func (b *mockBackend) StorePayload(signed []byte, signature string, payloadType formats.PayloadType) error {
+func (b *mockBackend) StorePayload(signed []byte, signature string, key string) error {
 	if b.shouldErr {
 		return errors.New("mock error storing")
 	}

--- a/pkg/signing/storage/storage.go
+++ b/pkg/signing/storage/storage.go
@@ -14,7 +14,6 @@ limitations under the License.
 package storage
 
 import (
-	"github.com/tektoncd/chains/pkg/signing/formats"
 	"github.com/tektoncd/chains/pkg/signing/storage/tekton"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -23,7 +22,7 @@ import (
 
 // Backend is an interface to store a chains Payload
 type Backend interface {
-	StorePayload(signed []byte, signature string, payloadType formats.PayloadType) error
+	StorePayload(signed []byte, signature string, key string) error
 	Type() string
 }
 

--- a/pkg/signing/storage/tekton/tekton.go
+++ b/pkg/signing/storage/tekton/tekton.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/chains/pkg/patch"
-	"github.com/tektoncd/chains/pkg/signing/formats"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
@@ -49,14 +48,14 @@ func NewStorageBackend(ps versioned.Interface, logger *zap.SugaredLogger, tr *v1
 }
 
 // StorePayload implements the Payloader interface.
-func (b *Backend) StorePayload(signed []byte, signature string, payloadType formats.PayloadType) error {
-	b.logger.Infof("Storing payload type %s on TaskRun %s/%s", payloadType, b.tr.Namespace, b.tr.Name)
+func (b *Backend) StorePayload(signed []byte, signature string, key string) error {
+	b.logger.Infof("Storing payload on TaskRun %s/%s", b.tr.Namespace, b.tr.Name)
 
 	// Use patch instead of update to prevent race conditions.
 	patchBytes, err := patch.GetAnnotationsPatch(map[string]string{
 		// Base64 encode both the signature and the payload
-		fmt.Sprintf(PayloadAnnotationFormat, payloadType):   base64.StdEncoding.EncodeToString(signed),
-		fmt.Sprintf(SignatureAnnotationFormat, payloadType): base64.StdEncoding.EncodeToString([]byte(signature)),
+		fmt.Sprintf(PayloadAnnotationFormat, key):   base64.StdEncoding.EncodeToString(signed),
+		fmt.Sprintf(SignatureAnnotationFormat, key): base64.StdEncoding.EncodeToString([]byte(signature)),
 	})
 	if err != nil {
 		return err

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -69,7 +69,7 @@ func TestTektonStorage(t *testing.T) {
 	tr = waitForCondition(t, c.PipelineClient, tr.Name, ns, signed, 120*time.Second)
 
 	// Let's fetch the signature and body:
-	signature, body := tr.Annotations["chains.tekton.dev/signature-tekton"], tr.Annotations["chains.tekton.dev/payload-tekton"]
+	signature, body := tr.Annotations["chains.tekton.dev/signature-taskrun"], tr.Annotations["chains.tekton.dev/payload-taskrun"]
 	// base64 decode them
 	sigBytes, err := base64.StdEncoding.DecodeString(signature)
 	if err != nil {


### PR DESCRIPTION
This will be used to uniquely identity the artifacts we sign within
a storage system.