### PR TITLE
Use sigstores Signer interface for signing

### DIFF
--- a/config/100-deployment.yaml
+++ b/config/100-deployment.yaml
@@ -31,11 +31,9 @@ metadata:
 data:
   artifacts.taskrun.format: tekton
   artifacts.taskrun.storage: tekton
-  artifacts.taskrun.signer: pgp
   artifacts.taskrun.signer: x509
   artifacts.oci.storage: tekton
   artifacts.oci.format: simplesigning
-  artifacts.oci.signer: pgp
   artifacts.oci.signer: x509
 ---
 apiVersion: apps/v1

--- a/config/100-deployment.yaml
+++ b/config/100-deployment.yaml
@@ -32,9 +32,11 @@ data:
   artifacts.taskrun.format: tekton
   artifacts.taskrun.storage: tekton
   artifacts.taskrun.signer: pgp
+  artifacts.taskrun.signer: x509
   artifacts.oci.storage: tekton
   artifacts.oci.format: simplesigning
   artifacts.oci.signer: pgp
+  artifacts.oci.signer: x509
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/pkg/chains/signing/iface.go
+++ b/pkg/chains/signing/iface.go
@@ -13,8 +13,10 @@ limitations under the License.
 
 package signing
 
+import "github.com/sigstore/sigstore/pkg/signature"
+
 type Signer interface {
-	Sign(i interface{}) (string, []byte, error)
+	signature.Signer
 	Type() string
 }
 

--- a/pkg/chains/signing/kms/kms.go
+++ b/pkg/chains/signing/kms/kms.go
@@ -15,11 +15,11 @@ package kms
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/tektoncd/chains/pkg/config"
 
 	"github.com/sigstore/sigstore/pkg/kms"
+	"github.com/sigstore/sigstore/pkg/signature"
 
 	"github.com/tektoncd/chains/pkg/chains/signing"
 	"go.uber.org/zap"
