### PR TITLE
Test against nightly instead of latest.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -25,6 +25,8 @@ initialize $@
 
 header "Setting up environment"
 
+# Test against nightly instead of latest.
+export RELEASE_YAML="https://storage.googleapis.com/tekton-releases-nightly/pipeline/latest/release.yaml"
 install_pipeline_crd
 install_chains
 


### PR DESCRIPTION
This will help catch issues faster, and allow us to develop faster against changes in Pipeline.