@@ -27,7 +27,7 @@ import (
 
 // Signer exposes methods to sign payloads using a KMS
 type Signer struct {
-	k      kms.KMS
+	signature.Signer
 	logger *zap.SugaredLogger
 }
 
@@ -37,28 +37,10 @@ func NewSigner(cfg config.KMSSigner, logger *zap.SugaredLogger) (*Signer, error)
 	if err != nil {
 		return nil, err
 	}
-
-	s := &Signer{
-		k:      k,
+	return &Signer{
+		Signer: k,
 		logger: logger,
-	}
-
-	return s, nil
-}
-
-// Sign signs an incoming payload.
-// It returns the signature and the marshaled payload object.
-func (s *Signer) Sign(i interface{}) (string, []byte, error) {
-	b, err := json.Marshal(i)
-	if err != nil {
-		return "", nil, err
-	}
-
-	sig, _, err := s.k.Sign(context.Background(), b)
-	if err != nil {
-		return "", nil, err
-	}
-	return string(sig), b, nil
+	}, nil
 }
 
 func (s *Signer) Type() string {

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -168,7 +168,7 @@ func TestTaskRunSigner_SignTaskRun(t *testing.T) {
 			if _, err := ps.TektonV1beta1().TaskRuns(tr.Namespace).Create(ctx, tr, metav1.CreateOptions{}); err != nil {
 				t.Errorf("error creating fake taskrun: %v", err)
 			}
-			if err := ts.SignTaskRun(tr); (err != nil) != tt.wantErr {
+			if err := ts.SignTaskRun(ctx, tr); (err != nil) != tt.wantErr {
 				t.Errorf("TaskRunSigner.SignTaskRun() error = %v", err)
 			}
 

--- a/pkg/chains/storage/gcs/gcs.go
+++ b/pkg/chains/storage/gcs/gcs.go
@@ -56,7 +56,7 @@ func NewStorageBackend(logger *zap.SugaredLogger, tr *v1beta1.TaskRun, cfg confi
 }
 
 // StorePayload implements the Payloader interface.
-func (b *Backend) StorePayload(signed []byte, signature string, key string) error {
+func (b *Backend) StorePayload(rawPayload []byte, signature string, key string) error {
 	// We need two object names: the signature and the payload. We want to make these unique to the UID, but easy to find based on the
 	// name/namespace as well.
 	// $bucket/taskrun-$namespace-$name-$uid/$key.signature
@@ -76,7 +76,7 @@ func (b *Backend) StorePayload(signed []byte, signature string, key string) erro
 	payloadName := path.Join(root, fmt.Sprintf("%s.payload", key))
 	payloadObj := b.writer.GetWriter(payloadName)
 	defer payloadObj.Close()
-	if _, err := payloadObj.Write(signed); err != nil {
+	if _, err := payloadObj.Write(rawPayload); err != nil {
 		return err
 	}
 	if err := payloadObj.Close(); err != nil {

--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -65,10 +65,10 @@ func NewStorageBackend(logger *zap.SugaredLogger, tr *v1beta1.TaskRun, cfg confi
 }
 
 // StorePayload implements the Payloader interface.
-func (b *Backend) StorePayload(signed []byte, signature string, key string) error {
+func (b *Backend) StorePayload(rawPayload []byte, signature string, key string) error {
 	b.logger.Infof("Storing payload on TaskRun %s/%s", b.tr.Namespace, b.tr.Name)
 
-	img, err := createImage(signed, signature)
+	img, err := createImage(rawPayload, signature)
 	if err != nil {
 		return err
 	}

--- a/pkg/chains/storage/storage.go
+++ b/pkg/chains/storage/storage.go
@@ -25,7 +25,7 @@ import (
 
 // Backend is an interface to store a chains Payload
 type Backend interface {
-	StorePayload(signed []byte, signature string, key string) error
+	StorePayload(rawPayload []byte, signature string, key string) error
 	Type() string
 }
 

--- a/pkg/chains/storage/tekton/tekton.go
+++ b/pkg/chains/storage/tekton/tekton.go
@@ -50,13 +50,13 @@ func NewStorageBackend(ps versioned.Interface, logger *zap.SugaredLogger, tr *v1
 }
 
 // StorePayload implements the Payloader interface.
-func (b *Backend) StorePayload(signed []byte, signature string, key string) error {
+func (b *Backend) StorePayload(rawPayload []byte, signature string, key string) error {
 	b.logger.Infof("Storing payload on TaskRun %s/%s", b.tr.Namespace, b.tr.Name)
 
 	// Use patch instead of update to prevent race conditions.
 	patchBytes, err := patch.GetAnnotationsPatch(map[string]string{
 		// Base64 encode both the signature and the payload
-		fmt.Sprintf(PayloadAnnotationFormat, key):   base64.StdEncoding.EncodeToString(signed),
+		fmt.Sprintf(PayloadAnnotationFormat, key):   base64.StdEncoding.EncodeToString(rawPayload),
 		fmt.Sprintf(SignatureAnnotationFormat, key): base64.StdEncoding.EncodeToString([]byte(signature)),
 	})
 	if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -54,7 +54,7 @@ func (r *Reconciler) handleTaskRun(ctx context.Context, tr *v1beta1.TaskRun) err
 		return nil
 	}
 
-	if err := r.TaskRunSigner.SignTaskRun(tr); err != nil {
+	if err := r.TaskRunSigner.SignTaskRun(ctx, tr); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -142,7 +142,7 @@ type mockSigner struct {
 	signed bool
 }
 
-func (m *mockSigner) SignTaskRun(tr *v1beta1.TaskRun) error {
+func (m *mockSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) error {
 	m.signed = true
 	return nil
 }


### PR DESCRIPTION
This means we can remove some of the kms/x509 signing code since it's already built into sigstore

can add in ed25519 once https://github.com/sigstore/sigstore/pull/51 is merged