### PR TITLE
in-toto attestations (ITE-6) as a formatter.

### DIFF
--- a/INTOTO.md
+++ b/INTOTO.md
@@ -1,0 +1,123 @@
+# In-toto attestation formater
+
+## Overview
+
+In-toto attestation spec is defined
+[here](https://github.com/in-toto/attestation/tree/v0.1.0/spec).
+
+The in-toto format can be enabled by configuring Chains to use format
+`in-toto-ite6`.
+
+To provide a git URL/commit as material, add a parameter named
+`CHAINS-GIT_COMMIT` and `CHAINS-GIT_URL`. The value of these
+parameters should be fed by some VCS task (e.g like this
+[task](https://github.com/tektoncd/catalog/blob/main/task/git-clone/0.3/git-clone.yaml#L81).
+A `PipeLine` example where another task `checkout` have URL/commit as
+task results:
+
+```
+    - name: build
+      params:
+        - name: CHAINS-GIT_COMMIT
+          value: "$(tasks.checkout.results.commit)"
+        - name: CHAINS-GIT_URL
+          value: "$(tasks.checkout.results.url)"
+```
+
+### Type Hinting
+
+To capture arifacts created by a task, Chains will scan the TaskRun
+result for a result name `*_DIGEST`. The result shall be a string on
+the format `alg:digest`, alg is common `sha256`. If the result is named
+`Foo_DIGEST`, Chains will try to find a parameter or result (in that
+order) with the name `Foo`. The parameter or result named `Foo` shall
+contain the name (reference) to the built artifact.
+
+An example (a Task):
+```
+  params:
+  - name: IMAGE
+    description: Name (reference) of the image to build.
+...
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
+```
+
+So if the `IMAGE` parameter have the value `gcr.io/test/foo` and the
+result `IMAGE_DIGEST` is `sha256:abcd` then an attestation for the
+subject `pkg:/docker/test/foo@sha256:abcd?repository_url=gcr.io`
+is created. Note that image references are represented using [Package
+URL](https://github.com/package-url/purl-spec) format.
+
+## Limitations
+This is an MVP implementation of the the in-toto attestation
+format. More work would be required to properly capture the
+`Entrypoint` field in the provenance predicate, now the `TaskRef`'s name
+is used. Also metadata related to hermeticity/reproducible are
+currently not populated.
+
+## Examples
+
+Example attestation:
+
+```
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://in-toto.io/Provenance/v0.1",
+  "subject": [
+    {
+      "name": "file-SNAPSHOT.jar",
+      "digest": {
+        "sha256": "3f1017b520fe358d7b3796879232cd36259066ccd5bab5466cbedb444064dfed"
+      }
+    }
+  ],
+  "predicate": {
+    "builder": {
+      "id": "https://configured.builder@v1"
+    },
+    "recipe": {
+      "type": "https://tekton.dev/attestations/chains@v1",
+      "definedInMaterial": 0,
+      "entryPoint": "maven"
+    },
+    "metadata": {
+      "buildStartedOn": "2021-05-11T11:05:50Z",
+      "buildFinishedOn": "2021-05-11T11:15:42Z",
+      "completeness": {
+        "arguments": false,
+        "environment": false,
+        "materials": false
+      },
+      "reproducible": false
+    },
+    "materials": [
+      {
+        "uri": "git+https://github.com/org/repo",
+        "digest": {
+          "git_commit": "c4b75d454655c1755ab116947e88a59ac03e28a9"
+        }
+      },
+      {
+        "uri": "pkg:docker/alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f",
+        "digest": {
+          "sha256": "69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f"
+        }
+      },
+      {
+        "uri": "pkg:docker/alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f",
+        "digest": {
+          "sha256": "69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f"
+        }
+      },
+      {
+        "uri": "pkg:docker/org/build/openjdk-11@sha256:51aa63475b5e1e2e22d1dc416556a14658a7e03a0d3c88bb9dd7b6e3411ae34a?repository_url=gcr.io",
+        "digest": {
+          "sha256": "51aa63475b5e1e2e22d1dc416556a14658a7e03a0d3c88bb9dd7b6e3411ae34a"
+        }
+      }
+    ]
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ When outputing an OCI image without using a `PipelineResource`, `Chains` will lo
 * `IMAGE_URL` - The URL to the built OCI image
 * `IMAGE_DIGEST` - The Digest of the built OCI image
 
+For in-toto attestations, see [INTOTO.md](INTOTO.md) for description
+of in-toto specific type hinting.
+
 Note that these are provided automatically when using `PipelineResources`.
 
 ### Signing Secrets
@@ -221,4 +224,3 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for an overview of our processes
 See [DEVELOPMENT.md](DEVELOPMENT.md) for how to get started
 See [ROADMAP.md](ROADMAP.md) for the current roadmap
 Look at our good first issues and our help wanted issues
-

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,7 @@ require (
 	github.com/google/go-containerregistry v0.5.0
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20210129212729-5c4818de4025
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/jedisct1/go-minisign v0.0.0-20210414164026-819d7e2534ac // indirect
-	github.com/jstemmer/go-junit-report v0.9.1 // indirect
-	github.com/leodido/go-urn v1.2.1 // indirect
-	github.com/magiconair/properties v1.8.5 // indirect
-	github.com/pelletier/go-toml v1.9.0 // indirect
+	github.com/in-toto/in-toto-golang v0.1.1-0.20210505200736-471bd79ebd18
 	github.com/pkg/errors v0.9.1
 	github.com/sigstore/cosign v0.3.2-0.20210504221908-6a2c836159a9
 	github.com/sigstore/sigstore v0.0.0-20210427115853-11e6eaab7cdc
@@ -23,11 +19,6 @@ require (
 	go.uber.org/zap v1.16.0
 	gocloud.dev v0.22.0
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
-	golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6 // indirect
-	golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78 // indirect
-	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 // indirect
-	golang.org/x/term v0.0.0-20210422114643-f5beecf764ed // indirect
-	google.golang.org/genproto v0.0.0-20210426193834-eac7f76ac494 // indirect
 	k8s.io/api v0.19.7
 	k8s.io/apimachinery v0.19.7
 	k8s.io/client-go v0.19.7

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,7 @@ github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae/go.mod h1:S/7n9cop
 github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGrrHhcQw=
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/cavaliercoder/badio v0.0.0-20160213150051-ce5280129e9e h1:YYUjy5BRwO5zPtfk+aa2gw255FIIoi93zMmuy19o0bc=
 github.com/cavaliercoder/badio v0.0.0-20160213150051-ce5280129e9e/go.mod h1:V284PjgVwSk4ETmz84rpu9ehpGg7swlIH8npP9k2bGw=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/cavaliercoder/go-rpm v0.0.0-20200122174316-8cb9fd9c31a8 h1:jP7ki8Tzx9ThnFPLDhBYAhEpI2+jOURnHQNURgsMvnY=
@@ -366,6 +367,7 @@ github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQo
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e/go.mod h1:HyVoz1Mz5Co8TFO8EupIdlcpwShBmY98dkT2xeHkvEI=
@@ -376,6 +378,7 @@ github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
+github.com/frankban/quicktest v1.10.0 h1:Gfh+GAJZOAoKZsIZeZbdn2JF10kN1XHNvjsvQK8gVkE=
 github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
@@ -536,6 +539,7 @@ github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=
 github.com/go-toolsmith/astcopy v1.0.0/go.mod h1:vrgyG+5Bxrnz4MZWPF+pI4R8h3qKRjjyvV/DSez4WVQ=
@@ -595,6 +599,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -611,6 +616,7 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -692,8 +698,10 @@ github.com/google/go-licenses v0.0.0-20200602185517-f29a4c695c3d/go.mod h1:g1VOU
 github.com/google/go-licenses v0.0.0-20210329231322-ce1d9163b77d/go.mod h1:+TYOmkVoJOpwnS0wfdsJCV9CoD5nJYsHoFk/0CrTK4M=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=
+github.com/google/go-replayers/grpcreplay v1.0.0 h1:B5kVOzJ1hBgnevTgIWhSTatQ3608yu/2NnU0Ta1d0kY=
 github.com/google/go-replayers/grpcreplay v1.0.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=
 github.com/google/go-replayers/httpreplay v0.1.0/go.mod h1:YKZViNhiGgqdBlUbI2MwGpq4pXxNmhJLPHQ7cv2b5no=
+github.com/google/go-replayers/httpreplay v0.1.2 h1:HCfx+dQzwN9XbGTHF8qJ+67WN8glL9FTWV5rraCJ/jU=
 github.com/google/go-replayers/httpreplay v0.1.2/go.mod h1:YKZViNhiGgqdBlUbI2MwGpq4pXxNmhJLPHQ7cv2b5no=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -703,8 +711,10 @@ github.com/google/licenseclassifier v0.0.0-20190926221455-842c0d70d702/go.mod h1
 github.com/google/licenseclassifier v0.0.0-20210325184830-bb04aff29e72/go.mod h1:qsqn2hxC+vURpyBRygGUuinTO42MFRLcsmQ/P8v94+M=
 github.com/google/mako v0.0.0-20190821191249-122f8dcef9e3/go.mod h1:YzLcVlL+NqWnmUEPuhS1LxDDwGO9WNbVlEXaF4IH35g=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
+github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible h1:xmapqc1AyLoB+ddYT6r04bD9lIjlOqGaREovi0SzFaE=
 github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
+github.com/google/martian/v3 v3.1.0 h1:wCKgOCHuUEVfsaQLpPSJb7VdYCdTVZQAuOdYm1yc/60=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/monologue v0.0.0-20190606152607-4b11a32b5934/go.mod h1:6NTfaQoUpg5QmPsCUWLR3ig33FHrKXhTtWzF0DVdmuk=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -748,6 +758,7 @@ github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3i
 github.com/googleapis/gnostic v0.5.3 h1:2qsuRm+bzgwSIKikigPASa2GhW8H2Dn4Qq7UxD8K/48=
 github.com/googleapis/gnostic v0.5.3/go.mod h1:TRWw1s4gxBGjSe301Dai3c7wXJAZy57+/6tawkOvqHQ=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/goreleaser/goreleaser v0.134.0/go.mod h1:ZT6Y2rSYa6NxQzIsdfWWNWAlYGXGbreo66NmE+3X3WQ=
@@ -789,6 +800,7 @@ github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/S
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v0.14.1 h1:nQcJDQwIAGnmoUWp8ubocEX40cCml/17YkF6csQLReU=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -852,6 +864,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/in-toto/in-toto-golang v0.1.1-0.20210505200736-471bd79ebd18 h1:eof0G7NssBxSPzUZstI8ofmf1sOZ44dZy7rmEnSF+GM=
+github.com/in-toto/in-toto-golang v0.1.1-0.20210505200736-471bd79ebd18/go.mod h1:CV6wDPIrRheCXNQXxrr+x6Ued1MLKbe2z7wU56SlVQc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
@@ -870,6 +884,7 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
@@ -889,6 +904,7 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
@@ -919,11 +935,13 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -936,6 +954,7 @@ github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
+github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac h1:+2b6iGRJe3hvV/yVXrd41yVEjxuFHxasJqDhkIjS4gk=
 github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac/go.mod h1:Frd2bnT3w5FB5q49ENTfVlztJES+1k/7lyWX2+9gq/M=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
@@ -965,8 +984,10 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
+github.com/mattn/go-ieproxy v0.0.1 h1:qiyop7gCflfhwCzGyeT0gro3sF9AIg9HU98JORTkqfI=
 github.com/mattn/go-ieproxy v0.0.1/go.mod h1:pYabZ6IHcRpFh7vIaLfK7rdcWgFEb3SFJ6/gNWuh88E=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -974,6 +995,7 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -1043,9 +1065,11 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/nbutton23/zxcvbn-go v0.0.0-20160627004424-a22cb81b2ecd/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/nbutton23/zxcvbn-go v0.0.0-20171102151520-eafdab6b0663/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/predeclared v0.0.0-20190419143655-18a43bb90ffc/go.mod h1:62PewwiQTlm/7Rj+cxVYqZvDIUc+JjZq6GHAC1fsObQ=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
@@ -1064,6 +1088,7 @@ github.com/onsi/ginkgo v1.10.2/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
+github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1073,6 +1098,7 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/open-policy-agent/opa v0.28.0/go.mod h1:jYuhmtyoJI9HSLgVWEqUwfKecsLi/8wk0Uv76misZDU=
@@ -1132,6 +1158,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
@@ -1219,6 +1246,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/ksuid v1.0.3/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/shibumi/go-pathspec v1.2.0 h1:KVKEDHYk7bQolRMs7nfzjT3SBOCgcXFJzccnj9bsGbA=
+github.com/shibumi/go-pathspec v1.2.0/go.mod h1:bDxCftD0fST3qXIlHoQ/fChsU4mWMVklXp1yPErQaaY=
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shurcooL/githubv4 v0.0.0-20190718010115-4ba037080260/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
@@ -1247,8 +1276,10 @@ github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/assertions v1.0.0 h1:UVQPSSmc3qtTi+zPPkCXvZX9VvW/xT/NsRvKfwY81a8=
 github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/gunit v1.0.0/go.mod h1:qwPWnhz6pn0NnRBP++URONOVyNkPyr4SauJk4cUOwJs=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -1298,6 +1329,7 @@ github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5J
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25/go.mod h1:lbP8tGiBjZ5YWIc2fzuRpTaz0b/53vT6PEs3QuAWzuU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20170130113145-4d4bfba8f1d1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -1305,6 +1337,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -1320,6 +1353,7 @@ github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613/go.mod h1:g
 github.com/theupdateframework/go-tuf v0.0.0-20201230183259-aee6270feb55 h1:Zn+mA4qTRyao2Petd+YovKaFOUuxDj158kqCIqvwTow=
 github.com/theupdateframework/go-tuf v0.0.0-20201230183259-aee6270feb55/go.mod h1:L+uU/NRFK/7h0NYAnsmvsX9EghDB5QVCcHCIrK2h5nw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.0.2 h1:Z7S3cePv9Jwm1KwS0513MRaoUe3S01WPbLNV40pwWZU=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tilinna/clock v1.0.2/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=
 github.com/timakin/bodyclose v0.0.0-20190721030226-87058b9bfcec/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
@@ -1347,6 +1381,7 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk8LWSxF3s=
 github.com/valyala/quicktemplate v1.1.1/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
@@ -1423,6 +1458,7 @@ go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/automaxprocs v1.3.0/go.mod h1:9CWT6lKIep8U41DDaPiH6eFscnTyjfTANNQNx6LrIcA=
 go.uber.org/automaxprocs v1.4.0 h1:CpDZl6aOlLhReez+8S3eEotD7Jx0Os++lemPlMULQP0=
 go.uber.org/automaxprocs v1.4.0/go.mod h1:/mTEdr7LvHhs0v7mjdxDreTz1OG5zdZGqgOnhWiR/+Q=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
@@ -1983,6 +2019,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/cheggaaa/pb.v1 v1.0.28/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
@@ -1993,6 +2030,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gcfg.v1 v1.2.0/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
+gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
@@ -2009,6 +2047,7 @@ gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76
 gopkg.in/src-d/go-billy.v4 v4.3.2/go.mod h1:nDjArDMp+XMs1aFAESLRjfGSgfvoYN0hDfzEk0GjC98=
 gopkg.in/src-d/go-git-fixtures.v3 v3.5.0/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
 gopkg.in/src-d/go-git.v4 v4.13.1/go.mod h1:nx5NYcxdKxq5fpltdHnPa2Exj4Sx0EclMWZQbYDu2z8=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.1/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
@@ -2029,7 +2068,9 @@ gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -2040,6 +2081,7 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
 honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
 k8s.io/api v0.19.7 h1:MpHhls03C2pyzoYcpbe4QqYiiZjdvW+tuWq6TbjV14Y=
 k8s.io/api v0.19.7/go.mod h1:KTryDUT3l6Mtv7K2J2486PNL9DBns3wOYTkGR+iz63Y=

--- a/pkg/chains/formats/format.go
+++ b/pkg/chains/formats/format.go
@@ -24,10 +24,7 @@ type PayloadType string
 const (
 	PayloadTypeTekton        PayloadType = "tekton"
 	PayloadTypeSimpleSigning PayloadType = "simplesigning"
+	PayloadTypeInTotoIte6    PayloadType = "in-toto-ite6"
 )
 
-// AllPayloadTypes is a list of all valid Payload types.
-var AllPayloadTypes = map[PayloadType]Payloader{
-	PayloadTypeTekton:        &Tekton{},
-	PayloadTypeSimpleSigning: &SimpleSigning{},
-}
+var AllFormatters = []PayloadType{PayloadTypeTekton, PayloadTypeSimpleSigning, PayloadTypeInTotoIte6}

--- a/pkg/chains/formats/intotoite6/intotoite6.go
+++ b/pkg/chains/formats/intotoite6/intotoite6.go
@@ -1,0 +1,353 @@
+package intotoite6
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/config"
+
+	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+const (
+	tektonID = "https://tekton.dev/attestations/chains@v1"
+)
+
+var ErrNoBuilderID = errors.New("no builder id configured")
+
+const (
+	commitParam        = "CHAINS-GIT_COMMIT"
+	urlParam           = "CHAINS-GIT_URL"
+	ociDigestResult    = "IMAGE_DIGEST"
+	chainsDigestSuffix = "_DIGEST"
+)
+
+type artifactType int
+
+const (
+	artifactTypeUnknown artifactType = iota
+	artifactTypeOCI
+)
+
+type InTotoIte6 struct {
+	builderID string
+}
+
+type artifactResult struct {
+	ParamName  string
+	ResultName string
+	Type       artifactType
+}
+
+type vcsInfo struct {
+	Commit string
+	URL    string
+}
+
+func NewFormatter(cfg config.Config) (formats.Payloader, error) {
+	if cfg.Builder.ID == "" {
+		return nil, ErrNoBuilderID
+	}
+
+	return &InTotoIte6{builderID: cfg.Builder.ID}, nil
+}
+
+func (i *InTotoIte6) CreatePayload(obj interface{}) (interface{}, error) {
+	var tr *v1beta1.TaskRun
+
+	switch v := obj.(type) {
+	case *v1beta1.TaskRun:
+		tr = v
+	default:
+		return nil, fmt.Errorf("unsupported type: %s", v)
+
+	}
+
+	if tr.Spec.TaskRef == nil {
+		return nil, fmt.Errorf("provided TaskRef is nil for %s", tr.Status.PodName)
+	}
+
+	// Here we translate a Tekton TaskRun into an InToto ite6 provenance
+	// attestation.
+	// https://github.com/in-toto/attestation/blob/main/spec/predicates/provenance.md
+	// At a high leevel, the  mapping looks roughly like:
+	// Configured builder id -> Builder.Id
+	// Results with name *_DIGEST -> Subject
+	// Step containers -> Materials
+	// Params with name CHAINS-GIT_* -> Materials and recipe.materials
+	// tekton-chains -> Recipe.type
+	// Taskname -> Recipe.entry_point
+	att := in_toto.ProvenanceStatement{
+		StatementHeader: in_toto.StatementHeader{
+			Type:          in_toto.StatementInTotoV01,
+			PredicateType: in_toto.PredicateProvenanceV01,
+		},
+		Predicate: in_toto.ProvenancePredicate{
+			Builder: in_toto.ProvenanceBuilder{
+				ID: i.builderID,
+			},
+			Recipe: in_toto.ProvenanceRecipe{
+				Type:       tektonID,
+				EntryPoint: tr.Spec.TaskRef.Name,
+			},
+		},
+	}
+	if tr.Status.StartTime != nil {
+		att.Predicate.Metadata.BuildStartedOn = &tr.Status.StartTime.Time
+	}
+	if tr.Status.CompletionTime != nil {
+		att.Predicate.Metadata.BuildFinishedOn = &tr.Status.CompletionTime.Time
+	}
+
+	results := getResultDigests(tr)
+	att.StatementHeader.Subject = getSubjectDigests(tr, results)
+
+	att.Predicate.Materials = []in_toto.ProvenanceMaterial{}
+	vcsInfo := getVcsInfo(tr)
+	var recipeMaterialUri string
+
+	// Store git rev as Materials and Recipe.Material
+	if vcsInfo != nil {
+		att.Predicate.Materials = append(att.Predicate.Materials, in_toto.ProvenanceMaterial{
+			URI:    vcsInfo.URL,
+			Digest: map[string]string{"git_commit": vcsInfo.Commit},
+		})
+		// Remember the URI of the recipe material. We need to find it later to set the index correctly (after sorting)
+		recipeMaterialUri = vcsInfo.URL
+	}
+
+	// Add all found step containers as materials
+	for _, trs := range tr.Status.Steps {
+		uri, alg, digest := getPackageURLDocker(trs.ImageID)
+		if uri == "" {
+			continue
+		}
+
+		att.Predicate.Materials = append(att.Predicate.Materials, in_toto.ProvenanceMaterial{
+			URI:    uri,
+			Digest: in_toto.DigestSet{alg: digest},
+		})
+	}
+
+	sort.Slice(att.Predicate.Materials, func(i, j int) bool {
+		return att.Predicate.Materials[i].URI <= att.Predicate.Materials[j].URI
+	})
+
+	if recipeMaterialUri != "" {
+		for i, m := range att.Predicate.Materials {
+			if m.URI == recipeMaterialUri {
+				att.Predicate.Recipe.DefinedInMaterial = intP(i)
+				break
+			}
+		}
+	}
+
+	return att, nil
+}
+
+func (i *InTotoIte6) Type() formats.PayloadType {
+	return formats.PayloadTypeInTotoIte6
+}
+
+// getResultDigests scans over the task.Status.TaskSpec.Results to find any
+// result that has a name that ends with _DIGEST.
+func getResultDigests(tr *v1beta1.TaskRun) []artifactResult {
+	results := []artifactResult{}
+	// Scan for digests
+	for _, r := range tr.Status.TaskSpec.Results {
+		if strings.HasSuffix(r.Name, chainsDigestSuffix) {
+			// 7 chars in _DIGEST
+			at := artifactTypeUnknown
+
+			// IMAGE_DIGEST always refers to an OCI image
+			if r.Name == ociDigestResult {
+				at = artifactTypeOCI
+			}
+
+			results = append(results, artifactResult{
+				ParamName:  r.Name[:len(r.Name)-7],
+				ResultName: r.Name,
+				Type:       at,
+			})
+		}
+	}
+
+	return results
+}
+
+// getVcsInfo scans over the input parameters and looks for parameters
+// with specified names.
+func getVcsInfo(tr *v1beta1.TaskRun) *vcsInfo {
+	var v vcsInfo
+	// Scan for git params to use for materials
+	for _, p := range tr.Spec.Params {
+		if p.Name == commitParam {
+			v.Commit = p.Value.StringVal
+			continue
+		}
+		if p.Name == urlParam {
+			v.URL = p.Value.StringVal
+			// make sure url is PURL (git+https)
+			if !strings.HasPrefix(v.URL, "git+") {
+				v.URL = "git+" + v.URL
+			}
+			continue
+		}
+	}
+
+	if v.Commit == "" || v.URL == "" {
+		return nil
+	}
+
+	return &v
+}
+
+// getSubjectDigests uses depends on taskResults with names ending with
+// _DIGEST.
+// To be able to find the resource that matches the digest, it relies on a
+// naming schema for an input parameter.
+// If the output result from this task is foo_DIGEST, it expects to find an
+// parameter named 'foo', and resolves this value to use for the subject with
+// for the found digest.
+// If no parameter is found, we search the results of this task, which allows
+// for a task to create a random resource not known prior to execution that
+// gets checksummed and added as the subject.
+// Digests can be on two formats: $alg:$digest (commonly used for container
+// image hashes), or $alg:$digest $path, which is used when a step is
+// calculating a hash of a previous step.
+func getSubjectDigests(tr *v1beta1.TaskRun, results []artifactResult) []in_toto.Subject {
+	subs := []in_toto.Subject{}
+	r := regexp.MustCompile(`(\S+)\s+(\S+)`)
+
+	// Resolve *_DIGEST variables
+Results:
+	for _, ar := range results {
+		// Look for subject amongst the params
+		sub := ""
+		for _, p := range tr.Spec.Params {
+			if ar.ParamName == p.Name {
+				if p.Value.Type != v1beta1.ParamTypeString {
+					continue
+				}
+				sub = p.Value.StringVal
+				break
+			}
+		}
+		if sub == "" {
+			// Loog amongst task results
+			for _, trr := range tr.Status.TaskRunResults {
+				if trr.Name == ar.ParamName {
+					sub = strings.TrimRight(trr.Value, "\n")
+					break
+				}
+			}
+		}
+
+		if sub == "" {
+			// Parameter was not specifed for this task run
+			continue
+		}
+
+		// Loop over the parameters
+		for _, trr := range tr.Status.TaskRunResults {
+			if trr.Name == ar.ResultName {
+				// Value should be on format:
+				// alg:hash
+				// alg:hash filename
+				mod := strings.TrimRight(trr.Value, "\n")
+				ah := strings.Split(mod, ":")
+				if len(ah) != 2 {
+					continue
+				}
+				alg := ah[0]
+
+				// Is format "hash filename"
+				groups := r.FindStringSubmatch(ah[1])
+				var hash string
+				if len(groups) == 3 {
+					hash = groups[1]
+				} else {
+					hash = ah[1]
+				}
+
+				// OCI image shall use pacakge url format for subjects
+				if ar.Type == artifactTypeOCI {
+					imageID := getOCIImageID(sub, alg, hash)
+					sub, _, _ = getPackageURLDocker(imageID)
+				}
+
+				subs = append(subs, in_toto.Subject{
+					Name: sub,
+					Digest: map[string]string{
+						alg: hash,
+					},
+				})
+				// Subject found, go after next result
+				continue Results
+			}
+		}
+	}
+
+	sort.Slice(subs, func(i, j int) bool {
+		return subs[i].Name <= subs[j].Name
+	})
+	return subs
+}
+
+func intP(i int) *int {
+	return &i
+}
+
+// getPackageURLDocker takes an image id and creates a package URL string
+// based from it.
+// https://github.com/package-url/purl-spec
+func getPackageURLDocker(imageID string) (string, string, string) {
+	// Default registry per purl spec
+	const defaultRegistry = "hub.docker.com"
+
+	// imageID formats: name@alg:digest
+	//                  schema://name@alg:digest
+	d := strings.Split(imageID, "//")
+	if len(d) == 2 {
+		// Get away with schema
+		imageID = d[1]
+	}
+
+	digest, err := name.NewDigest(imageID, name.WithDefaultRegistry(defaultRegistry))
+	if err != nil {
+		return "", "", ""
+	}
+
+	// DigestStr() is alg:digest
+	parts := strings.Split(digest.DigestStr(), ":")
+	if len(parts) != 2 {
+		return "", "", ""
+	}
+
+	purl := fmt.Sprintf("pkg:docker/%s@%s",
+		digest.Context().RepositoryStr(),
+		digest.DigestStr(),
+	)
+
+	// Only inlude registry if it's not the default
+	registry := digest.Context().Registry.Name()
+	if registry != defaultRegistry {
+		purl = fmt.Sprintf("%s?repository_url=%s", purl, registry)
+	}
+
+	return purl, parts[0], parts[1]
+}
+
+// getOCIImageID generates an imageID that is compatible imageID field in
+// the task result's status field.
+func getOCIImageID(name, alg, digest string) string {
+	// image id is: docker://name@alg:digest
+	return fmt.Sprintf("docker://%s@%s:%s", name, alg, digest)
+}

--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -1,0 +1,614 @@
+package intotoite6
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/config"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+var testData1 = `
+{
+  "spec": {
+    "params": [
+      {
+        "name": "IMAGE",
+        "value": "test.io/test/image"
+      },
+      {
+        "name": "CHAINS-GIT_COMMIT",
+        "value": "abcd"
+      },
+      {
+        "name": "CHAINS-GIT_URL",
+        "value": "https://git.test.com"
+      },
+      {
+        "name": "filename",
+        "value": "/bin/ls"
+      }
+    ],
+    "taskRef": {
+      "name": "test-task",
+      "kind": "Task"
+    },
+    "serviceAccountName": "default"
+  },
+  "status": {
+    "startTime": "2021-03-29T09:50:00Z",
+    "completionTime": "2021-03-29T09:50:15Z",
+    "conditions": [
+      {
+        "type": "Succeeded",
+        "status": "True",
+        "lastTransitionTime": "2021-03-29T09:50:15Z",
+        "reason": "Succeeded",
+        "message": "All Steps have completed executing"
+      }
+    ],
+    "podName": "test-pod-name",
+    "steps": [
+      {
+        "name": "step1",
+        "container": "step-step1",
+        "imageID": "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+      },
+      {
+        "name": "step2",
+        "container": "step-step2",
+        "imageID": "docker-pullable://gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"
+      },
+      {
+        "name": "step3",
+        "container": "step-step3",
+        "imageID": "docker-pullable://gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"
+      }
+    ],
+    "taskResults": [
+      {
+        "name": "IMAGE_DIGEST",
+        "value": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+      },
+      {
+        "name": "filename_DIGEST",
+        "value": "sha256:hash5   /bin/ls"
+      }
+    ],
+    "taskSpec": {
+      "params": [
+        {
+          "name": "IMAGE",
+          "type": "string"
+        },
+        {
+          "name": "filename",
+          "type": "string"
+        },
+        {
+          "name": "DOCKERFILE",
+          "type": "string"
+        },
+        {
+          "name": "CONTEXT",
+          "type": "string"
+        },
+        {
+          "name": "EXTRA_ARGS",
+          "type": "string"
+        },
+        {
+          "name": "BUILDER_IMAGE",
+          "type": "string"
+        }
+      ],
+      "results": [
+        {
+          "name": "IMAGE_DIGEST",
+          "description": "Digest of the image just built."
+        },
+        {
+          "name": "filename_DIGEST",
+          "description": "Digest of the file just built."
+        }
+      ]
+    }
+  }
+}
+`
+
+var e1BuildStart = time.Unix(1617011400, 0)
+var e1BuildFinished = time.Unix(1617011415, 0)
+var expected1 = in_toto.ProvenanceStatement{
+	StatementHeader: in_toto.StatementHeader{
+		Type:          in_toto.StatementInTotoV01,
+		PredicateType: in_toto.PredicateProvenanceV01,
+		Subject: []in_toto.Subject{
+			{
+				Name: "/bin/ls",
+				Digest: map[string]string{
+					"sha256": "hash5",
+				},
+			},
+			{
+				Name: "pkg:docker/test/image@sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7?repository_url=test.io",
+				Digest: map[string]string{
+					"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+				},
+			},
+		},
+	},
+	Predicate: in_toto.ProvenancePredicate{
+		Metadata: in_toto.ProvenanceMetadata{
+			BuildStartedOn:  &e1BuildStart,
+			BuildFinishedOn: &e1BuildFinished,
+		},
+		Materials: []in_toto.ProvenanceMaterial{
+			{
+				URI: "git+https://git.test.com",
+				Digest: map[string]string{
+					"git_commit": "abcd",
+				},
+			},
+			{
+				URI: "pkg:docker/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6?repository_url=gcr.io",
+				Digest: map[string]string{
+					"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+				},
+			},
+			{
+				URI: "pkg:docker/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac?repository_url=gcr.io",
+				Digest: map[string]string{
+					"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
+				},
+			},
+			{
+				URI: "pkg:docker/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478?repository_url=gcr.io",
+				Digest: map[string]string{
+					"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
+				},
+			},
+		},
+		Builder: in_toto.ProvenanceBuilder{
+			ID: "test_builder-1",
+		},
+		Recipe: in_toto.ProvenanceRecipe{
+			Type:              tektonID,
+			EntryPoint:        "test-task",
+			DefinedInMaterial: intP(0),
+		},
+	},
+}
+
+var testData2 = `
+{
+  "spec": {
+    "params": [],
+    "taskRef": {
+      "name": "test-task",
+      "kind": "Task"
+    },
+    "serviceAccountName": "default"
+  },
+  "status": {
+    "conditions": [
+      {
+        "type": "Succeeded",
+        "status": "True",
+        "lastTransitionTime": "2021-03-29T09:50:15Z",
+        "reason": "Succeeded",
+        "message": "All Steps have completed executing"
+      }
+    ],
+    "podName": "test-pod-name",
+    "steps": [
+      {
+        "name": "step1",
+        "container": "step-step1",
+        "imageID": "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+      }
+    ],
+    "taskResults": [
+      {
+        "name": "some-uri_DIGEST",
+        "value": "sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+      },
+      {
+        "name": "some-uri",
+        "value": "pkg:deb/debian/curl@7.50.3-1"
+      }
+    ],
+    "taskSpec": {
+      "params": [],
+      "results": [
+        {
+          "name": "some-uri_DIGEST",
+          "description": "Digest of a file to push."
+        },
+        {
+          "name": "some-uri",
+          "description": "some calculated uri"
+        }
+      ]
+    }
+  }
+}
+`
+
+var expected2 = in_toto.ProvenanceStatement{
+	StatementHeader: in_toto.StatementHeader{
+		Type:          in_toto.StatementInTotoV01,
+		PredicateType: in_toto.PredicateProvenanceV01,
+		Subject: []in_toto.Subject{
+			{
+				Name: "pkg:deb/debian/curl@7.50.3-1",
+				Digest: map[string]string{
+					"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+				},
+			},
+		},
+	},
+	Predicate: in_toto.ProvenancePredicate{
+		Materials: []in_toto.ProvenanceMaterial{
+			{
+				URI: "pkg:docker/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6?repository_url=gcr.io",
+				Digest: map[string]string{
+					"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+				},
+			},
+		},
+		Builder: in_toto.ProvenanceBuilder{
+			ID: "test_builder-2",
+		},
+		Recipe: in_toto.ProvenanceRecipe{
+			Type:       tektonID,
+			EntryPoint: "test-task",
+		},
+	},
+}
+
+var dataMultpleSubjects = `
+{
+  "spec": {
+    "params": [],
+    "taskRef": {
+      "name": "test-task",
+      "kind": "Task"
+    },
+    "serviceAccountName": "default"
+  },
+  "status": {
+    "conditions": [
+      {
+        "type": "Succeeded",
+        "status": "True",
+        "lastTransitionTime": "2021-03-29T09:50:15Z",
+        "reason": "Succeeded",
+        "message": "All Steps have completed executing"
+      }
+    ],
+    "podName": "test-pod-name",
+    "steps": [
+      {
+        "name": "step1",
+        "container": "step-step1",
+        "imageID": "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+      }
+    ],
+    "taskResults": [
+      {
+        "name": "file1_DIGEST",
+        "value": "sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+      },
+      {
+        "name": "file1",
+        "value": "pkg:deb/debian/curl@7.50.3-1"
+      },
+      {
+        "name": "file2_DIGEST",
+        "value": "sha256:daa1a56e13c85cf164e7d9e595006649e3a04c47fe4a8261320e18a0bf3b0367"
+      },
+      {
+        "name": "file2",
+        "value": "pkg:generic/curl@7.50.3-1.tar.gz"
+      }
+    ],
+    "taskSpec": {
+      "params": [],
+      "results": [
+        {
+          "name": "file1_DIGEST",
+          "description": "Digest of a file to push."
+        },
+        {
+          "name": "file1",
+          "description": "some assembled file"
+        },
+        {
+          "name": "file2_DIGEST",
+          "description": "Digest of a file to push."
+        },
+        {
+          "name": "file2",
+          "description": "some assembled file"
+        }
+      ]
+    }
+  }
+}
+`
+
+var expectedMultipleSubjects = in_toto.ProvenanceStatement{
+	StatementHeader: in_toto.StatementHeader{
+		Type:          in_toto.StatementInTotoV01,
+		PredicateType: in_toto.PredicateProvenanceV01,
+		Subject: []in_toto.Subject{
+			{
+				Name: "pkg:deb/debian/curl@7.50.3-1",
+				Digest: map[string]string{
+					"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+				},
+			},
+			{
+				Name: "pkg:generic/curl@7.50.3-1.tar.gz",
+				Digest: map[string]string{
+					"sha256": "daa1a56e13c85cf164e7d9e595006649e3a04c47fe4a8261320e18a0bf3b0367",
+				},
+			},
+		},
+	},
+	Predicate: in_toto.ProvenancePredicate{
+		Materials: []in_toto.ProvenanceMaterial{
+			{
+				URI: "pkg:docker/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6?repository_url=gcr.io",
+				Digest: map[string]string{
+					"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+				},
+			},
+		},
+		Builder: in_toto.ProvenanceBuilder{
+			ID: "test_builder-multiple",
+		},
+		Recipe: in_toto.ProvenanceRecipe{
+			Type:       tektonID,
+			EntryPoint: "test-task",
+		},
+	},
+}
+
+func TestInTotoIte6_CreatePayload1(t *testing.T) {
+	var tr v1beta1.TaskRun
+
+	err := json.Unmarshal([]byte(testData1), &tr)
+	if err != nil {
+		t.Errorf("json.Unmarshal() error = %v", err)
+		return
+	}
+
+	cfg := config.Config{
+		Builder: config.BuilderConfig{
+			ID: "test_builder-1",
+		},
+	}
+	i, _ := NewFormatter(cfg)
+
+	got, err := i.CreatePayload(&tr)
+
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if diff := cmp.Diff(expected1, got); diff != "" {
+		t.Errorf("InTotoIte6.CreatePayload(): -want +got: %s", diff)
+	}
+}
+
+func TestInTotoIte6_CreatePayload2(t *testing.T) {
+	var tr v1beta1.TaskRun
+
+	err := json.Unmarshal([]byte(testData2), &tr)
+	if err != nil {
+		t.Errorf("json.Unmarshal() error = %v", err)
+		return
+	}
+
+	cfg := config.Config{
+		Builder: config.BuilderConfig{
+			ID: "test_builder-2",
+		},
+	}
+	i, _ := NewFormatter(cfg)
+	got, err := i.CreatePayload(&tr)
+
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if diff := cmp.Diff(expected2, got); diff != "" {
+		t.Errorf("InTotoIte6.CreatePayload(): -want +got: %s", diff)
+	}
+}
+
+func TestInTotoIte6_MultipleSubjects(t *testing.T) {
+	var tr v1beta1.TaskRun
+
+	err := json.Unmarshal([]byte(dataMultpleSubjects), &tr)
+	if err != nil {
+		t.Errorf("json.Unmarshal() error = %v", err)
+		return
+	}
+
+	cfg := config.Config{
+		Builder: config.BuilderConfig{
+			ID: "test_builder-multiple",
+		},
+	}
+	i, _ := NewFormatter(cfg)
+	got, err := i.CreatePayload(&tr)
+
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if diff := cmp.Diff(expectedMultipleSubjects, got); diff != "" {
+		t.Errorf("InTotoIte6.CreatePayload(): -want +got: %s", diff)
+	}
+}
+
+func TestNewFormatter(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		cfg := config.Config{
+			Builder: config.BuilderConfig{
+				ID: "testid",
+			},
+		}
+		f, err := NewFormatter(cfg)
+		if f == nil {
+			t.Error("Failed to create formater")
+		}
+		if err != nil {
+			t.Errorf("Error creating formater: %s", err)
+		}
+	})
+	t.Run("Fail", func(t *testing.T) {
+		cfg := config.Config{}
+		f, err := NewFormatter(cfg)
+		if f != nil {
+			t.Error("Expected to create to fail")
+		}
+		if err != ErrNoBuilderID {
+			t.Errorf("Unexpected error : %s", err)
+		}
+	})
+}
+
+func TestPurlDocker(t *testing.T) {
+	tests := []struct {
+		imageID string
+		purl    string
+		alg     string
+		digest  string
+	}{
+		{
+			imageID: "alpine@sha256:3f1017b520fe358d7b3796879232cd36259066ccd5bab5466cbedb444064dfed",
+			purl:    "pkg:docker/alpine@sha256:3f1017b520fe358d7b3796879232cd36259066ccd5bab5466cbedb444064dfed",
+			alg:     "sha256",
+			digest:  "3f1017b520fe358d7b3796879232cd36259066ccd5bab5466cbedb444064dfed",
+		},
+		{
+			imageID: "org/alpine@sha256:3f1017b520fe358d7b3796879232cd36259066ccd5bab5466cbedb444064dfed",
+			purl:    "pkg:docker/org/alpine@sha256:3f1017b520fe358d7b3796879232cd36259066ccd5bab5466cbedb444064dfed",
+			alg:     "sha256",
+			digest:  "3f1017b520fe358d7b3796879232cd36259066ccd5bab5466cbedb444064dfed",
+		},
+		{
+			imageID: "docker://alpine@sha256:6e0447537050cf871f9ab6a3fec5715f9c6fff5212f6666993f1fc46b1f717a3",
+			purl:    "pkg:docker/alpine@sha256:6e0447537050cf871f9ab6a3fec5715f9c6fff5212f6666993f1fc46b1f717a3",
+			alg:     "sha256",
+			digest:  "6e0447537050cf871f9ab6a3fec5715f9c6fff5212f6666993f1fc46b1f717a3",
+		},
+		{
+			imageID: "docker://org/name@sha256:55bbe28f6e4abb21be67cdd592e6e3b7b21b1a7b159768d539eb63119bbc1d28",
+			purl:    "pkg:docker/org/name@sha256:55bbe28f6e4abb21be67cdd592e6e3b7b21b1a7b159768d539eb63119bbc1d28",
+			alg:     "sha256",
+			digest:  "55bbe28f6e4abb21be67cdd592e6e3b7b21b1a7b159768d539eb63119bbc1d28",
+		},
+		{
+			imageID: "docker://gcr.io/org/name@sha256:64e1a1f5bd1c888e107e0145e26582edfab24779c1bbb0e11f3768432c5c0399",
+			purl:    "pkg:docker/org/name@sha256:64e1a1f5bd1c888e107e0145e26582edfab24779c1bbb0e11f3768432c5c0399?repository_url=gcr.io",
+			alg:     "sha256",
+			digest:  "64e1a1f5bd1c888e107e0145e26582edfab24779c1bbb0e11f3768432c5c0399",
+		},
+	}
+
+	for _, test := range tests {
+		purl, alg, digest := getPackageURLDocker(test.imageID)
+		if purl != test.purl {
+			t.Errorf("Invalid package url, got '%s' want '%s'", purl, test.purl)
+		}
+		if alg != test.alg {
+			t.Errorf("Invalid alg, got '%s' want '%s'", alg, test.alg)
+		}
+		if digest != test.digest {
+			t.Errorf("Invalid digest, got '%s' want '%s'", digest, test.digest)
+		}
+	}
+}
+
+func TestGetOCIImageID(t *testing.T) {
+	tests := []struct {
+		imageID string
+		name    string
+		alg     string
+		digest  string
+	}{
+		{
+			imageID: "docker://name@sha256:digest",
+			name:    "name",
+			alg:     "sha256",
+			digest:  "digest",
+		},
+	}
+	for _, test := range tests {
+		imageID := getOCIImageID(test.name, test.alg, test.digest)
+		if imageID != test.imageID {
+			t.Errorf("Invalid image ID, got '%s' want '%s'", imageID, test.imageID)
+		}
+	}
+}
+
+func TestCreatePayloadError(t *testing.T) {
+	cfg := config.Config{
+		Builder: config.BuilderConfig{
+			ID: "testid",
+		},
+	}
+	f, _ := NewFormatter(cfg)
+
+	t.Run("nil TaskRef", func(t *testing.T) {
+		var tr = v1beta1.TaskRun{
+			Status: v1beta1.TaskRunStatus{
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					PodName: "test-pod",
+				},
+			},
+		}
+
+		p, err := f.CreatePayload(&tr)
+		if p != nil {
+			t.Errorf("Unexpected payload")
+		}
+		if err == nil {
+			t.Errorf("Expected error")
+		} else {
+			if err.Error() != "provided TaskRef is nil for test-pod" {
+				t.Errorf("wrong error returned: '%s'", err.Error())
+			}
+		}
+	})
+
+	t.Run("Invalid type", func(t *testing.T) {
+		p, err := f.CreatePayload("not a task ref")
+
+		if p != nil {
+			t.Errorf("Unexpected payload")
+		}
+		if err == nil {
+			t.Errorf("Expected error")
+		} else {
+			if err.Error() != "unsupported type: not a task ref" {
+				t.Errorf("wrong error returned: '%s'", err.Error())
+			}
+		}
+	})
+
+}
+
+func TestCorrectPayloadType(t *testing.T) {
+	var i InTotoIte6
+	if i.Type() != formats.PayloadTypeInTotoIte6 {
+		t.Errorf("Invalid type returned: %s", i.Type())
+	}
+}

--- a/pkg/chains/formats/simple/simple.go
+++ b/pkg/chains/formats/simple/simple.go
@@ -11,11 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package formats
+package simple
 
 import (
 	"fmt"
 	"path"
+
+	"github.com/tektoncd/chains/pkg/chains/formats"
 
 	"github.com/google/go-containerregistry/pkg/name"
 )
@@ -37,6 +39,10 @@ func (i *SimpleSigning) CreatePayload(obj interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("unsupported type %s", v)
 	}
 
+}
+
+func NewFormatter() (formats.Payloader, error) {
+	return &SimpleSigning{}, nil
 }
 
 func NewSimpleStruct() Simple {
@@ -62,8 +68,8 @@ type Critical struct {
 	Type     string
 }
 
-func (i *SimpleSigning) Type() PayloadType {
-	return PayloadTypeSimpleSigning
+func (i *SimpleSigning) Type() formats.PayloadType {
+	return formats.PayloadTypeSimpleSigning
 }
 
 func (s *Simple) ImageName() string {

--- a/pkg/chains/formats/simple/simple_test.go
+++ b/pkg/chains/formats/simple/simple_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package formats
+package simple
 
 import (
 	"reflect"

--- a/pkg/chains/formats/tekton/tekton.go
+++ b/pkg/chains/formats/tekton/tekton.go
@@ -11,16 +11,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package formats
+package tekton
 
 import (
 	"fmt"
+
+	"github.com/tektoncd/chains/pkg/chains/formats"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
 // Tekton is a formatter that just captures the TaskRun Status with no modifications.
 type Tekton struct {
+}
+
+func NewFormatter() (formats.Payloader, error) {
+	return &Tekton{}, nil
 }
 
 // CreatePayload implements the Payloader interface.
@@ -35,6 +41,6 @@ func (i *Tekton) CreatePayload(obj interface{}) (interface{}, error) {
 
 }
 
-func (i *Tekton) Type() PayloadType {
-	return PayloadTypeTekton
+func (i *Tekton) Type() formats.PayloadType {
+	return formats.PayloadTypeTekton
 }

--- a/pkg/chains/formats/tekton/tekton_test.go
+++ b/pkg/chains/formats/tekton/tekton_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package formats
+package tekton
 
 import (
 	"reflect"

--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/pkg/cosign"
-	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/formats/simple"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
@@ -65,7 +65,7 @@ func NewStorageBackend(logger *zap.SugaredLogger, tr *v1beta1.TaskRun, cfg confi
 func (b *Backend) StorePayload(rawPayload []byte, signature string, key string) error {
 	b.logger.Infof("Storing payload on TaskRun %s/%s", b.tr.Namespace, b.tr.Name)
 
-	format := formats.NewSimpleStruct()
+	format := simple.NewSimpleStruct()
 	if err := json.Unmarshal(rawPayload, &format); err != nil {
 		return errors.Wrap(err, "only OCI artifacts can be stored in an OCI registry")
 	}

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -15,6 +15,7 @@ type Config struct {
 	Artifacts ArtifactConfigs
 	Storage   StorageConfigs
 	Signers   SignerConfigs
+	Builder   BuilderConfig
 }
 
 // ArtifactConfig contains the configuration for how to sign/store/format the signatures for each artifact type
@@ -43,6 +44,10 @@ type SignerConfigs struct {
 	PGP  PGPSigner
 	X509 X509Signer
 	KMS  KMSSigner
+}
+
+type BuilderConfig struct {
+	ID string
 }
 
 type PGPSigner struct {
@@ -92,6 +97,9 @@ const (
 	// KMS
 	kmsSignerKMSRef = "signers.kms.kmsref"
 
+	// Builder config
+	builderIDKey = "builder.id"
+
 	chainsConfig = "chains-config"
 )
 
@@ -105,7 +113,7 @@ var defaults = map[string]string{
 }
 
 var supportedValues = map[string][]string{
-	taskrunFormatKey:  {"tekton"},
+	taskrunFormatKey:  {"tekton", "in-toto-ite6"},
 	taskrunStorageKey: {"tekton", "oci", "gcs", "docdb"},
 	taskrunSignerKey:  {"pgp", "x509", "kms"},
 	ociFormatKey:      {"tekton", "simplesigning"},
@@ -136,6 +144,9 @@ func parse(data map[string]string) Config {
 	cfg.Storage.DocDB.URL = valueOrDefault(docDBUrlKey, data)
 
 	cfg.Signers.KMS.KMSRef = valueOrDefault(kmsSignerKMSRef, data)
+
+	// Build config
+	cfg.Builder.ID = valueOrDefault(builderIDKey, data)
 
 	return cfg
 }

--- a/vendor/github.com/in-toto/in-toto-golang/LICENSE
+++ b/vendor/github.com/in-toto/in-toto-golang/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2018 New York University
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/in-toto/in-toto-golang/in_toto/canonicaljson.go
+++ b/vendor/github.com/in-toto/in-toto-golang/in_toto/canonicaljson.go
@@ -1,0 +1,145 @@
+package in_toto
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+)
+
+/*
+encodeCanonicalString is a helper function to canonicalize the passed string
+according to the OLPC canonical JSON specification for strings (see
+http://wiki.laptop.org/go/Canonical_JSON).  String canonicalization consists of
+escaping backslashes ("\") and double quotes (") and wrapping the resulting
+string in double quotes (").
+*/
+func encodeCanonicalString(s string) string {
+	re := regexp.MustCompile(`([\"\\])`)
+	return fmt.Sprintf("\"%s\"", re.ReplaceAllString(s, "\\$1"))
+}
+
+/*
+encodeCanonical is a helper function to recursively canonicalize the passed
+object according to the OLPC canonical JSON specification (see
+http://wiki.laptop.org/go/Canonical_JSON) and write it to the passed
+*bytes.Buffer.  If canonicalization fails it returns an error.
+*/
+func encodeCanonical(obj interface{}, result *bytes.Buffer) (err error) {
+	// Since this function is called recursively, we use panic if an error occurs
+	// and recover in a deferred function, which is always called before
+	// returning. There we set the error that is returned eventually.
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New(r.(string))
+		}
+	}()
+
+	switch objAsserted := obj.(type) {
+	case string:
+		result.WriteString(encodeCanonicalString(objAsserted))
+
+	case bool:
+		if objAsserted {
+			result.WriteString("true")
+		} else {
+			result.WriteString("false")
+		}
+
+	// The wrapping `EncodeCanonical` function decodes the passed json data with
+	// `decoder.UseNumber` so that any numeric value is stored as `json.Number`
+	// (instead of the default `float64`). This allows us to assert that it is a
+	// non-floating point number, which are the only numbers allowed by the used
+	// canonicalization specification.
+	case json.Number:
+		if _, err := objAsserted.Int64(); err != nil {
+			panic(fmt.Sprintf("Can't canonicalize floating point number '%s'",
+				objAsserted))
+		}
+		result.WriteString(objAsserted.String())
+
+	case nil:
+		result.WriteString("null")
+
+	// Canonicalize slice
+	case []interface{}:
+		result.WriteString("[")
+		for i, val := range objAsserted {
+			if err := encodeCanonical(val, result); err != nil {
+				return err
+			}
+			if i < (len(objAsserted) - 1) {
+				result.WriteString(",")
+			}
+		}
+		result.WriteString("]")
+
+	case map[string]interface{}:
+		result.WriteString("{")
+
+		// Make a list of keys
+		var mapKeys []string
+		for key := range objAsserted {
+			mapKeys = append(mapKeys, key)
+		}
+		// Sort keys
+		sort.Strings(mapKeys)
+
+		// Canonicalize map
+		for i, key := range mapKeys {
+			// Note: `key` must be a `string` (see `case map[string]interface{}`) and
+			// canonicalization of strings cannot err out (see `case string`), thus
+			// no error handling is needed here.
+			encodeCanonical(key, result)
+
+			result.WriteString(":")
+			if err := encodeCanonical(objAsserted[key], result); err != nil {
+				return err
+			}
+			if i < (len(mapKeys) - 1) {
+				result.WriteString(",")
+			}
+			i++
+		}
+		result.WriteString("}")
+
+	default:
+		// We recover in a deferred function defined above
+		panic(fmt.Sprintf("Can't canonicalize '%s' of type '%s'",
+			objAsserted, reflect.TypeOf(objAsserted)))
+	}
+	return nil
+}
+
+/*
+EncodeCanonical JSON canonicalizes the passed object and returns it as a byte
+slice.  It uses the OLPC canonical JSON specification (see
+http://wiki.laptop.org/go/Canonical_JSON).  If canonicalization fails the byte
+slice is nil and the second return value contains the error.
+*/
+func EncodeCanonical(obj interface{}) ([]byte, error) {
+	// FIXME: Terrible hack to turn the passed struct into a map, converting
+	// the struct's variable names to the json key names defined in the struct
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	var jsonMap interface{}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&jsonMap); err != nil {
+		return nil, err
+	}
+
+	// Create a buffer and write the canonicalized JSON bytes to it
+	var result bytes.Buffer
+	if err := encodeCanonical(jsonMap, &result); err != nil {
+		return nil, err
+	}
+
+	return result.Bytes(), nil
+}

--- a/vendor/github.com/in-toto/in-toto-golang/in_toto/hashlib.go
+++ b/vendor/github.com/in-toto/in-toto-golang/in_toto/hashlib.go
@@ -1,0 +1,30 @@
+package in_toto
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"hash"
+)
+
+/*
+getHashMapping returns a mapping from hash algorithm to supported hash
+interface.
+*/
+func getHashMapping() map[string]func() hash.Hash {
+	return map[string]func() hash.Hash{
+		"sha256": sha256.New,
+		"sha512": sha512.New,
+		"sha384": sha512.New384,
+	}
+}
+
+/*
+hashToHex calculates the hash over data based on hash algorithm h.
+*/
+func hashToHex(h hash.Hash, data []byte) []byte {
+	h.Write(data)
+	// We need to use h.Sum(nil) here, because otherwise hash.Sum() appends
+	// the hash to the passed data. So instead of having only the hash
+	// we would get: "dataHASH"
+	return h.Sum(nil)
+}

--- a/vendor/github.com/in-toto/in-toto-golang/in_toto/keylib.go
+++ b/vendor/github.com/in-toto/in-toto-golang/in_toto/keylib.go
@@ -1,0 +1,563 @@
+package in_toto
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// ErrFailedPEMParsing gets returned when PKCS1, PKCS8 or PKIX key parsing fails
+var ErrFailedPEMParsing = errors.New("failed parsing the PEM block: unsupported PEM type")
+
+// ErrNoPEMBlock gets triggered when there is no PEM block in the provided file
+var ErrNoPEMBlock = errors.New("failed to decode the data as PEM block (are you sure this is a pem file?)")
+
+// ErrUnsupportedKeyType is returned when we are dealing with a key type different to ed25519 or RSA
+var ErrUnsupportedKeyType = errors.New("unsupported key type")
+
+// ErrInvalidSignature is returned when the signature is invalid
+var ErrInvalidSignature = errors.New("invalid signature")
+
+// ErrInvalidKey is returned when a given key is none of RSA, ECDSA or ED25519
+var ErrInvalidKey = errors.New("invalid key")
+
+const (
+	rsaKeyType            string = "rsa"
+	ecdsaKeyType          string = "ecdsa"
+	ed25519KeyType        string = "ed25519"
+	rsassapsssha256Scheme string = "rsassa-pss-sha256"
+	ecdsaSha2nistp224     string = "ecdsa-sha2-nistp224"
+	ecdsaSha2nistp384     string = "ecdsa-sha2-nistp384"
+	ecdsaSha2nistp521     string = "ecdsa-sha2-nistp521"
+	ed25519Scheme         string = "ed25519"
+	pemPublicKey          string = "PUBLIC KEY"
+	pemPrivateKey         string = "PRIVATE KEY"
+	pemRSAPrivateKey      string = "PRIVATE RSA KEY"
+)
+
+/*
+getSupportedKeyIDHashAlgorithms returns a string slice of supported
+KeyIDHashAlgorithms. We need to use this function instead of a constant,
+because Go does not support global constant slices.
+*/
+func getSupportedKeyIDHashAlgorithms() Set {
+	return NewSet("sha256", "sha512")
+}
+
+/*
+getSupportedRSASchemes returns a string slice of supported RSA Key schemes.
+We need to use this function instead of a constant because Go does not support
+global constant slices.
+*/
+func getSupportedRSASchemes() []string {
+	return []string{rsassapsssha256Scheme}
+}
+
+/*
+getSupportedEcdsaSchemes returns a string slice of supported ecdsa Key schemes.
+We need to use this function instead of a constant because Go does not support
+global constant slices.
+*/
+func getSupportedEcdsaSchemes() []string {
+	return []string{ecdsaSha2nistp224, ecdsaSha2nistp384, ecdsaSha2nistp521}
+}
+
+/*
+getSupportedEd25519Schemes returns a string slice of supported ed25519 Key
+schemes. We need to use this function instead of a constant because Go does
+not support global constant slices.
+*/
+func getSupportedEd25519Schemes() []string {
+	return []string{ed25519Scheme}
+}
+
+/*
+generateKeyID creates a partial key map and generates the key ID
+based on the created partial key map via the SHA256 method.
+The resulting keyID will be directly saved in the corresponding key object.
+On success generateKeyID will return nil, in case of errors while encoding
+there will be an error.
+*/
+func (k *Key) generateKeyID() error {
+	// Create partial key map used to create the keyid
+	// Unfortunately, we can't use the Key object because this also carries
+	// yet unwanted fields, such as KeyID and KeyVal.Private and therefore
+	// produces a different hash. We generate the keyID exactly as we do in
+	// the securesystemslib  to keep interoperability between other in-toto
+	// implementations.
+	var keyToBeHashed = map[string]interface{}{
+		"keytype":               k.KeyType,
+		"scheme":                k.Scheme,
+		"keyid_hash_algorithms": k.KeyIDHashAlgorithms,
+		"keyval": map[string]string{
+			"public": k.KeyVal.Public,
+		},
+	}
+	keyCanonical, err := EncodeCanonical(keyToBeHashed)
+	if err != nil {
+		return err
+	}
+	// calculate sha256 and return string representation of keyID
+	keyHashed := sha256.Sum256(keyCanonical)
+	k.KeyID = fmt.Sprintf("%x", keyHashed)
+	err = validateKey(*k)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
+generatePEMBlock creates a PEM block from scratch via the keyBytes and the pemType.
+If successful it returns a PEM block as []byte slice. This function should always
+succeed, if keyBytes is empty the PEM block will have an empty byte block.
+Therefore only header and footer will exist.
+*/
+func generatePEMBlock(keyBytes []byte, pemType string) []byte {
+	// construct PEM block
+	pemBlock := &pem.Block{
+		Type:    pemType,
+		Headers: nil,
+		Bytes:   keyBytes,
+	}
+	return pem.EncodeToMemory(pemBlock)
+}
+
+/*
+setKeyComponents sets all components in our key object.
+Furthermore it makes sure to remove any trailing and leading whitespaces or newlines.
+We treat key types differently for interoperability reasons to the in-toto python
+implementation and the securesystemslib.
+*/
+func (k *Key) setKeyComponents(pubKeyBytes []byte, privateKeyBytes []byte, keyType string, scheme string, KeyIDHashAlgorithms []string) error {
+	// assume we have a privateKey if the key size is bigger than 0
+	switch keyType {
+	case rsaKeyType:
+		if len(privateKeyBytes) > 0 {
+			k.KeyVal = KeyVal{
+				Private: strings.TrimSpace(string(generatePEMBlock(privateKeyBytes, pemRSAPrivateKey))),
+				Public:  strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, pemPublicKey))),
+			}
+		} else {
+			k.KeyVal = KeyVal{
+				Public: strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, pemPublicKey))),
+			}
+		}
+	case ecdsaKeyType:
+		if len(privateKeyBytes) > 0 {
+			k.KeyVal = KeyVal{
+				Private: strings.TrimSpace(string(generatePEMBlock(privateKeyBytes, pemPrivateKey))),
+				Public:  strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, pemPublicKey))),
+			}
+		} else {
+			k.KeyVal = KeyVal{
+				Public: strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, pemPublicKey))),
+			}
+		}
+	case ed25519KeyType:
+		if len(privateKeyBytes) > 0 {
+			k.KeyVal = KeyVal{
+				Private: strings.TrimSpace(hex.EncodeToString(privateKeyBytes)),
+				Public:  strings.TrimSpace(hex.EncodeToString(pubKeyBytes)),
+			}
+		} else {
+			k.KeyVal = KeyVal{
+				Public: strings.TrimSpace(hex.EncodeToString(pubKeyBytes)),
+			}
+		}
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedKeyType, keyType)
+	}
+	k.KeyType = keyType
+	k.Scheme = scheme
+	k.KeyIDHashAlgorithms = KeyIDHashAlgorithms
+	if err := k.generateKeyID(); err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
+parseKey tries to parse a PEM []byte slice. Using the following standards
+in the given order:
+
+	* PKCS8
+	* PKCS1
+	* PKIX
+
+On success it returns the parsed key and nil.
+On failure it returns nil and the error ErrFailedPEMParsing
+*/
+func parseKey(data []byte) (interface{}, error) {
+	key, err := x509.ParsePKCS8PrivateKey(data)
+	if err == nil {
+		return key, nil
+	}
+	key, err = x509.ParsePKCS1PrivateKey(data)
+	if err == nil {
+		return key, nil
+	}
+	key, err = x509.ParsePKIXPublicKey(data)
+	if err == nil {
+		return key, nil
+	}
+	return nil, ErrFailedPEMParsing
+}
+
+/*
+decodeAndParse receives potential PEM bytes decodes them via pem.Decode
+and pushes them to parseKey. If any error occurs during this process,
+the function will return nil and an error (either ErrFailedPEMParsing
+or ErrNoPEMBlock). On success it will return the decoded pemData, the
+key object interface and nil as error. We need the decoded pemData,
+because LoadKey relies on decoded pemData for operating system
+interoperability.
+*/
+func decodeAndParse(pemBytes []byte) (*pem.Block, interface{}, error) {
+	// pem.Decode returns the parsed pem block and a rest.
+	// The rest is everything, that could not be parsed as PEM block.
+	// Therefore we can drop this via using the blank identifier "_"
+	data, _ := pem.Decode(pemBytes)
+	if data == nil {
+		return nil, nil, ErrNoPEMBlock
+	}
+	// Try to load private key, if this fails try to load
+	// key as public key
+	key, err := parseKey(data.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, key, nil
+}
+
+/*
+LoadKey loads the key file at specified file path into the key object.
+It automatically derives the PEM type and the key type.
+Right now the following PEM types are supported:
+
+	* PKCS1 for private keys
+	* PKCS8	for private keys
+	* PKIX for public keys
+
+The following key types are supported and will be automatically assigned to
+the key type field:
+
+	* ed25519
+	* rsa
+	* ecdsa
+
+The following schemes are supported:
+
+	* ed25519 -> ed25519
+	* rsa -> rsassa-pss-sha256
+	* ecdsa -> ecdsa-sha256-nistp256
+
+Note that, this behavior is consistent with the securesystemslib, except for
+ecdsa. We do not use the scheme string as key type in in-toto-golang.
+Instead we are going with a ecdsa/ecdsa-sha2-nistp256 pair.
+
+On success it will return nil. The following errors can happen:
+
+	* path not found or not readable
+	* no PEM block in the loaded file
+	* no valid PKCS8/PKCS1 private key or PKIX public key
+	* errors while marshalling
+	* unsupported key types
+*/
+func (k *Key) LoadKey(path string, scheme string, KeyIDHashAlgorithms []string) error {
+	pemFile, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := pemFile.Close(); closeErr != nil {
+			err = closeErr
+		}
+	}()
+	return k.LoadKeyReader(pemFile, scheme, KeyIDHashAlgorithms)
+}
+
+// LoadKeyReader loads the key from a supplied reader. The logic matches LoadKey otherwise.
+func (k *Key) LoadKeyReader(r io.Reader, scheme string, KeyIDHashAlgorithms []string) error {
+	if r == nil {
+		return ErrNoPEMBlock
+	}
+	// Read key bytes
+	pemBytes, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	// decodeAndParse returns the pemData for later use
+	// and a parsed key object (for operations on that key, like extracting the public Key)
+	pemData, key, err := decodeAndParse(pemBytes)
+	if err != nil {
+		return err
+	}
+
+	// Use type switch to identify the key format
+	switch key.(type) {
+	case *rsa.PublicKey:
+		pubKeyBytes, err := x509.MarshalPKIXPublicKey(key.(*rsa.PublicKey))
+		if err != nil {
+			return err
+		}
+		if err := k.setKeyComponents(pubKeyBytes, []byte{}, rsaKeyType, scheme, KeyIDHashAlgorithms); err != nil {
+			return err
+		}
+	case *rsa.PrivateKey:
+		// Note: RSA Public Keys will get stored as X.509 SubjectPublicKeyInfo (RFC5280)
+		// This behavior is consistent to the securesystemslib
+		pubKeyBytes, err := x509.MarshalPKIXPublicKey(key.(*rsa.PrivateKey).Public())
+		if err != nil {
+			return err
+		}
+		if err := k.setKeyComponents(pubKeyBytes, pemData.Bytes, rsaKeyType, scheme, KeyIDHashAlgorithms); err != nil {
+			return err
+		}
+	case ed25519.PublicKey:
+		if err := k.setKeyComponents(key.(ed25519.PublicKey), []byte{}, ed25519KeyType, scheme, KeyIDHashAlgorithms); err != nil {
+			return err
+		}
+	case ed25519.PrivateKey:
+		pubKeyBytes := key.(ed25519.PrivateKey).Public()
+		if err := k.setKeyComponents(pubKeyBytes.(ed25519.PublicKey), key.(ed25519.PrivateKey), ed25519KeyType, scheme, KeyIDHashAlgorithms); err != nil {
+			return err
+		}
+	case *ecdsa.PrivateKey:
+		pubKeyBytes, err := x509.MarshalPKIXPublicKey(key.(*ecdsa.PrivateKey).Public())
+		if err != nil {
+			return err
+		}
+		if err := k.setKeyComponents(pubKeyBytes, pemData.Bytes, ecdsaKeyType, scheme, KeyIDHashAlgorithms); err != nil {
+			return err
+		}
+	case *ecdsa.PublicKey:
+		pubKeyBytes, err := x509.MarshalPKIXPublicKey(key.(*ecdsa.PublicKey))
+		if err != nil {
+			return err
+		}
+		if err := k.setKeyComponents(pubKeyBytes, []byte{}, ecdsaKeyType, scheme, KeyIDHashAlgorithms); err != nil {
+			return err
+		}
+	default:
+		// We should never get here, because we implement all from Go supported Key Types
+		panic("unexpected Error in LoadKey function")
+	}
+	return nil
+}
+
+/*
+GenerateSignature will automatically detect the key type and sign the signable data
+with the provided key. If everything goes right GenerateSignature will return
+a for the key valid signature and err=nil. If something goes wrong it will
+return a not initialized signature and an error. Possible errors are:
+
+	* ErrNoPEMBlock
+	* ErrUnsupportedKeyType
+
+Currently supported is only one scheme per key.
+
+Note that in-toto-golang has different requirements to an ecdsa key.
+In in-toto-golang we use the string 'ecdsa' as string for the key type.
+In the key scheme we use: ecdsa-sha2-nistp256.
+*/
+func GenerateSignature(signable []byte, key Key) (Signature, error) {
+	err := validateKey(key)
+	if err != nil {
+		return Signature{}, err
+	}
+	var signature Signature
+	var signatureBuffer []byte
+	hashMapping := getHashMapping()
+	// The following switch block is needed for keeping interoperability
+	// with the securesystemslib and the python implementation
+	// in which we are storing RSA keys in PEM format, but ed25519 keys hex encoded.
+	switch key.KeyType {
+	case rsaKeyType:
+		// We do not need the pemData here, so we can throw it away via '_'
+		_, parsedKey, err := decodeAndParse([]byte(key.KeyVal.Private))
+		if err != nil {
+			return Signature{}, err
+		}
+		parsedKey, ok := parsedKey.(*rsa.PrivateKey)
+		if !ok {
+			return Signature{}, ErrKeyKeyTypeMismatch
+		}
+		switch key.Scheme {
+		case rsassapsssha256Scheme:
+			hashed := hashToHex(hashMapping["sha256"](), signable)
+			// We use rand.Reader as secure random source for rsa.SignPSS()
+			signatureBuffer, err = rsa.SignPSS(rand.Reader, parsedKey.(*rsa.PrivateKey), crypto.SHA256, hashed,
+				&rsa.PSSOptions{SaltLength: sha256.Size, Hash: crypto.SHA256})
+			if err != nil {
+				return signature, err
+			}
+		default:
+			// supported key schemes will get checked in validateKey
+			panic("unexpected Error in GenerateSignature function")
+		}
+	case ecdsaKeyType:
+		// We do not need the pemData here, so we can throw it away via '_'
+		_, parsedKey, err := decodeAndParse([]byte(key.KeyVal.Private))
+		if err != nil {
+			return Signature{}, err
+		}
+		parsedKey, ok := parsedKey.(*ecdsa.PrivateKey)
+		if !ok {
+			return Signature{}, ErrKeyKeyTypeMismatch
+		}
+		curveSize := parsedKey.(*ecdsa.PrivateKey).Curve.Params().BitSize
+		var hashed []byte
+		if err := matchEcdsaScheme(curveSize, key.Scheme); err != nil {
+			return Signature{}, ErrCurveSizeSchemeMismatch
+		}
+		// implement https://tools.ietf.org/html/rfc5656#section-6.2.1
+		// We determine the curve size and choose the correct hashing
+		// method based on the curveSize
+		switch {
+		case curveSize <= 256:
+			hashed = hashToHex(hashMapping["sha256"](), signable)
+		case 256 < curveSize && curveSize <= 384:
+			hashed = hashToHex(hashMapping["sha384"](), signable)
+		case curveSize > 384:
+			hashed = hashToHex(hashMapping["sha512"](), signable)
+		default:
+			panic("unexpected Error in GenerateSignature function")
+		}
+		// Generate the ecdsa signature on the same way, as we do in the securesystemslib
+		// We are marshalling the ecdsaSignature struct as ASN.1 INTEGER SEQUENCES
+		// into an ASN.1 Object.
+		signatureBuffer, err = ecdsa.SignASN1(rand.Reader, parsedKey.(*ecdsa.PrivateKey), hashed[:])
+	case ed25519KeyType:
+		// We do not need a scheme switch here, because ed25519
+		// only consist of sha256 and curve25519.
+		privateHex, err := hex.DecodeString(key.KeyVal.Private)
+		if err != nil {
+			return signature, ErrInvalidHexString
+		}
+		// Note: We can directly use the key for signing and do not
+		// need to use ed25519.NewKeyFromSeed().
+		signatureBuffer = ed25519.Sign(privateHex, signable)
+	default:
+		// We should never get here, because we call validateKey in the first
+		// line of the function.
+		panic("unexpected Error in GenerateSignature function")
+	}
+	signature.Sig = hex.EncodeToString(signatureBuffer)
+	signature.KeyID = key.KeyID
+	return signature, nil
+}
+
+/*
+VerifySignature will verify unverified byte data via a passed key and signature.
+Supported key types are:
+
+	* rsa
+	* ed25519
+	* ecdsa
+
+When encountering an RSA key, VerifySignature will decode the PEM block in the key
+and will call rsa.VerifyPSS() for verifying the RSA signature.
+When encountering an ed25519 key, VerifySignature will decode the hex string encoded
+public key and will use ed25519.Verify() for verifying the ed25519 signature.
+When the given key is an ecdsa key, VerifySignature will unmarshall the ASN1 object
+and will use the retrieved ecdsa components 'r' and 's' for verifying the signature.
+On success it will return nil. In case of an unsupported key type or any other error
+it will return an error.
+
+Note that in-toto-golang has different requirements to an ecdsa key.
+In in-toto-golang we use the string 'ecdsa' as string for the key type.
+In the key scheme we use: ecdsa-sha2-nistp256.
+*/
+func VerifySignature(key Key, sig Signature, unverified []byte) error {
+	err := validateKey(key)
+	if err != nil {
+		return err
+	}
+	sigBytes, err := hex.DecodeString(sig.Sig)
+	if err != nil {
+		return err
+	}
+	hashMapping := getHashMapping()
+	switch key.KeyType {
+	case rsaKeyType:
+		// We do not need the pemData here, so we can throw it away via '_'
+		_, parsedKey, err := decodeAndParse([]byte(key.KeyVal.Public))
+		if err != nil {
+			return err
+		}
+		parsedKey, ok := parsedKey.(*rsa.PublicKey)
+		if !ok {
+			return ErrKeyKeyTypeMismatch
+		}
+		switch key.Scheme {
+		case rsassapsssha256Scheme:
+			hashed := hashToHex(hashMapping["sha256"](), unverified)
+			err = rsa.VerifyPSS(parsedKey.(*rsa.PublicKey), crypto.SHA256, hashed, sigBytes, &rsa.PSSOptions{SaltLength: sha256.Size, Hash: crypto.SHA256})
+			if err != nil {
+				return fmt.Errorf("%w: %s", ErrInvalidSignature, err)
+			}
+		default:
+			// supported key schemes will get checked in validateKey
+			panic("unexpected Error in VerifySignature function")
+		}
+	case ecdsaKeyType:
+		// We do not need the pemData here, so we can throw it away via '_'
+		_, parsedKey, err := decodeAndParse([]byte(key.KeyVal.Public))
+		if err != nil {
+			return err
+		}
+		parsedKey, ok := parsedKey.(*ecdsa.PublicKey)
+		if !ok {
+			return ErrKeyKeyTypeMismatch
+		}
+		curveSize := parsedKey.(*ecdsa.PublicKey).Curve.Params().BitSize
+		var hashed []byte
+		if err := matchEcdsaScheme(curveSize, key.Scheme); err != nil {
+			return ErrCurveSizeSchemeMismatch
+		}
+		// implement https://tools.ietf.org/html/rfc5656#section-6.2.1
+		// We determine the curve size and choose the correct hashing
+		// method based on the curveSize
+		switch {
+		case curveSize <= 256:
+			hashed = hashToHex(hashMapping["sha256"](), unverified)
+		case 256 < curveSize && curveSize <= 384:
+			hashed = hashToHex(hashMapping["sha384"](), unverified)
+		case curveSize > 384:
+			hashed = hashToHex(hashMapping["sha512"](), unverified)
+		default:
+			panic("unexpected Error in VerifySignature function")
+		}
+		if ok := ecdsa.VerifyASN1(parsedKey.(*ecdsa.PublicKey), hashed, sigBytes); !ok {
+			return ErrInvalidSignature
+		}
+	case ed25519KeyType:
+		// We do not need a scheme switch here, because ed25519
+		// only consist of sha256 and curve25519.
+		pubHex, err := hex.DecodeString(key.KeyVal.Public)
+		if err != nil {
+			return ErrInvalidHexString
+		}
+		if ok := ed25519.Verify(pubHex, unverified, sigBytes); !ok {
+			return fmt.Errorf("%w: ed25519", ErrInvalidSignature)
+		}
+	default:
+		// We should never get here, because we call validateKey in the first
+		// line of the function.
+		panic("unexpected Error in VerifySignature function")
+	}
+	return nil
+}

--- a/vendor/github.com/in-toto/in-toto-golang/in_toto/model.go
+++ b/vendor/github.com/in-toto/in-toto-golang/in_toto/model.go
@@ -1,0 +1,962 @@
+package in_toto
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+/*
+KeyVal contains the actual values of a key, as opposed to key metadata such as
+a key identifier or key type.  For RSA keys, the key value is a pair of public
+and private keys in PEM format stored as strings.  For public keys the Private
+field may be an empty string.
+*/
+type KeyVal struct {
+	Private string `json:"private"`
+	Public  string `json:"public"`
+}
+
+/*
+Key represents a generic in-toto key that contains key metadata, such as an
+identifier, supported hash algorithms to create the identifier, the key type
+and the supported signature scheme, and the actual key value.
+*/
+type Key struct {
+	KeyID               string   `json:"keyid"`
+	KeyIDHashAlgorithms []string `json:"keyid_hash_algorithms"`
+	KeyType             string   `json:"keytype"`
+	KeyVal              KeyVal   `json:"keyval"`
+	Scheme              string   `json:"scheme"`
+}
+
+// ErrEmptyKeyField will be thrown if a field in our Key struct is empty.
+var ErrEmptyKeyField = errors.New("empty field in key")
+
+// ErrInvalidHexString will be thrown, if a string doesn't match a hex string.
+var ErrInvalidHexString = errors.New("invalid hex string")
+
+// ErrSchemeKeyTypeMismatch will be thrown, if the given scheme and key type are not supported together.
+var ErrSchemeKeyTypeMismatch = errors.New("the scheme and key type are not supported together")
+
+// ErrUnsupportedKeyIDHashAlgorithms will be thrown, if the specified KeyIDHashAlgorithms is not supported.
+var ErrUnsupportedKeyIDHashAlgorithms = errors.New("the given keyID hash algorithm is not supported")
+
+// ErrKeyKeyTypeMismatch will be thrown, if the specified keyType does not match the key
+var ErrKeyKeyTypeMismatch = errors.New("the given key does not match its key type")
+
+// ErrNoPublicKey gets returned when the private key value is not empty.
+var ErrNoPublicKey = errors.New("the given key is not a public key")
+
+// ErrCurveSizeSchemeMismatch gets returned, when the scheme and curve size are incompatible
+// for example: curve size = "521" and scheme = "ecdsa-sha2-nistp224"
+var ErrCurveSizeSchemeMismatch = errors.New("the scheme does not match the curve size")
+
+const (
+	// StatementInTotoV01 is the statement type for the generalized link format
+	// containing statements. This is constant for all predicate types.
+	StatementInTotoV01 = "https://in-toto.io/Statement/v0.1"
+	// PredicateSPDX represents a SBOM using the SPDX standard.
+	// The SPDX mandates 'spdxVersion' field, so predicate type can omit
+	// version.
+	PredicateSPDX = "https://spdx.dev/Document"
+	// PredicateLinkV1 represents an in-toto 0.9 link.
+	PredicateLinkV1 = "https://in-toto.io/Link/v1"
+	// PredicateProvenanceV01 represents a build provenance for an artifact.
+	PredicateProvenanceV01 = "https://in-toto.io/Provenance/v0.1"
+)
+
+/*
+matchEcdsaScheme checks if the scheme suffix, matches the ecdsa key
+curve size. We do not need a full regex match here, because
+our validateKey functions are already checking for a valid scheme string.
+*/
+func matchEcdsaScheme(curveSize int, scheme string) error {
+	if !strings.HasSuffix(scheme, strconv.Itoa(curveSize)) {
+		return ErrCurveSizeSchemeMismatch
+	}
+	return nil
+}
+
+/*
+validateHexString is used to validate that a string passed to it contains
+only valid hexadecimal characters.
+*/
+func validateHexString(str string) error {
+	formatCheck, _ := regexp.MatchString("^[a-fA-F0-9]+$", str)
+	if !formatCheck {
+		return fmt.Errorf("%w: %s", ErrInvalidHexString, str)
+	}
+	return nil
+}
+
+/*
+validateKeyVal validates the KeyVal struct. In case of an ed25519 key,
+it will check for a hex string for private and public key. In any other
+case, validateKeyVal will try to decode the PEM block. If this succeeds,
+we have a valid PEM block in our KeyVal struct. On success it will return nil
+on failure it will return the corresponding error. This can be either
+an ErrInvalidHexString, an ErrNoPEMBlock or an ErrUnsupportedKeyType
+if the KeyType is unknown.
+*/
+func validateKeyVal(key Key) error {
+	switch key.KeyType {
+	case ed25519KeyType:
+		// We cannot use matchPublicKeyKeyType or matchPrivateKeyKeyType here,
+		// because we retrieve the key not from PEM. Hence we are dealing with
+		// plain ed25519 key bytes. These bytes can't be typechecked like in the
+		// matchKeyKeytype functions.
+		err := validateHexString(key.KeyVal.Public)
+		if err != nil {
+			return err
+		}
+		if key.KeyVal.Private != "" {
+			err := validateHexString(key.KeyVal.Private)
+			if err != nil {
+				return err
+			}
+		}
+	case rsaKeyType, ecdsaKeyType:
+		// We do not need the pemData here, so we can throw it away via '_'
+		_, parsedKey, err := decodeAndParse([]byte(key.KeyVal.Public))
+		if err != nil {
+			return err
+		}
+		err = matchPublicKeyKeyType(parsedKey, key.KeyType)
+		if err != nil {
+			return err
+		}
+		if key.KeyVal.Private != "" {
+			// We do not need the pemData here, so we can throw it away via '_'
+			_, parsedKey, err := decodeAndParse([]byte(key.KeyVal.Private))
+			if err != nil {
+				return err
+			}
+			err = matchPrivateKeyKeyType(parsedKey, key.KeyType)
+			if err != nil {
+				return err
+			}
+		}
+	default:
+		return ErrUnsupportedKeyType
+	}
+	return nil
+}
+
+/*
+matchPublicKeyKeyType validates an interface if it can be asserted to a
+the RSA or ECDSA public key type. We can only check RSA and ECDSA this way,
+because we are storing them in PEM format. Ed25519 keys are stored as plain
+ed25519 keys encoded as hex strings, thus we have no metadata for them.
+This function will return nil on success. If the key type does not match
+it will return an ErrKeyKeyTypeMismatch.
+*/
+func matchPublicKeyKeyType(key interface{}, keyType string) error {
+	switch key.(type) {
+	case *rsa.PublicKey:
+		if keyType != rsaKeyType {
+			return ErrKeyKeyTypeMismatch
+		}
+	case *ecdsa.PublicKey:
+		if keyType != ecdsaKeyType {
+			return ErrKeyKeyTypeMismatch
+		}
+	default:
+		return ErrInvalidKey
+	}
+	return nil
+}
+
+/*
+matchPrivateKeyKeyType validates an interface if it can be asserted to a
+the RSA or ECDSA private key type. We can only check RSA and ECDSA this way,
+because we are storing them in PEM format. Ed25519 keys are stored as plain
+ed25519 keys encoded as hex strings, thus we have no metadata for them.
+This function will return nil on success. If the key type does not match
+it will return an ErrKeyKeyTypeMismatch.
+*/
+func matchPrivateKeyKeyType(key interface{}, keyType string) error {
+	// we can only check RSA and ECDSA this way, because we are storing them in PEM
+	// format. ed25519 keys are stored as plain ed25519 keys encoded as hex strings
+	// so we have no metadata for them.
+	switch key.(type) {
+	case *rsa.PrivateKey:
+		if keyType != rsaKeyType {
+			return ErrKeyKeyTypeMismatch
+		}
+	case *ecdsa.PrivateKey:
+		if keyType != ecdsaKeyType {
+			return ErrKeyKeyTypeMismatch
+		}
+	default:
+		return ErrInvalidKey
+	}
+	return nil
+}
+
+/*
+matchKeyTypeScheme checks if the specified scheme matches our specified
+keyType. If the keyType is not supported it will return an
+ErrUnsupportedKeyType. If the keyType and scheme do not match it will return
+an ErrSchemeKeyTypeMismatch. If the specified keyType and scheme are
+compatible matchKeyTypeScheme will return nil.
+*/
+func matchKeyTypeScheme(key Key) error {
+	switch key.KeyType {
+	case rsaKeyType:
+		for _, scheme := range getSupportedRSASchemes() {
+			if key.Scheme == scheme {
+				return nil
+			}
+		}
+	case ed25519KeyType:
+		for _, scheme := range getSupportedEd25519Schemes() {
+			if key.Scheme == scheme {
+				return nil
+			}
+		}
+	case ecdsaKeyType:
+		for _, scheme := range getSupportedEcdsaSchemes() {
+			if key.Scheme == scheme {
+				return nil
+			}
+		}
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedKeyType, key.KeyType)
+	}
+	return ErrSchemeKeyTypeMismatch
+}
+
+/*
+validateKey checks the outer key object (everything, except the KeyVal struct).
+It verifies the keyID for being a hex string and checks for empty fields.
+On success it will return nil, on error it will return the corresponding error.
+Either: ErrEmptyKeyField or ErrInvalidHexString.
+*/
+func validateKey(key Key) error {
+	err := validateHexString(key.KeyID)
+	if err != nil {
+		return err
+	}
+	// This probably can be done more elegant with reflection
+	// but we care about performance, do we?!
+	if key.KeyType == "" {
+		return fmt.Errorf("%w: keytype", ErrEmptyKeyField)
+	}
+	if key.KeyVal.Public == "" {
+		return fmt.Errorf("%w: keyval.public", ErrEmptyKeyField)
+	}
+	if key.Scheme == "" {
+		return fmt.Errorf("%w: scheme", ErrEmptyKeyField)
+	}
+	err = matchKeyTypeScheme(key)
+	if err != nil {
+		return err
+	}
+	// only check for supported KeyIDHashAlgorithms, if the variable has been set
+	if key.KeyIDHashAlgorithms != nil {
+		supportedKeyIDHashAlgorithms := getSupportedKeyIDHashAlgorithms()
+		if !supportedKeyIDHashAlgorithms.IsSubSet(NewSet(key.KeyIDHashAlgorithms...)) {
+			return fmt.Errorf("%w: %#v, supported are: %#v", ErrUnsupportedKeyIDHashAlgorithms, key.KeyIDHashAlgorithms, getSupportedKeyIDHashAlgorithms())
+		}
+	}
+	return nil
+}
+
+/*
+validatePublicKey is a wrapper around validateKey. It test if the private key
+value in the key is empty and then validates the key via calling validateKey.
+On success it will return nil, on error it will return an ErrNoPublicKey error.
+*/
+func validatePublicKey(key Key) error {
+	if key.KeyVal.Private != "" {
+		return ErrNoPublicKey
+	}
+	err := validateKey(key)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
+Signature represents a generic in-toto signature that contains the identifier
+of the Key, which was used to create the signature and the signature data.  The
+used signature scheme is found in the corresponding Key.
+*/
+type Signature struct {
+	KeyID string `json:"keyid"`
+	Sig   string `json:"sig"`
+}
+
+/*
+validateSignature is a function used to check if a passed signature is valid,
+by inspecting the key ID and the signature itself.
+*/
+func validateSignature(signature Signature) error {
+	if err := validateHexString(signature.KeyID); err != nil {
+		return err
+	}
+	if err := validateHexString(signature.Sig); err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
+validateSliceOfSignatures is a helper function used to validate multiple
+signatures stored in a slice.
+*/
+func validateSliceOfSignatures(slice []Signature) error {
+	for _, signature := range slice {
+		if err := validateSignature(signature); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+/*
+Link represents the evidence of a supply chain step performed by a functionary.
+It should be contained in a generic Metablock object, which provides
+functionality for signing and signature verification, and reading from and
+writing to disk.
+*/
+type Link struct {
+	Type        string                 `json:"_type"`
+	Name        string                 `json:"name"`
+	Materials   map[string]interface{} `json:"materials"`
+	Products    map[string]interface{} `json:"products"`
+	ByProducts  map[string]interface{} `json:"byproducts"`
+	Command     []string               `json:"command"`
+	Environment map[string]interface{} `json:"environment"`
+}
+
+/*
+validateArtifacts is a general function used to validate products and materials.
+*/
+func validateArtifacts(artifacts map[string]interface{}) error {
+	for artifactName, artifact := range artifacts {
+		artifactValue := reflect.ValueOf(artifact).MapRange()
+		for artifactValue.Next() {
+			value := artifactValue.Value().Interface().(string)
+			hashType := artifactValue.Key().Interface().(string)
+			if err := validateHexString(value); err != nil {
+				return fmt.Errorf("in artifact '%s', %s hash value: %s",
+					artifactName, hashType, err.Error())
+			}
+		}
+	}
+	return nil
+}
+
+/*
+validateLink is a function used to ensure that a passed item of type Link
+matches the necessary format.
+*/
+func validateLink(link Link) error {
+	if link.Type != "link" {
+		return fmt.Errorf("invalid type for link '%s': should be 'link'",
+			link.Name)
+	}
+
+	if err := validateArtifacts(link.Materials); err != nil {
+		return fmt.Errorf("in materials of link '%s': %s", link.Name,
+			err.Error())
+	}
+
+	if err := validateArtifacts(link.Products); err != nil {
+		return fmt.Errorf("in products of link '%s': %s", link.Name,
+			err.Error())
+	}
+
+	return nil
+}
+
+/*
+LinkNameFormat represents a format string used to create the filename for a
+signed Link (wrapped in a Metablock). It consists of the name of the link and
+the first 8 characters of the signing key id. E.g.:
+	fmt.Sprintf(LinkNameFormat, "package",
+	"2f89b9272acfc8f4a0a0f094d789fdb0ba798b0fe41f2f5f417c12f0085ff498")
+	// returns "package.2f89b9272.link"
+*/
+const LinkNameFormat = "%s.%.8s.link"
+
+/*
+LinkNameFormatShort is for links that are not signed, e.g.:
+	fmt.Sprintf(LinkNameFormatShort, "unsigned")
+	// returns "unsigned.link"
+*/
+const LinkNameFormatShort = "%s.link"
+
+/*
+SublayoutLinkDirFormat represents the format of the name of the directory for
+sublayout links during the verification workflow.
+*/
+const SublayoutLinkDirFormat = "%s.%.8s"
+
+/*
+SupplyChainItem summarizes common fields of the two available supply chain
+item types, Inspection and Step.
+*/
+type SupplyChainItem struct {
+	Name              string     `json:"name"`
+	ExpectedMaterials [][]string `json:"expected_materials"`
+	ExpectedProducts  [][]string `json:"expected_products"`
+}
+
+/*
+validateArtifactRule calls UnpackRule to validate that the passed rule conforms
+with any of the available rule formats.
+*/
+func validateArtifactRule(rule []string) error {
+	if _, err := UnpackRule(rule); err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
+validateSliceOfArtifactRules iterates over passed rules to validate them.
+*/
+func validateSliceOfArtifactRules(rules [][]string) error {
+	for _, rule := range rules {
+		if err := validateArtifactRule(rule); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+/*
+validateSupplyChainItem is used to validate the common elements found in both
+steps and inspections. Here, the function primarily ensures that the name of
+a supply chain item isn't empty.
+*/
+func validateSupplyChainItem(item SupplyChainItem) error {
+	if item.Name == "" {
+		return fmt.Errorf("name cannot be empty")
+	}
+
+	if err := validateSliceOfArtifactRules(item.ExpectedMaterials); err != nil {
+		return fmt.Errorf("invalid material rule: %s", err)
+	}
+	if err := validateSliceOfArtifactRules(item.ExpectedProducts); err != nil {
+		return fmt.Errorf("invalid product rule: %s", err)
+	}
+	return nil
+}
+
+/*
+Inspection represents an in-toto supply chain inspection, whose command in the
+Run field is executed during final product verification, generating unsigned
+link metadata.  Materials and products used/produced by the inspection are
+constrained by the artifact rules in the inspection's ExpectedMaterials and
+ExpectedProducts fields.
+*/
+type Inspection struct {
+	Type string   `json:"_type"`
+	Run  []string `json:"run"`
+	SupplyChainItem
+}
+
+/*
+validateInspection ensures that a passed inspection is valid and matches the
+necessary format of an inspection.
+*/
+func validateInspection(inspection Inspection) error {
+	if err := validateSupplyChainItem(inspection.SupplyChainItem); err != nil {
+		return fmt.Errorf("inspection %s", err.Error())
+	}
+	if inspection.Type != "inspection" {
+		return fmt.Errorf("invalid Type value for inspection '%s': should be "+
+			"'inspection'", inspection.SupplyChainItem.Name)
+	}
+	return nil
+}
+
+/*
+Step represents an in-toto step of the supply chain performed by a functionary.
+During final product verification in-toto looks for corresponding Link
+metadata, which is used as signed evidence that the step was performed
+according to the supply chain definition.  Materials and products used/produced
+by the step are constrained by the artifact rules in the step's
+ExpectedMaterials and ExpectedProducts fields.
+*/
+type Step struct {
+	Type            string   `json:"_type"`
+	PubKeys         []string `json:"pubkeys"`
+	ExpectedCommand []string `json:"expected_command"`
+	Threshold       int      `json:"threshold"`
+	SupplyChainItem
+}
+
+/*
+validateStep ensures that a passed step is valid and matches the
+necessary format of an step.
+*/
+func validateStep(step Step) error {
+	if err := validateSupplyChainItem(step.SupplyChainItem); err != nil {
+		return fmt.Errorf("step %s", err.Error())
+	}
+	if step.Type != "step" {
+		return fmt.Errorf("invalid Type value for step '%s': should be 'step'",
+			step.SupplyChainItem.Name)
+	}
+	for _, keyID := range step.PubKeys {
+		if err := validateHexString(keyID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+/*
+ISO8601DateSchema defines the format string of a timestamp following the
+ISO 8601 standard.
+*/
+const ISO8601DateSchema = "2006-01-02T15:04:05Z"
+
+/*
+Layout represents the definition of a software supply chain.  It lists the
+sequence of steps required in the software supply chain and the functionaries
+authorized to perform these steps.  Functionaries are identified by their
+public keys.  In addition, the layout may list a sequence of inspections that
+are executed during in-toto supply chain verification.  A layout should be
+contained in a generic Metablock object, which provides functionality for
+signing and signature verification, and reading from and writing to disk.
+*/
+type Layout struct {
+	Type    string         `json:"_type"`
+	Steps   []Step         `json:"steps"`
+	Inspect []Inspection   `json:"inspect"`
+	Keys    map[string]Key `json:"keys"`
+	Expires string         `json:"expires"`
+	Readme  string         `json:"readme"`
+}
+
+// Go does not allow to pass `[]T` (slice with certain type) to a function
+// that accepts `[]interface{}` (slice with generic type)
+// We have to manually create the interface slice first, see
+// https://golang.org/doc/faq#convert_slice_of_interface
+// TODO: Is there a better way to do polymorphism for steps and inspections?
+func (l *Layout) stepsAsInterfaceSlice() []interface{} {
+	stepsI := make([]interface{}, len(l.Steps))
+	for i, v := range l.Steps {
+		stepsI[i] = v
+	}
+	return stepsI
+}
+func (l *Layout) inspectAsInterfaceSlice() []interface{} {
+	inspectionsI := make([]interface{}, len(l.Inspect))
+	for i, v := range l.Inspect {
+		inspectionsI[i] = v
+	}
+	return inspectionsI
+}
+
+/*
+validateLayout is a function used to ensure that a passed item of type Layout
+matches the necessary format.
+*/
+func validateLayout(layout Layout) error {
+	if layout.Type != "layout" {
+		return fmt.Errorf("invalid Type value for layout: should be 'layout'")
+	}
+
+	if _, err := time.Parse(ISO8601DateSchema, layout.Expires); err != nil {
+		return fmt.Errorf("expiry time parsed incorrectly - date either" +
+			" invalid or of incorrect format")
+	}
+
+	for keyID, key := range layout.Keys {
+		if key.KeyID != keyID {
+			return fmt.Errorf("invalid key found")
+		}
+		err := validatePublicKey(key)
+		if err != nil {
+			return err
+		}
+	}
+
+	var namesSeen = make(map[string]bool)
+	for _, step := range layout.Steps {
+		if namesSeen[step.Name] {
+			return fmt.Errorf("non unique step or inspection name found")
+		}
+
+		namesSeen[step.Name] = true
+
+		if err := validateStep(step); err != nil {
+			return err
+		}
+	}
+	for _, inspection := range layout.Inspect {
+		if namesSeen[inspection.Name] {
+			return fmt.Errorf("non unique step or inspection name found")
+		}
+
+		namesSeen[inspection.Name] = true
+	}
+	return nil
+}
+
+/*
+Metablock is a generic container for signable in-toto objects such as Layout
+or Link.  It has two fields, one that contains the signable object and one that
+contains corresponding signatures.  Metablock also provides functionality for
+signing and signature verification, and reading from and writing to disk.
+*/
+type Metablock struct {
+	// NOTE: Whenever we want to access an attribute of `Signed` we have to
+	// perform type assertion, e.g. `metablock.Signed.(Layout).Keys`
+	// Maybe there is a better way to store either Layouts or Links in `Signed`?
+	// The notary folks seem to have separate container structs:
+	// https://github.com/theupdateframework/notary/blob/master/tuf/data/root.go#L10-L14
+	// https://github.com/theupdateframework/notary/blob/master/tuf/data/targets.go#L13-L17
+	// I implemented it this way, because there will be several functions that
+	// receive or return a Metablock, where the type of Signed has to be inferred
+	// on runtime, e.g. when iterating over links for a layout, and a link can
+	// turn out to be a layout (sublayout)
+	Signed     interface{} `json:"signed"`
+	Signatures []Signature `json:"signatures"`
+}
+
+/*
+checkRequiredJSONFields checks that the passed map (obj) has keys for each of
+the json tags in the passed struct type (typ), and returns an error otherwise.
+*/
+func checkRequiredJSONFields(obj map[string]interface{},
+	typ reflect.Type) error {
+
+	// Create list of json tags, e.g. `json:"_type"`
+	attributeCount := typ.NumField()
+	allFields := make([]string, 0)
+	for i := 0; i < attributeCount; i++ {
+		allFields = append(allFields, typ.Field(i).Tag.Get("json"))
+	}
+
+	// Assert that there's a key in the passed map for each tag
+	for _, field := range allFields {
+		if _, ok := obj[field]; !ok {
+			return fmt.Errorf("required field %s missing", field)
+		}
+	}
+	return nil
+}
+
+/*
+Load parses JSON formatted metadata at the passed path into the Metablock
+object on which it was called.  It returns an error if it cannot parse
+a valid JSON formatted Metablock that contains a Link or Layout.
+*/
+func (mb *Metablock) Load(path string) (err error) {
+	// Open file and close before returning
+	jsonFile, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := jsonFile.Close(); closeErr != nil {
+			err = closeErr
+		}
+	}()
+
+	// Read entire file
+	jsonBytes, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal JSON into a map of raw messages (signed and signatures)
+	// We can't fully unmarshal immediately, because we need to inspect the
+	// type (link or layout) to decide which data structure to use
+	var rawMb map[string]*json.RawMessage
+	if err := json.Unmarshal(jsonBytes, &rawMb); err != nil {
+		return err
+	}
+
+	// Error out on missing `signed` or `signatures` field or if
+	// one of them has a `null` value, which would lead to a nil pointer
+	// dereference in Unmarshal below.
+	if rawMb["signed"] == nil || rawMb["signatures"] == nil {
+		return fmt.Errorf("In-toto metadata requires 'signed' and" +
+			" 'signatures' parts")
+	}
+
+	// Fully unmarshal signatures part
+	if err := json.Unmarshal(*rawMb["signatures"], &mb.Signatures); err != nil {
+		return err
+	}
+
+	// Temporarily copy signed to opaque map to inspect the `_type` of signed
+	// and create link or layout accordingly
+	var signed map[string]interface{}
+	if err := json.Unmarshal(*rawMb["signed"], &signed); err != nil {
+		return err
+	}
+
+	if signed["_type"] == "link" {
+		var link Link
+		if err := checkRequiredJSONFields(signed, reflect.TypeOf(link)); err != nil {
+			return err
+		}
+
+		data, err := rawMb["signed"].MarshalJSON()
+		if err != nil {
+			return err
+		}
+		decoder := json.NewDecoder(strings.NewReader(string(data)))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&link); err != nil {
+			return err
+		}
+		mb.Signed = link
+
+	} else if signed["_type"] == "layout" {
+		var layout Layout
+		if err := checkRequiredJSONFields(signed, reflect.TypeOf(layout)); err != nil {
+			return err
+		}
+
+		data, err := rawMb["signed"].MarshalJSON()
+		if err != nil {
+			return err
+		}
+		decoder := json.NewDecoder(strings.NewReader(string(data)))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&layout); err != nil {
+			return err
+		}
+
+		mb.Signed = layout
+
+	} else {
+		return fmt.Errorf("The '_type' field of the 'signed' part of in-toto" +
+			" metadata must be one of 'link' or 'layout'")
+	}
+
+	return nil
+}
+
+/*
+Dump JSON serializes and writes the Metablock on which it was called to the
+passed path.  It returns an error if JSON serialization or writing fails.
+*/
+func (mb *Metablock) Dump(path string) error {
+	// JSON encode Metablock formatted with newlines and indentation
+	// TODO: parametrize format
+	jsonBytes, err := json.MarshalIndent(mb, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// Write JSON bytes to the passed path with permissions (-rw-r--r--)
+	err = ioutil.WriteFile(path, jsonBytes, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+/*
+GetSignableRepresentation returns the canonical JSON representation of the
+Signed field of the Metablock on which it was called.  If canonicalization
+fails the first return value is nil and the second return value is the error.
+*/
+func (mb *Metablock) GetSignableRepresentation() ([]byte, error) {
+	return EncodeCanonical(mb.Signed)
+}
+
+/*
+VerifySignature verifies the first signature, corresponding to the passed Key,
+that it finds in the Signatures field of the Metablock on which it was called.
+It returns an error if Signatures does not contain a Signature corresponding to
+the passed Key, the object in Signed cannot be canonicalized, or the Signature
+is invalid.
+*/
+func (mb *Metablock) VerifySignature(key Key) error {
+	var sig Signature
+	for _, s := range mb.Signatures {
+		if s.KeyID == key.KeyID {
+			sig = s
+			break
+		}
+	}
+
+	if sig == (Signature{}) {
+		return fmt.Errorf("No signature found for key '%s'", key.KeyID)
+	}
+
+	dataCanonical, err := mb.GetSignableRepresentation()
+	if err != nil {
+		return err
+	}
+
+	if err := VerifySignature(key, sig, dataCanonical); err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
+ValidateMetablock ensures that a passed Metablock object is valid. It indirectly
+validates the Link or Layout that the Metablock object contains.
+*/
+func ValidateMetablock(mb Metablock) error {
+	switch mbSignedType := mb.Signed.(type) {
+	case Layout:
+		if err := validateLayout(mb.Signed.(Layout)); err != nil {
+			return err
+		}
+	case Link:
+		if err := validateLink(mb.Signed.(Link)); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown type '%s', should be 'layout' or 'link'",
+			mbSignedType)
+	}
+
+	if err := validateSliceOfSignatures(mb.Signatures); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+/*
+Sign creates a signature over the signed portion of the metablock using the Key
+object provided. It then appends the resulting signature to the signatures
+field as provided. It returns an error if the Signed object cannot be
+canonicalized, or if the key is invalid or not supported.
+*/
+func (mb *Metablock) Sign(key Key) error {
+
+	dataCanonical, err := mb.GetSignableRepresentation()
+	if err != nil {
+		return err
+	}
+
+	newSignature, err := GenerateSignature(dataCanonical, key)
+	if err != nil {
+		return err
+	}
+
+	mb.Signatures = append(mb.Signatures, newSignature)
+	return nil
+}
+
+/*
+DigestSet contains a set of digests. It is represented as a map from
+algorithm name to lowercase hex-encoded value.
+*/
+type DigestSet map[string]string
+
+// Subject describes the set of software artifacts the statement applies to.
+type Subject struct {
+	Name   string    `json:"name"`
+	Digest DigestSet `json:"digest"`
+}
+
+// StatementHeader defines the common fields for all statements
+type StatementHeader struct {
+	Type          string    `json:"_type"`
+	PredicateType string    `json:"predicateType"`
+	Subject       []Subject `json:"subject"`
+}
+
+/*
+Statement binds the attestation to a particular subject and identifies the
+of the predicate. This struct represents a generic statement.
+*/
+type Statement struct {
+	StatementHeader
+	// Predicate contains type speficic metadata.
+	Predicate interface{} `json:"predicate"`
+}
+
+// ProvenanceBuilder idenfifies the entity that executed the build steps.
+type ProvenanceBuilder struct {
+	ID string `json:"id"`
+}
+
+// ProvenanceRecipe describes the actions performed by the builder.
+type ProvenanceRecipe struct {
+	Type string `json:"type"`
+	// DefinedInMaterial can be sent as the null pointer to indicate that
+	// the value is not present.
+	DefinedInMaterial *int        `json:"definedInMaterial,omitempty"`
+	EntryPoint        string      `json:"entryPoint"`
+	Arguments         interface{} `json:"arguments,omitempty"`
+	Environment       interface{} `json:"environment,omitempty"`
+}
+
+// ProvenanceComplete indicates wheter the claims in build/recipe are complete.
+// For in depth information refer to the specifictaion:
+// https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/provenance.md
+type ProvenanceComplete struct {
+	Arguments   bool `json:"arguments"`
+	Environment bool `json:"environment"`
+	Materials   bool `json:"materials"`
+}
+
+// ProvenanceMetadata contains metadata for the built artifact.
+type ProvenanceMetadata struct {
+	// Use pointer to make sure that the abscense of a time is not
+	// encoded as the Epoch time.
+	BuildStartedOn  *time.Time         `json:"buildStartedOn,omitempty"`
+	BuildFinishedOn *time.Time         `json:"buildFinishedOn,omitempty"`
+	Completeness    ProvenanceComplete `json:"completeness"`
+	Reproducible    bool               `json:"reproducible"`
+}
+
+// ProvenanceMaterial defines the materials used to build an artifact.
+type ProvenanceMaterial struct {
+	URI    string    `json:"uri"`
+	Digest DigestSet `json:"digest,omitempty"`
+}
+
+// ProvenancePredicate is the provenance predicate definition.
+type ProvenancePredicate struct {
+	Builder   ProvenanceBuilder    `json:"builder"`
+	Recipe    ProvenanceRecipe     `json:"recipe"`
+	Metadata  ProvenanceMetadata   `json:"metadata"`
+	Materials []ProvenanceMaterial `json:"materials,omitempty"`
+}
+
+// ProvenanceStatement is the definition for an entire provenance statement.
+type ProvenanceStatement struct {
+	StatementHeader
+	Predicate ProvenancePredicate `json:"predicate"`
+}
+
+// LinkStatement is the definition for an entire link statement.
+type LinkStatement struct {
+	StatementHeader
+	Predicate Link `json:"predicate"`
+}
+
+/*
+SPDXStatement is the definition for an entire SPDX statement.
+Currently not implemented. Some tooling exists here:
+https://github.com/spdx/tools-golang, but this software is still in
+early state.
+This struct is the same as the generic Statement struct but is added for
+completeness
+*/
+type SPDXStatement struct {
+	StatementHeader
+	Predicate interface{} `json:"predicate"`
+}

--- a/vendor/github.com/in-toto/in-toto-golang/in_toto/rulelib.go
+++ b/vendor/github.com/in-toto/in-toto-golang/in_toto/rulelib.go
@@ -1,0 +1,131 @@
+package in_toto
+
+import (
+	"fmt"
+	"strings"
+)
+
+// An error message issued in UnpackRule if it receives a malformed rule.
+var errorMsg = "Wrong rule format, available formats are:\n" +
+	"\tMATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS)" +
+	" [IN <destination-path-prefix>] FROM <step>,\n" +
+	"\tCREATE <pattern>,\n" +
+	"\tDELETE <pattern>,\n" +
+	"\tMODIFY <pattern>,\n" +
+	"\tALLOW <pattern>,\n" +
+	"\tDISALLOW <pattern>,\n" +
+	"\tREQUIRE <filename>\n\n"
+
+/*
+UnpackRule parses the passed rule and extracts and returns the information
+required for rule processing.  It can be used to verify if a rule has a valid
+format.  Available rule formats are:
+
+	MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS)
+		[IN <destination-path-prefix>] FROM <step>,
+	CREATE <pattern>,
+	DELETE <pattern>,
+	MODIFY <pattern>,
+	ALLOW <pattern>,
+	DISALLOW <pattern>
+
+Rule tokens are normalized to lower case before returning.  The returned map
+has the following format:
+
+	{
+		"type": "match" | "create" | "delete" |"modify" | "allow" | "disallow"
+		"pattern": "<file name pattern>",
+		"srcPrefix": "<path or empty string>", // MATCH rule only
+		"dstPrefix": "<path or empty string>", // MATCH rule only
+		"dstType": "materials" | "products">, // MATCH rule only
+		"dstName": "<step name>", // Match rule only
+	}
+
+If the rule does not match any of the available formats the first return value
+is nil and the second return value is the error.
+*/
+func UnpackRule(rule []string) (map[string]string, error) {
+	// Cache rule len
+	ruleLen := len(rule)
+
+	// Create all lower rule copy to case-insensitively parse out tokens whose
+	// position we don't know yet. We keep the original rule to retain the
+	// non-token elements' case.
+	ruleLower := make([]string, ruleLen)
+	for i, val := range rule {
+		ruleLower[i] = strings.ToLower(val)
+	}
+
+	switch ruleLower[0] {
+	case "create", "modify", "delete", "allow", "disallow", "require":
+		if ruleLen != 2 {
+			return nil,
+				fmt.Errorf("%s Got:\n\t %s", errorMsg, rule)
+		}
+
+		return map[string]string{
+			"type":    ruleLower[0],
+			"pattern": rule[1],
+		}, nil
+
+	case "match":
+		var srcPrefix string
+		var dstType string
+		var dstPrefix string
+		var dstName string
+
+		// MATCH <pattern> IN <source-path-prefix> WITH (MATERIALS|PRODUCTS) \
+		// IN <destination-path-prefix> FROM <step>
+		if ruleLen == 10 && ruleLower[2] == "in" &&
+			ruleLower[4] == "with" && ruleLower[6] == "in" &&
+			ruleLower[8] == "from" {
+			srcPrefix = rule[3]
+			dstType = ruleLower[5]
+			dstPrefix = rule[7]
+			dstName = rule[9]
+			// MATCH <pattern> IN <source-path-prefix> WITH (MATERIALS|PRODUCTS) \
+			// FROM <step>
+		} else if ruleLen == 8 && ruleLower[2] == "in" &&
+			ruleLower[4] == "with" && ruleLower[6] == "from" {
+			srcPrefix = rule[3]
+			dstType = ruleLower[5]
+			dstPrefix = ""
+			dstName = rule[7]
+
+			// MATCH <pattern> WITH (MATERIALS|PRODUCTS) IN <destination-path-prefix>
+			// FROM <step>
+		} else if ruleLen == 8 && ruleLower[2] == "with" &&
+			ruleLower[4] == "in" && ruleLower[6] == "from" {
+			srcPrefix = ""
+			dstType = ruleLower[3]
+			dstPrefix = rule[5]
+			dstName = rule[7]
+
+			// MATCH <pattern> WITH (MATERIALS|PRODUCTS) FROM <step>
+		} else if ruleLen == 6 && ruleLower[2] == "with" &&
+			ruleLower[4] == "from" {
+			srcPrefix = ""
+			dstType = ruleLower[3]
+			dstPrefix = ""
+			dstName = rule[5]
+
+		} else {
+			return nil,
+				fmt.Errorf("%s Got:\n\t %s", errorMsg, rule)
+
+		}
+
+		return map[string]string{
+			"type":      ruleLower[0],
+			"pattern":   rule[1],
+			"srcPrefix": srcPrefix,
+			"dstPrefix": dstPrefix,
+			"dstType":   dstType,
+			"dstName":   dstName,
+		}, nil
+
+	default:
+		return nil,
+			fmt.Errorf("%s Got:\n\t %s", errorMsg, rule)
+	}
+}

--- a/vendor/github.com/in-toto/in-toto-golang/in_toto/runlib.go
+++ b/vendor/github.com/in-toto/in-toto-golang/in_toto/runlib.go
@@ -1,0 +1,305 @@
+package in_toto
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/shibumi/go-pathspec"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"syscall"
+)
+
+// ErrSymCycle signals a detected symlink cycle in our RecordArtifacts() function.
+var ErrSymCycle = errors.New("symlink cycle detected")
+
+// ErrUnsupportedHashAlgorithm signals a missing hash mapping in getHashMapping
+var ErrUnsupportedHashAlgorithm = errors.New("unsupported hash algorithm detected")
+
+// visitedSymlinks is a hashset that contains all paths that we have visited.
+var visitedSymlinks Set
+
+/*
+RecordArtifact reads and hashes the contents of the file at the passed path
+using sha256 and returns a map in the following format:
+
+	{
+		"<path>": {
+			"sha256": <hex representation of hash>
+		}
+	}
+
+If reading the file fails, the first return value is nil and the second return
+value is the error.
+NOTE: For cross-platform consistency Windows-style line separators (CRLF) are
+normalized to Unix-style line separators (LF) before hashing file contents.
+*/
+func RecordArtifact(path string, hashAlgorithms []string) (map[string]interface{}, error) {
+	supportedHashMappings := getHashMapping()
+	// Read file from passed path
+	contents, err := ioutil.ReadFile(path)
+	hashedContentsMap := make(map[string]interface{})
+	if err != nil {
+		return nil, err
+	}
+	// "Normalize" file contents. We convert all line separators to '\n'
+	// for keeping operating system independence
+	contents = bytes.ReplaceAll(contents, []byte("\r\n"), []byte("\n"))
+
+	// Create a map of all the hashes present in the hash_func list
+	for _, element := range hashAlgorithms {
+		if _, ok := supportedHashMappings[element]; !ok {
+			return nil, fmt.Errorf("%w: %s", ErrUnsupportedHashAlgorithm, element)
+		}
+		h := supportedHashMappings[element]
+		result := fmt.Sprintf("%x", hashToHex(h(), contents))
+		hashedContentsMap[element] = result
+	}
+
+	// Return it in a format that is conformant with link metadata artifacts
+	return hashedContentsMap, nil
+}
+
+/*
+RecordArtifacts is a wrapper around recordArtifacts.
+RecordArtifacts initializes a set for storing visited symlinks,
+calls recordArtifacts and deletes the set if no longer needed.
+recordArtifacts walks through the passed slice of paths, traversing
+subdirectories, and calls RecordArtifact for each file. It returns a map in
+the following format:
+
+	{
+		"<path>": {
+			"sha256": <hex representation of hash>
+		},
+		"<path>": {
+		"sha256": <hex representation of hash>
+		},
+		...
+	}
+
+If recording an artifact fails the first return value is nil and the second
+return value is the error.
+*/
+func RecordArtifacts(paths []string, hashAlgorithms []string, gitignorePatterns []string) (evalArtifacts map[string]interface{}, err error) {
+	// Make sure to initialize a fresh hashset for every RecordArtifacts call
+	visitedSymlinks = NewSet()
+	evalArtifacts, err = recordArtifacts(paths, hashAlgorithms, gitignorePatterns)
+	// pass result and error through
+	return evalArtifacts, err
+}
+
+/*
+recordArtifacts walks through the passed slice of paths, traversing
+subdirectories, and calls RecordArtifact for each file. It returns a map in
+the following format:
+
+	{
+		"<path>": {
+			"sha256": <hex representation of hash>
+		},
+		"<path>": {
+		"sha256": <hex representation of hash>
+		},
+		...
+	}
+
+If recording an artifact fails the first return value is nil and the second
+return value is the error.
+*/
+func recordArtifacts(paths []string, hashAlgorithms []string, gitignorePatterns []string) (map[string]interface{}, error) {
+	artifacts := make(map[string]interface{})
+	for _, path := range paths {
+		err := filepath.Walk(path,
+			func(path string, info os.FileInfo, err error) error {
+				// Abort if Walk function has a problem,
+				// e.g. path does not exist
+				if err != nil {
+					return err
+				}
+				// We need to call pathspec.GitIgnore inside of our filepath.Walk, because otherwise
+				// we will not catch all paths. Just imagine a path like "." and a pattern like "*.pub".
+				// If we would call pathspec outside of the filepath.Walk this would not match.
+				ignore, err := pathspec.GitIgnore(gitignorePatterns, path)
+				if err != nil {
+					return err
+				}
+				if ignore {
+					return nil
+				}
+				// Don't hash directories
+				if info.IsDir() {
+					return nil
+				}
+
+				// check for symlink and evaluate the last element in a symlink
+				// chain via filepath.EvalSymlinks. We use EvalSymlinks here,
+				// because with os.Readlink() we would just read the next
+				// element in a possible symlink chain. This would mean more
+				// iterations. infoMode()&os.ModeSymlink uses the file
+				// type bitmask to check for a symlink.
+				if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+					// return with error if we detect a symlink cycle
+					if ok := visitedSymlinks.Has(path); ok {
+						// this error will get passed through
+						// to RecordArtifacts()
+						return ErrSymCycle
+					}
+					evalSym, err := filepath.EvalSymlinks(path)
+					if err != nil {
+						return err
+					}
+					// add symlink to visitedSymlinks set
+					// this way, we know which link we have visited already
+					// if we visit a symlink twice, we have detected a symlink cycle
+					visitedSymlinks.Add(path)
+					// We recursively call RecordArtifacts() to follow
+					// the new path.
+					evalArtifacts, evalErr := recordArtifacts([]string{evalSym}, hashAlgorithms, gitignorePatterns)
+					if evalErr != nil {
+						return evalErr
+					}
+					for key, value := range evalArtifacts {
+						artifacts[key] = value
+					}
+					return nil
+				}
+				artifact, err := RecordArtifact(path, hashAlgorithms)
+				// Abort if artifact can't be recorded, e.g.
+				// due to file permissions
+				if err != nil {
+					return err
+				}
+				artifacts[path] = artifact
+				return nil
+			})
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return artifacts, nil
+}
+
+/*
+waitErrToExitCode converts an error returned by Cmd.wait() to an exit code.  It
+returns -1 if no exit code can be inferred.
+*/
+func waitErrToExitCode(err error) int {
+	// If there's no exit code, we return -1
+	retVal := -1
+
+	// See https://stackoverflow.com/questions/10385551/get-exit-code-go
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			// The program has exited with an exit code != 0
+			// This works on both Unix and Windows. Although package
+			// syscall is generally platform dependent, WaitStatus is
+			// defined for both Unix and Windows and in both cases has
+			// an ExitStatus() method with the same signature.
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				retVal = status.ExitStatus()
+			}
+		}
+	} else {
+		retVal = 0
+	}
+
+	return retVal
+}
+
+/*
+RunCommand executes the passed command in a subprocess.  The first element of
+cmdArgs is used as executable and the rest as command arguments.  It captures
+and returns stdout, stderr and exit code.  The format of the returned map is:
+
+	{
+		"return-value": <exit code>,
+		"stdout": "<standard output>",
+		"stderr": "<standard error>"
+	}
+
+If the command cannot be executed or no pipes for stdout or stderr can be
+created the first return value is nil and the second return value is the error.
+NOTE: Since stdout and stderr are captured, they cannot be seen during the
+command execution.
+*/
+func RunCommand(cmdArgs []string) (map[string]interface{}, error) {
+
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	// TODO: duplicate stdout, stderr
+	stdout, _ := ioutil.ReadAll(stdoutPipe)
+	stderr, _ := ioutil.ReadAll(stderrPipe)
+
+	retVal := waitErrToExitCode(cmd.Wait())
+
+	return map[string]interface{}{
+		"return-value": float64(retVal),
+		"stdout":       string(stdout),
+		"stderr":       string(stderr),
+	}, nil
+}
+
+/*
+InTotoRun executes commands, e.g. for software supply chain steps or
+inspections of an in-toto layout, and creates and returns corresponding link
+metadata.  Link metadata contains recorded products at the passed productPaths
+and materials at the passed materialPaths.  The returned link is wrapped in a
+Metablock object.  If command execution or artifact recording fails the first
+return value is an empty Metablock and the second return value is the error.
+*/
+func InTotoRun(name string, materialPaths []string, productPaths []string,
+	cmdArgs []string, key Key, hashAlgorithms []string, gitignorePatterns []string) (Metablock, error) {
+	var linkMb Metablock
+	materials, err := RecordArtifacts(materialPaths, hashAlgorithms, gitignorePatterns)
+	if err != nil {
+		return linkMb, err
+	}
+
+	byProducts, err := RunCommand(cmdArgs)
+	if err != nil {
+		return linkMb, err
+	}
+
+	products, err := RecordArtifacts(productPaths, hashAlgorithms, gitignorePatterns)
+	if err != nil {
+		return linkMb, err
+	}
+
+	linkMb.Signed = Link{
+		Type:        "link",
+		Name:        name,
+		Materials:   materials,
+		Products:    products,
+		ByProducts:  byProducts,
+		Command:     cmdArgs,
+		Environment: map[string]interface{}{},
+	}
+	linkMb.Signatures = []Signature{}
+	// We use a new feature from Go1.13 here, to check the key struct.
+	// IsZero() will return True, if the key hasn't been initialized
+	// with other values than the default ones.
+	if !reflect.ValueOf(key).IsZero() {
+		if err := linkMb.Sign(key); err != nil {
+			return linkMb, err
+		}
+	}
+	return linkMb, nil
+}

--- a/vendor/github.com/in-toto/in-toto-golang/in_toto/util.go
+++ b/vendor/github.com/in-toto/in-toto-golang/in_toto/util.go
@@ -1,0 +1,149 @@
+package in_toto
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+/*
+Set represents a data structure for set operations. See `NewSet` for how to
+create a Set, and available Set receivers for useful set operations.
+
+Under the hood Set aliases map[string]struct{}, where the map keys are the set
+elements and the map values are a memory-efficient way of storing the keys.
+*/
+type Set map[string]struct{}
+
+/*
+NewSet creates a new Set, assigns it the optionally passed variadic string
+elements, and returns it.
+*/
+func NewSet(elems ...string) Set {
+	var s Set
+	s = make(map[string]struct{})
+	for _, elem := range elems {
+		s.Add(elem)
+	}
+	return s
+}
+
+/*
+Has returns True if the passed string is member of the set on which it was
+called and False otherwise.
+*/
+func (s Set) Has(elem string) bool {
+	_, ok := s[elem]
+	return ok
+}
+
+/*
+Add adds the passed string to the set on which it was called, if the string is
+not a member of the set.
+*/
+func (s Set) Add(elem string) {
+	s[elem] = struct{}{}
+}
+
+/*
+Remove removes the passed string from the set on which was is called, if the
+string is a member of the set.
+*/
+func (s Set) Remove(elem string) {
+	delete(s, elem)
+}
+
+/*
+Intersection creates and returns a new Set with the elements of the set on
+which it was called that are also in the passed set.
+*/
+func (s Set) Intersection(s2 Set) Set {
+	res := NewSet()
+	for elem := range s {
+		if s2.Has(elem) == false {
+			continue
+		}
+		res.Add(elem)
+	}
+	return res
+}
+
+/*
+Difference creates and returns a new Set with the elements of the set on
+which it was called that are not in the passed set.
+*/
+func (s Set) Difference(s2 Set) Set {
+	res := NewSet()
+	for elem := range s {
+		if s2.Has(elem) {
+			continue
+		}
+		res.Add(elem)
+	}
+	return res
+}
+
+/*
+Filter creates and returns a new Set with the elements of the set on which it
+was called that match the passed pattern. A matching error is treated like a
+non-match plus a warning is printed.
+*/
+func (s Set) Filter(pattern string) Set {
+	res := NewSet()
+	for elem := range s {
+		matched, err := filepath.Match(pattern, elem)
+		if err != nil {
+			fmt.Printf("WARNING: %s, pattern was '%s'\n", err, pattern)
+			continue
+		}
+		if !matched {
+			continue
+		}
+		res.Add(elem)
+	}
+	return res
+}
+
+/*
+Slice creates and returns an unordered string slice with the elements of the
+set on which it was called.
+*/
+func (s Set) Slice() []string {
+	var res []string
+	res = make([]string, 0, len(s))
+	for elem := range s {
+		res = append(res, elem)
+	}
+	return res
+}
+
+/*
+InterfaceKeyStrings returns string keys of passed interface{} map in an
+unordered string slice.
+*/
+func InterfaceKeyStrings(m map[string]interface{}) []string {
+	res := make([]string, len(m))
+	i := 0
+	for k := range m {
+		res[i] = k
+		i++
+	}
+	return res
+}
+
+/*
+IsSubSet checks if the parameter subset is a
+subset of the superset s.
+*/
+func (s Set) IsSubSet(subset Set) bool {
+	if len(subset) > len(s) {
+		return false
+	}
+	for key := range subset {
+		if s.Has(key) {
+			continue
+		} else {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/in-toto/in-toto-golang/in_toto/verifylib.go
+++ b/vendor/github.com/in-toto/in-toto-golang/in_toto/verifylib.go
@@ -1,0 +1,838 @@
+/*
+Package in_toto implements types and routines to verify a software supply chain
+according to the in-toto specification.
+See https://github.com/in-toto/docs/blob/master/in-toto-spec.md
+*/
+package in_toto
+
+import (
+	"fmt"
+	osPath "path"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+)
+
+/*
+RunInspections iteratively executes the command in the Run field of all
+inspections of the passed layout, creating unsigned link metadata that records
+all files found in the current working directory as materials (before command
+execution) and products (after command execution).  A map with inspection names
+as keys and Metablocks containing the generated link metadata as values is
+returned.  The format is:
+
+	{
+		<inspection name> : Metablock,
+		<inspection name> : Metablock,
+		...
+	}
+
+If executing the inspection command fails, or if the executed command has a
+non-zero exit code, the first return value is an empty Metablock map and the
+second return value is the error.
+*/
+func RunInspections(layout Layout) (map[string]Metablock, error) {
+	inspectionMetadata := make(map[string]Metablock)
+
+	for _, inspection := range layout.Inspect {
+
+		linkMb, err := InTotoRun(inspection.Name, []string{"."}, []string{"."},
+			inspection.Run, Key{}, []string{"sha256"}, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		retVal := linkMb.Signed.(Link).ByProducts["return-value"]
+		if retVal != float64(0) {
+			return nil, fmt.Errorf("Inspection command '%s' of inspection '%s'"+
+				" returned a non-zero value: %d", inspection.Run, inspection.Name,
+				retVal)
+		}
+
+		// Dump inspection link to cwd using the short link name format
+		linkName := fmt.Sprintf(LinkNameFormatShort, inspection.Name)
+		if err := linkMb.Dump(linkName); err != nil {
+			fmt.Printf("JSON serialization or writing failed: %s", err)
+		}
+
+		inspectionMetadata[inspection.Name] = linkMb
+	}
+	return inspectionMetadata, nil
+}
+
+// verifyMatchRule is a helper function to process artifact rules of
+// type MATCH. See VerifyArtifacts for more details.
+func verifyMatchRule(ruleData map[string]string,
+	srcArtifacts map[string]interface{}, srcArtifactQueue Set,
+	itemsMetadata map[string]Metablock) Set {
+	consumed := NewSet()
+	// Get destination link metadata
+	dstLinkMb, exists := itemsMetadata[ruleData["dstName"]]
+	if !exists {
+		// Destination link does not exist, rule can't consume any
+		// artifacts
+		return consumed
+	}
+
+	// Get artifacts from destination link metadata
+	var dstArtifacts map[string]interface{}
+	switch ruleData["dstType"] {
+	case "materials":
+		dstArtifacts = dstLinkMb.Signed.(Link).Materials
+
+	case "products":
+		dstArtifacts = dstLinkMb.Signed.(Link).Products
+	}
+
+	// Normalize optional source and destination prefixes, i.e. if
+	// there is a prefix, then add a trailing slash if not there yet
+	for _, prefix := range []string{"srcPrefix", "dstPrefix"} {
+		if ruleData[prefix] != "" &&
+			!strings.HasSuffix(ruleData[prefix], "/") {
+			ruleData[prefix] += "/"
+		}
+	}
+	// Iterate over queue and mark consumed artifacts
+	for srcPath := range srcArtifactQueue {
+		// Remove optional source prefix from source artifact path
+		// Noop if prefix is empty, or artifact does not have it
+		srcBasePath := strings.TrimPrefix(srcPath, ruleData["srcPrefix"])
+
+		// Ignore artifacts not matched by rule pattern
+		matched, err := filepath.Match(ruleData["pattern"], srcBasePath)
+		if err != nil || !matched {
+			continue
+		}
+
+		// Construct corresponding destination artifact path, i.e.
+		// an optional destination prefix plus the source base path
+		dstPath := osPath.Join(ruleData["dstPrefix"], srcBasePath)
+
+		// Try to find the corresponding destination artifact
+		dstArtifact, exists := dstArtifacts[dstPath]
+		// Ignore artifacts without corresponding destination artifact
+		if !exists {
+			continue
+		}
+
+		// Ignore artifact pairs with no matching hashes
+		if !reflect.DeepEqual(srcArtifacts[srcPath], dstArtifact) {
+			continue
+		}
+
+		// Only if a source and destination artifact pair was found and
+		// their hashes are equal, will we mark the source artifact as
+		// successfully consumed, i.e. it will be removed from the queue
+		consumed.Add(srcPath)
+	}
+	return consumed
+}
+
+/*
+VerifyArtifacts iteratively applies the material and product rules of the
+passed items (step or inspection) to enforce and authorize artifacts (materials
+or products) reported by the corresponding link and to guarantee that
+artifacts are linked together across links.  In the beginning all artifacts are
+placed in a queue according to their type.  If an artifact gets consumed by a
+rule it is removed from the queue.  An artifact can only be consumed once in
+the course of processing the set of rules in ExpectedMaterials or
+ExpectedProducts.
+
+Rules of type MATCH, ALLOW, CREATE, DELETE, MODIFY and DISALLOW are supported.
+
+All rules except for DISALLOW consume queued artifacts on success, and
+leave the queue unchanged on failure.  Hence, it is left to a terminal
+DISALLOW rule to fail overall verification, if artifacts are left in the queue
+that should have been consumed by preceding rules.
+*/
+func VerifyArtifacts(items []interface{},
+	itemsMetadata map[string]Metablock) error {
+	// Verify artifact rules for each item in the layout
+	for _, itemI := range items {
+		// The layout item (interface) must be a Link or an Inspection we are only
+		// interested in the name and the expected materials and products
+		var itemName string
+		var expectedMaterials [][]string
+		var expectedProducts [][]string
+
+		switch item := itemI.(type) {
+		case Step:
+			itemName = item.Name
+			expectedMaterials = item.ExpectedMaterials
+			expectedProducts = item.ExpectedProducts
+
+		case Inspection:
+			itemName = item.Name
+			expectedMaterials = item.ExpectedMaterials
+			expectedProducts = item.ExpectedProducts
+
+		default: // Something wrong
+			return fmt.Errorf("VerifyArtifacts received an item of invalid type,"+
+				" elements of passed slice 'items' must be one of 'Step' or"+
+				" 'Inspection', got: '%s'", reflect.TypeOf(item))
+		}
+
+		// Use the item's name to extract the corresponding link
+		srcLinkMb, exists := itemsMetadata[itemName]
+		if !exists {
+			return fmt.Errorf("VerifyArtifacts could not find metadata"+
+				" for item '%s', got: '%s'", itemName, itemsMetadata)
+		}
+
+		// Create shortcuts to materials and products (including hashes) reported
+		// by the item's link, required to verify "match" rules
+		materials := srcLinkMb.Signed.(Link).Materials
+		products := srcLinkMb.Signed.(Link).Products
+
+		// All other rules only require the material or product paths (without
+		// hashes). We extract them from the corresponding maps and store them as
+		// sets for convenience in further processing
+		materialPaths := NewSet(InterfaceKeyStrings(materials)...)
+		productPaths := NewSet(InterfaceKeyStrings(products)...)
+
+		// For `create`, `delete` and `modify` rules we prepare sets of artifacts
+		// (without hashes) that were created, deleted or modified in the current
+		// step or inspection
+		created := productPaths.Difference(materialPaths)
+		deleted := materialPaths.Difference(productPaths)
+		remained := materialPaths.Intersection(productPaths)
+		modified := NewSet()
+		for name := range remained {
+			if !reflect.DeepEqual(materials[name], products[name]) {
+				modified.Add(name)
+			}
+		}
+
+		// For each item we have to run rule verification, once per artifact type.
+		// Here we prepare the corresponding data for each round.
+		verificationDataList := []map[string]interface{}{
+			{
+				"srcType":       "materials",
+				"rules":         expectedMaterials,
+				"artifacts":     materials,
+				"artifactPaths": materialPaths,
+			},
+			{
+				"srcType":       "products",
+				"rules":         expectedProducts,
+				"artifacts":     products,
+				"artifactPaths": productPaths,
+			},
+		}
+		// TODO: Add logging library (see in-toto/in-toto-golang#4)
+		// fmt.Printf("Verifying %s '%s' ", reflect.TypeOf(itemI), itemName)
+
+		// Process all material rules using the corresponding materials and all
+		// product rules using the corresponding products
+		for _, verificationData := range verificationDataList {
+			// TODO: Add logging library (see in-toto/in-toto-golang#4)
+			// fmt.Printf("%s...\n", verificationData["srcType"])
+
+			rules := verificationData["rules"].([][]string)
+			artifacts := verificationData["artifacts"].(map[string]interface{})
+
+			// Use artifacts (without hashes) as base queue. Each rule only operates
+			// on artifacts in that queue.  If a rule consumes an artifact (i.e. can
+			// be applied successfully), the artifact is removed from the queue. By
+			// applying a DISALLOW rule eventually, verification may return an error,
+			// if the rule matches any artifacts in the queue that should have been
+			// consumed earlier.
+			queue := verificationData["artifactPaths"].(Set)
+
+			// TODO: Add logging library (see in-toto/in-toto-golang#4)
+			// fmt.Printf("Initial state\nMaterials: %s\nProducts: %s\nQueue: %s\n\n",
+			// 	materialPaths.Slice(), productPaths.Slice(), queue.Slice())
+
+			// Verify rules sequentially
+			for _, rule := range rules {
+				// Parse rule and error out if it is malformed
+				// NOTE: the rule format should have been validated before
+				ruleData, err := UnpackRule(rule)
+				if err != nil {
+					return err
+				}
+
+				// Apply rule pattern to filter queued artifacts that are up for rule
+				// specific consumption
+				filtered := queue.Filter(ruleData["pattern"])
+
+				var consumed Set
+				switch ruleData["type"] {
+				case "match":
+					// Note: here we need to perform more elaborate filtering
+					consumed = verifyMatchRule(ruleData, artifacts, queue, itemsMetadata)
+
+				case "allow":
+					// Consumes all filtered artifacts
+					consumed = filtered
+
+				case "create":
+					// Consumes filtered artifacts that were created
+					consumed = filtered.Intersection(created)
+
+				case "delete":
+					// Consumes filtered artifacts that were deleted
+					consumed = filtered.Intersection(deleted)
+
+				case "modify":
+					// Consumes filtered artifacts that were modified
+					consumed = filtered.Intersection(modified)
+
+				case "disallow":
+					// Does not consume but errors out if artifacts were filtered
+					if len(filtered) > 0 {
+						return fmt.Errorf("Artifact verification failed for %s '%s',"+
+							" %s %s disallowed by rule %s.",
+							reflect.TypeOf(itemI).Name(), itemName,
+							verificationData["srcType"], filtered.Slice(), rule)
+					}
+				case "require":
+					// REQUIRE is somewhat of a weird animal that does not use
+					// patterns bur rather single filenames (for now).
+					if !queue.Has(ruleData["pattern"]) {
+						return fmt.Errorf("Artifact verification failed for %s in REQUIRE '%s',"+
+							" because %s is not in %s.", verificationData["srcType"],
+							ruleData["pattern"], ruleData["pattern"], queue.Slice())
+					}
+				}
+				// Update queue by removing consumed artifacts
+				queue = queue.Difference(consumed)
+				// TODO: Add logging library (see in-toto/in-toto-golang#4)
+				// fmt.Printf("Rule: %s\nQueue: %s\n\n", rule, queue.Slice())
+			}
+		}
+	}
+	return nil
+}
+
+/*
+ReduceStepsMetadata merges for each step of the passed Layout all the passed
+per-functionary links into a single link, asserting that the reported Materials
+and Products are equal across links for a given step.  This function may be
+used at a time during the overall verification, where link threshold's have
+been verified and subsequent verification only needs one exemplary link per
+step.  The function returns a map with one Metablock (link) per step:
+
+	{
+		<step name> : Metablock,
+		<step name> : Metablock,
+		...
+	}
+
+If links corresponding to the same step report different Materials or different
+Products, the first return value is an empty Metablock map and the second
+return value is the error.
+*/
+func ReduceStepsMetadata(layout Layout,
+	stepsMetadata map[string]map[string]Metablock) (map[string]Metablock,
+	error) {
+	stepsMetadataReduced := make(map[string]Metablock)
+
+	for _, step := range layout.Steps {
+		linksPerStep, ok := stepsMetadata[step.Name]
+		// We should never get here, layout verification must fail earlier
+		if !ok || len(linksPerStep) < 1 {
+			panic("Could not reduce metadata for step '" + step.Name +
+				"', no link metadata found.")
+		}
+
+		// Get the first link (could be any link) for the current step, which will
+		// serve as reference link for below comparisons
+		var referenceKeyID string
+		var referenceLinkMb Metablock
+		for keyID, linkMb := range linksPerStep {
+			referenceLinkMb = linkMb
+			referenceKeyID = keyID
+			break
+		}
+
+		// Only one link, nothing to reduce, take the reference link
+		if len(linksPerStep) == 1 {
+			stepsMetadataReduced[step.Name] = referenceLinkMb
+
+			// Multiple links, reduce but first check
+		} else {
+			// Artifact maps must be equal for each type among all links
+			// TODO: What should we do if there are more links, than the
+			// threshold requires, but not all of them are equal? Right now we would
+			// also error.
+			for keyID, linkMb := range linksPerStep {
+				if !reflect.DeepEqual(linkMb.Signed.(Link).Materials,
+					referenceLinkMb.Signed.(Link).Materials) ||
+					!reflect.DeepEqual(linkMb.Signed.(Link).Products,
+						referenceLinkMb.Signed.(Link).Products) {
+					return nil, fmt.Errorf("Link '%s' and '%s' have different"+
+						" artifacts.",
+						fmt.Sprintf(LinkNameFormat, step.Name, referenceKeyID),
+						fmt.Sprintf(LinkNameFormat, step.Name, keyID))
+				}
+			}
+			// We haven't errored out, so we can reduce (i.e take the reference link)
+			stepsMetadataReduced[step.Name] = referenceLinkMb
+		}
+	}
+	return stepsMetadataReduced, nil
+}
+
+/*
+VerifyStepCommandAlignment (soft) verifies that for each step of the passed
+layout the command executed, as per the passed link, matches the expected
+command, as per the layout.  Soft verification means that, in case a command
+does not align, a warning is issued.
+*/
+func VerifyStepCommandAlignment(layout Layout,
+	stepsMetadata map[string]map[string]Metablock) {
+	for _, step := range layout.Steps {
+		linksPerStep, ok := stepsMetadata[step.Name]
+		// We should never get here, layout verification must fail earlier
+		if !ok || len(linksPerStep) < 1 {
+			panic("Could not verify command alignment for step '" + step.Name +
+				"', no link metadata found.")
+		}
+
+		for signerKeyID, linkMb := range linksPerStep {
+			expectedCommandS := strings.Join(step.ExpectedCommand, " ")
+			executedCommandS := strings.Join(linkMb.Signed.(Link).Command, " ")
+
+			if expectedCommandS != executedCommandS {
+				linkName := fmt.Sprintf(LinkNameFormat, step.Name, signerKeyID)
+				fmt.Printf("WARNING: Expected command for step '%s' (%s) and command"+
+					" reported by '%s' (%s) differ.\n",
+					step.Name, expectedCommandS, linkName, executedCommandS)
+			}
+		}
+	}
+}
+
+/*
+VerifyLinkSignatureThesholds verifies that for each step of the passed layout,
+there are at least Threshold links, validly signed by different authorized
+functionaries.  The returned map of link metadata per steps contains only
+links with valid signatures from distinct functionaries and has the format:
+
+	{
+		<step name> : {
+		<key id>: Metablock,
+		<key id>: Metablock,
+		...
+		},
+		<step name> : {
+		<key id>: Metablock,
+		<key id>: Metablock,
+		...
+		}
+		...
+	}
+
+If for any step of the layout there are not enough links available, the first
+return value is an empty map of Metablock maps and the second return value is
+the error.
+*/
+func VerifyLinkSignatureThesholds(layout Layout,
+	stepsMetadata map[string]map[string]Metablock) (
+	map[string]map[string]Metablock, error) {
+	// This will stores links with valid signature from an authorized functionary
+	// for all steps
+	stepsMetadataVerified := make(map[string]map[string]Metablock)
+
+	// Try to find enough (>= threshold) links each with a valid signature from
+	// distinct authorized functionaries for each step
+	for _, step := range layout.Steps {
+		// This will store links with valid signature from an authorized
+		// functionary for the given step
+		linksPerStepVerified := make(map[string]Metablock)
+
+		// Check if there are any links at all for the given step
+		linksPerStep, ok := stepsMetadata[step.Name]
+		if !ok || len(linksPerStep) < 1 {
+			continue
+		}
+
+		// For each link corresponding to a step, check that the signer key was
+		// authorized, the layout contains a verification key and the signature
+		// verification passes.  Only good links are stored, to verify thresholds
+		// below.
+		for signerKeyID, linkMb := range linksPerStep {
+			for _, authorizedKeyID := range step.PubKeys {
+				if signerKeyID == authorizedKeyID {
+					if verifierKey, ok := layout.Keys[authorizedKeyID]; ok {
+						if err := linkMb.VerifySignature(verifierKey); err == nil {
+							linksPerStepVerified[signerKeyID] = linkMb
+							break
+						}
+					}
+				}
+			}
+		}
+		// Store all good links for a step
+		stepsMetadataVerified[step.Name] = linksPerStepVerified
+	}
+
+	// Verify threshold for each step
+	for _, step := range layout.Steps {
+		linksPerStepVerified, _ := stepsMetadataVerified[step.Name]
+
+		if len(linksPerStepVerified) < step.Threshold {
+			linksPerStep, _ := stepsMetadata[step.Name]
+			return nil, fmt.Errorf("Step '%s' requires '%d' link metadata file(s)."+
+				" '%d' out of '%d' available link(s) have a valid signature from an"+
+				" authorized signer.", step.Name, step.Threshold,
+				len(linksPerStepVerified), len(linksPerStep))
+		}
+	}
+	return stepsMetadataVerified, nil
+}
+
+/*
+LoadLinksForLayout loads for every Step of the passed Layout a Metablock
+containing the corresponding Link.  A base path to a directory that contains
+the links may be passed using linkDir.  Link file names are constructed,
+using LinkNameFormat together with the corresponding step name and authorized
+functionary key ids.  A map of link metadata is returned and has the following
+format:
+
+	{
+		<step name> : {
+			<key id>: Metablock,
+			<key id>: Metablock,
+			...
+		},
+		<step name> : {
+		<key id>: Metablock,
+		<key id>: Metablock,
+		...
+		}
+		...
+	}
+
+If a link cannot be loaded at a constructed link name or is invalid, it is
+ignored. Only a preliminary threshold check is performed, that is, if there
+aren't at least Threshold links for any given step, the first return value
+is an empty map of Metablock maps and the second return value is the error.
+*/
+func LoadLinksForLayout(layout Layout, linkDir string) (
+	map[string]map[string]Metablock, error) {
+	stepsMetadata := make(map[string]map[string]Metablock)
+
+	for _, step := range layout.Steps {
+		linksPerStep := make(map[string]Metablock)
+
+		for _, authorizedKeyID := range step.PubKeys {
+			linkName := fmt.Sprintf(LinkNameFormat, step.Name, authorizedKeyID)
+			linkPath := osPath.Join(linkDir, linkName)
+
+			var linkMb Metablock
+			if err := linkMb.Load(linkPath); err != nil {
+				continue
+			}
+
+			linksPerStep[authorizedKeyID] = linkMb
+		}
+
+		if len(linksPerStep) < step.Threshold {
+			return nil, fmt.Errorf("Step '%s' requires '%d' link metadata file(s),"+
+				" found '%d'.", step.Name, step.Threshold, len(linksPerStep))
+		}
+
+		stepsMetadata[step.Name] = linksPerStep
+	}
+
+	return stepsMetadata, nil
+}
+
+/*
+VerifyLayoutExpiration verifies that the passed Layout has not expired.  It
+returns an error if the (zulu) date in the Expires field is in the past.
+*/
+func VerifyLayoutExpiration(layout Layout) error {
+	expires, err := time.Parse(ISO8601DateSchema, layout.Expires)
+	if err != nil {
+		return err
+	}
+	// Uses timezone of expires, i.e. UTC
+	if time.Until(expires) < 0 {
+		return fmt.Errorf("layout has expired on '%s'", expires)
+	}
+	return nil
+}
+
+/*
+VerifyLayoutSignatures verifies for each key in the passed key map the
+corresponding signature of the Layout in the passed Metablock's Signed field.
+Signatures and keys are associated by key id.  If the key map is empty, or the
+Metablock's Signature field does not have a signature for one or more of the
+passed keys, or a matching signature is invalid, an error is returned.
+*/
+func VerifyLayoutSignatures(layoutMb Metablock,
+	layoutKeys map[string]Key) error {
+	if len(layoutKeys) < 1 {
+		return fmt.Errorf("layout verification requires at least one key")
+	}
+
+	for _, key := range layoutKeys {
+		if err := layoutMb.VerifySignature(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+/*
+GetSummaryLink merges the materials of the first step (as mentioned in the
+layout) and the products of the last step and returns a new link. This link
+reports the materials and products and summarizes the overall software supply
+chain.
+NOTE: The assumption is that the steps mentioned in the layout are to be
+performed sequentially. So, the first step mentioned in the layout denotes what
+comes into the supply chain and the last step denotes what goes out.
+*/
+func GetSummaryLink(layout Layout, stepsMetadataReduced map[string]Metablock,
+	stepName string) (Metablock, error) {
+	var summaryLink Link
+	var result Metablock
+	if len(layout.Steps) > 0 {
+		firstStepLink := stepsMetadataReduced[layout.Steps[0].Name]
+		lastStepLink := stepsMetadataReduced[layout.Steps[len(layout.Steps)-1].Name]
+
+		summaryLink.Materials = firstStepLink.Signed.(Link).Materials
+		summaryLink.Name = stepName
+		summaryLink.Type = firstStepLink.Signed.(Link).Type
+
+		summaryLink.Products = lastStepLink.Signed.(Link).Products
+		summaryLink.ByProducts = lastStepLink.Signed.(Link).ByProducts
+		// Using the last command of the sublayout as the command
+		// of the summary link can be misleading. Is it necessary to
+		// include all the commands executed as part of sublayout?
+		summaryLink.Command = lastStepLink.Signed.(Link).Command
+	}
+
+	result.Signed = summaryLink
+
+	return result, nil
+}
+
+/*
+VerifySublayouts checks if any step in the supply chain is a sublayout, and if
+so, recursively resolves it and replaces it with a summary link summarizing the
+steps carried out in the sublayout.
+*/
+func VerifySublayouts(layout Layout,
+	stepsMetadataVerified map[string]map[string]Metablock,
+	superLayoutLinkPath string) (map[string]map[string]Metablock, error) {
+	for stepName, linkData := range stepsMetadataVerified {
+		for keyID, metadata := range linkData {
+			if _, ok := metadata.Signed.(Layout); ok {
+				layoutKeys := make(map[string]Key)
+				layoutKeys[keyID] = layout.Keys[keyID]
+
+				sublayoutLinkDir := fmt.Sprintf(SublayoutLinkDirFormat,
+					stepName, keyID)
+				sublayoutLinkPath := filepath.Join(superLayoutLinkPath,
+					sublayoutLinkDir)
+				summaryLink, err := InTotoVerify(metadata, layoutKeys,
+					sublayoutLinkPath, stepName, make(map[string]string))
+				if err != nil {
+					return nil, err
+				}
+				linkData[keyID] = summaryLink
+			}
+
+		}
+	}
+	return stepsMetadataVerified, nil
+}
+
+// TODO: find a better way than two helper functions for the replacer op
+
+func substituteParamatersInSlice(replacer *strings.Replacer, slice []string) []string {
+	newSlice := make([]string, 0)
+	for _, item := range slice {
+		newSlice = append(newSlice, replacer.Replace(item))
+	}
+	return newSlice
+}
+
+func substituteParametersInSliceOfSlices(replacer *strings.Replacer,
+	slice [][]string) [][]string {
+	newSlice := make([][]string, 0)
+	for _, item := range slice {
+		newSlice = append(newSlice, substituteParamatersInSlice(replacer,
+			item))
+	}
+	return newSlice
+}
+
+/*
+SubstituteParameters performs parameter substitution in steps and inspections
+in the following fields:
+- Expected Materials and Expected Products of both
+- Run of inspections
+- Expected Command of steps
+The substitution marker is '{}' and the keyword within the braces is replaced
+by a value found in the substitution map passed, parameterDictionary. The
+layout with parameters substituted is returned to the calling function.
+*/
+func SubstituteParameters(layout Layout,
+	parameterDictionary map[string]string) (Layout, error) {
+
+	if len(parameterDictionary) == 0 {
+		return layout, nil
+	}
+
+	parameters := make([]string, 0)
+
+	for parameter, value := range parameterDictionary {
+		parameterFormatCheck, _ := regexp.MatchString("^[a-zA-Z0-9_-]+$",
+			parameter)
+		if !parameterFormatCheck {
+			return layout, fmt.Errorf("invalid format for parameter")
+		}
+
+		parameters = append(parameters, "{"+parameter+"}")
+		parameters = append(parameters, value)
+	}
+
+	replacer := strings.NewReplacer(parameters...)
+
+	for i := range layout.Steps {
+		layout.Steps[i].ExpectedMaterials = substituteParametersInSliceOfSlices(
+			replacer, layout.Steps[i].ExpectedMaterials)
+		layout.Steps[i].ExpectedProducts = substituteParametersInSliceOfSlices(
+			replacer, layout.Steps[i].ExpectedProducts)
+		layout.Steps[i].ExpectedCommand = substituteParamatersInSlice(replacer,
+			layout.Steps[i].ExpectedCommand)
+	}
+
+	for i := range layout.Inspect {
+		layout.Inspect[i].ExpectedMaterials =
+			substituteParametersInSliceOfSlices(replacer,
+				layout.Inspect[i].ExpectedMaterials)
+		layout.Inspect[i].ExpectedProducts =
+			substituteParametersInSliceOfSlices(replacer,
+				layout.Inspect[i].ExpectedProducts)
+		layout.Inspect[i].Run = substituteParamatersInSlice(replacer,
+			layout.Inspect[i].Run)
+	}
+
+	return layout, nil
+}
+
+/*
+InTotoVerify can be used to verify an entire software supply chain according to
+the in-toto specification.  It requires the metadata of the root layout, a map
+that contains public keys to verify the root layout signatures, a path to a
+directory from where it can load link metadata files, which are treated as
+signed evidence for the steps defined in the layout, a step name, and a
+paramater dictionary used for parameter substitution. The step name only
+matters for sublayouts, where it's important to associate the summary of that
+step with a unique name. The verification routine is as follows:
+
+1. Verify layout signature(s) using passed key(s)
+2. Verify layout expiration date
+3. Substitute parameters in layout
+4. Load link metadata files for steps of layout
+5. Verify signatures and signature thresholds for steps of layout
+6. Verify sublayouts recursively
+7. Verify command alignment for steps of layout (only warns)
+8. Verify artifact rules for steps of layout
+9. Execute inspection commands (generates link metadata for each inspection)
+10. Verify artifact rules for inspections of layout
+
+InTotoVerify returns a summary link wrapped in a Metablock object and an error
+value. If any of the verification routines fail, verification is aborted and
+error is returned. In such an instance, the first value remains an empty
+Metablock object.
+
+NOTE: Artifact rules of type "create", "modify"
+and "delete" are currently not supported.
+*/
+func InTotoVerify(layoutMb Metablock, layoutKeys map[string]Key,
+	linkDir string, stepName string, parameterDictionary map[string]string) (
+	Metablock, error) {
+
+	var summaryLink Metablock
+	var err error
+
+	// Verify root signatures
+	if err := VerifyLayoutSignatures(layoutMb, layoutKeys); err != nil {
+		return summaryLink, err
+	}
+
+	// Extract the layout from its Metablock container (for further processing)
+	layout := layoutMb.Signed.(Layout)
+
+	// Verify layout expiration
+	if err := VerifyLayoutExpiration(layout); err != nil {
+		return summaryLink, err
+	}
+
+	// Substitute parameters in layout
+	layout, err = SubstituteParameters(layout, parameterDictionary)
+	if err != nil {
+		return summaryLink, err
+	}
+
+	// Load links for layout
+	stepsMetadata, err := LoadLinksForLayout(layout, linkDir)
+	if err != nil {
+		return summaryLink, err
+	}
+
+	// Verify link signatures
+	stepsMetadataVerified, err := VerifyLinkSignatureThesholds(layout,
+		stepsMetadata)
+	if err != nil {
+		return summaryLink, err
+	}
+
+	// Verify and resolve sublayouts
+	stepsSublayoutVerified, err := VerifySublayouts(layout,
+		stepsMetadataVerified, linkDir)
+	if err != nil {
+		return summaryLink, err
+	}
+
+	// Verify command alignment (WARNING only)
+	VerifyStepCommandAlignment(layout, stepsSublayoutVerified)
+
+	// Given that signature thresholds have been checked above and the rest of
+	// the relevant link properties, i.e. materials and products, have to be
+	// exactly equal, we can reduce the map of steps metadata. However, we error
+	// if the relevant properties are not equal among links of a step.
+	stepsMetadataReduced, err := ReduceStepsMetadata(layout,
+		stepsSublayoutVerified)
+	if err != nil {
+		return summaryLink, err
+	}
+
+	// Verify artifact rules
+	if err = VerifyArtifacts(layout.stepsAsInterfaceSlice(),
+		stepsMetadataReduced); err != nil {
+		return summaryLink, err
+	}
+
+	inspectionMetadata, err := RunInspections(layout)
+	if err != nil {
+		return summaryLink, err
+	}
+
+	// Add steps metadata to inspection metadata, because inspection artifact
+	// rules may also refer to artifacts reported by step links
+	for k, v := range stepsMetadataReduced {
+		inspectionMetadata[k] = v
+	}
+
+	if err = VerifyArtifacts(layout.inspectAsInterfaceSlice(),
+		inspectionMetadata); err != nil {
+		return summaryLink, err
+	}
+
+	summaryLink, err = GetSummaryLink(layout, stepsMetadataReduced, stepName)
+	if err != nil {
+		return summaryLink, err
+	}
+
+	return summaryLink, nil
+}

--- a/vendor/github.com/shibumi/go-pathspec/.gitignore
+++ b/vendor/github.com/shibumi/go-pathspec/.gitignore
@@ -1,0 +1,23 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test

--- a/vendor/github.com/shibumi/go-pathspec/GO-LICENSE
+++ b/vendor/github.com/shibumi/go-pathspec/GO-LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/shibumi/go-pathspec/LICENSE
+++ b/vendor/github.com/shibumi/go-pathspec/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/shibumi/go-pathspec/README.md
+++ b/vendor/github.com/shibumi/go-pathspec/README.md
@@ -1,0 +1,45 @@
+# go-pathspec
+
+[![build](https://github.com/shibumi/go-pathspec/workflows/build/badge.svg)](https://github.com/shibumi/go-pathspec/actions?query=workflow%3Abuild) [![Coverage Status](https://coveralls.io/repos/github/shibumi/go-pathspec/badge.svg)](https://coveralls.io/github/shibumi/go-pathspec) [![PkgGoDev](https://pkg.go.dev/badge/github.com/shibumi/go-pathspec)](https://pkg.go.dev/github.com/shibumi/go-pathspec)
+
+go-pathspec implements gitignore-style pattern matching for paths.
+
+## Alternatives
+
+There are a few alternatives, that try to be gitignore compatible or even state
+gitignore compatibility:
+
+### https://github.com/go-git/go-git
+
+go-git states it would be gitignore compatible, but actually they are missing a few
+special cases. This issue describes one of the not working patterns: https://github.com/go-git/go-git/issues/108
+
+What does not work is global filename pattern matching. Consider the following
+`.gitignore` file:
+
+```gitignore
+# gitignore test file
+parse.go
+```
+
+Then `parse.go` should match on all filenames called `parse.go`. You can test this via
+this shell script:
+```shell
+mkdir -p /tmp/test/internal/util
+touch /tmp/test/internal/util/parse.go
+cd /tmp/test/
+git init
+echo "parse.go" > .gitignore
+```
+
+With git `parse.go` will be excluded. The go-git implementation behaves different.
+
+### https://github.com/monochromegane/go-gitignore
+
+monochromegane's go-gitignore does not support the use of `**`-operators.
+This is not consistent to real gitignore behavior, too.
+
+## Authors
+
+Sander van Harmelen (<sander@xanzy.io>)  
+Christian Rebischke (<chris@shibumi.dev>)

--- a/vendor/github.com/shibumi/go-pathspec/gitignore.go
+++ b/vendor/github.com/shibumi/go-pathspec/gitignore.go
@@ -1,0 +1,299 @@
+//
+// Copyright 2014, Sander van Harmelen
+// Copyright 2020, Christian Rebischke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package pathspec implements git compatible gitignore pattern matching.
+// See the description below, if you are unfamiliar with it:
+//
+// A blank line matches no files, so it can serve as a separator for readability.
+//
+// A line starting with # serves as a comment. Put a backslash ("\") in front of
+// the first hash for patterns that begin with a hash.
+//
+// An optional prefix "!" which negates the pattern; any matching file excluded
+// by a previous pattern will become included again. If a negated pattern matches,
+// this will override lower precedence patterns sources. Put a backslash ("\") in
+// front of the first "!" for patterns that begin with a literal "!", for example,
+// "\!important!.txt".
+//
+// If the pattern ends with a slash, it is removed for the purpose of the following
+// description, but it would only find a match with a directory. In other words,
+// foo/ will match a directory foo and paths underneath it, but will not match a
+// regular file or a symbolic link foo (this is consistent with the way how pathspec
+// works in general in Git).
+//
+// If the pattern does not contain a slash /, Git treats it as a shell glob pattern
+// and checks for a match against the pathname relative to the location of the
+// .gitignore file (relative to the toplevel of the work tree if not from a
+// .gitignore file).
+//
+// Otherwise, Git treats the pattern as a shell glob suitable for consumption by
+// fnmatch(3) with the FNM_PATHNAME flag: wildcards in the pattern will not match
+// a / in the pathname. For example, "Documentation/*.html" matches
+// "Documentation/git.html" but not "Documentation/ppc/ppc.html" or/
+// "tools/perf/Documentation/perf.html".
+//
+// A leading slash matches the beginning of the pathname. For example, "/*.c"
+// matches "cat-file.c" but not "mozilla-sha1/sha1.c".
+//
+// Two consecutive asterisks ("**") in patterns matched against full pathname
+// may have special meaning:
+//
+// A leading "**" followed by a slash means match in all directories. For example,
+// "**/foo" matches file or directory "foo" anywhere, the same as pattern "foo".
+// "**/foo/bar" matches file or directory "bar" anywhere that is directly under
+// directory "foo".
+//
+// A trailing "/" matches everything inside. For example, "abc/" matches all files
+// inside directory "abc", relative to the location of the .gitignore file, with
+// infinite depth.
+//
+// A slash followed by two consecutive asterisks then a slash matches zero or more
+// directories. For example, "a/**/b" matches "a/b", "a/x/b", "a/x/y/b" and so on.
+//
+// Other consecutive asterisks are considered invalid.
+package pathspec
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type gitIgnorePattern struct {
+	Regex   string
+	Include bool
+}
+
+// GitIgnore uses a string slice of patterns for matching on a filepath string.
+// On match it returns true, otherwise false. On error it passes the error through.
+func GitIgnore(patterns []string, name string) (ignore bool, err error) {
+	for _, pattern := range patterns {
+		p := parsePattern(pattern)
+		// Convert Windows paths to Unix paths
+		name = filepath.ToSlash(name)
+		match, err := regexp.MatchString(p.Regex, name)
+		if err != nil {
+			return ignore, err
+		}
+		if match {
+			if p.Include {
+				return false, nil
+			}
+			ignore = true
+		}
+	}
+	return ignore, nil
+}
+
+// ReadGitIgnore implements the io.Reader interface for reading a gitignore file
+// line by line. It behaves exactly like the GitIgnore function. The only difference
+// is that GitIgnore works on a string slice.
+//
+// ReadGitIgnore returns a boolean value if we match or not and an error.
+func ReadGitIgnore(content io.Reader, name string) (ignore bool, err error) {
+	scanner := bufio.NewScanner(content)
+
+	for scanner.Scan() {
+		pattern := strings.TrimSpace(scanner.Text())
+		if len(pattern) == 0 || pattern[0] == '#' {
+			continue
+		}
+		p := parsePattern(pattern)
+		// Convert Windows paths to Unix paths
+		name = filepath.ToSlash(name)
+		match, err := regexp.MatchString(p.Regex, name)
+		if err != nil {
+			return ignore, err
+		}
+		if match {
+			if p.Include {
+				return false, scanner.Err()
+			}
+			ignore = true
+		}
+	}
+	return ignore, scanner.Err()
+}
+
+func parsePattern(pattern string) *gitIgnorePattern {
+	p := &gitIgnorePattern{}
+
+	// An optional prefix "!" which negates the pattern; any matching file
+	// excluded by a previous pattern will become included again.
+	if strings.HasPrefix(pattern, "!") {
+		pattern = pattern[1:]
+		p.Include = true
+	} else {
+		p.Include = false
+	}
+
+	// Remove leading back-slash escape for escaped hash ('#') or
+	// exclamation mark ('!').
+	if strings.HasPrefix(pattern, "\\") {
+		pattern = pattern[1:]
+	}
+
+	// Split pattern into segments.
+	patternSegs := strings.Split(pattern, "/")
+
+	// A pattern beginning with a slash ('/') will only match paths
+	// directly on the root directory instead of any descendant paths.
+	// So remove empty first segment to make pattern absoluut to root.
+	// A pattern without a beginning slash ('/') will match any
+	// descendant path. This is equivilent to "**/{pattern}". So
+	// prepend with double-asterisks to make pattern relative to
+	// root.
+	if patternSegs[0] == "" {
+		patternSegs = patternSegs[1:]
+	} else if patternSegs[0] != "**" {
+		patternSegs = append([]string{"**"}, patternSegs...)
+	}
+
+	// A pattern ending with a slash ('/') will match all descendant
+	// paths of if it is a directory but not if it is a regular file.
+	// This is equivalent to "{pattern}/**". So, set last segment to
+	// double asterisks to include all descendants.
+	if patternSegs[len(patternSegs)-1] == "" {
+		patternSegs[len(patternSegs)-1] = "**"
+	}
+
+	// Build regular expression from pattern.
+	var expr bytes.Buffer
+	expr.WriteString("^")
+	needSlash := false
+
+	for i, seg := range patternSegs {
+		switch seg {
+		case "**":
+			switch {
+			case i == 0 && i == len(patternSegs)-1:
+				// A pattern consisting solely of double-asterisks ('**')
+				// will match every path.
+				expr.WriteString(".+")
+			case i == 0:
+				// A normalized pattern beginning with double-asterisks
+				// ('**') will match any leading path segments.
+				expr.WriteString("(?:.+/)?")
+				needSlash = false
+			case i == len(patternSegs)-1:
+				// A normalized pattern ending with double-asterisks ('**')
+				// will match any trailing path segments.
+				expr.WriteString("/.+")
+			default:
+				// A pattern with inner double-asterisks ('**') will match
+				// multiple (or zero) inner path segments.
+				expr.WriteString("(?:/.+)?")
+				needSlash = true
+			}
+		case "*":
+			// Match single path segment.
+			if needSlash {
+				expr.WriteString("/")
+			}
+			expr.WriteString("[^/]+")
+			needSlash = true
+		default:
+			// Match segment glob pattern.
+			if needSlash {
+				expr.WriteString("/")
+			}
+			expr.WriteString(translateGlob(seg))
+			needSlash = true
+		}
+	}
+	expr.WriteString("$")
+	p.Regex = expr.String()
+	return p
+}
+
+// NOTE: This is derived from `fnmatch.translate()` and is similar to
+// the POSIX function `fnmatch()` with the `FNM_PATHNAME` flag set.
+func translateGlob(glob string) string {
+	var regex bytes.Buffer
+	escape := false
+
+	for i := 0; i < len(glob); i++ {
+		char := glob[i]
+		// Escape the character.
+		switch {
+		case escape:
+			escape = false
+			regex.WriteString(regexp.QuoteMeta(string(char)))
+		case char == '\\':
+			// Escape character, escape next character.
+			escape = true
+		case char == '*':
+			// Multi-character wildcard. Match any string (except slashes),
+			// including an empty string.
+			regex.WriteString("[^/]*")
+		case char == '?':
+			// Single-character wildcard. Match any single character (except
+			// a slash).
+			regex.WriteString("[^/]")
+		case char == '[':
+			regex.WriteString(translateBracketExpression(&i, glob))
+		default:
+			// Regular character, escape it for regex.
+			regex.WriteString(regexp.QuoteMeta(string(char)))
+		}
+	}
+	return regex.String()
+}
+
+// Bracket expression wildcard. Except for the beginning
+// exclamation mark, the whole bracket expression can be used
+// directly as regex but we have to find where the expression
+// ends.
+// - "[][!]" matches ']', '[' and '!'.
+// - "[]-]" matches ']' and '-'.
+// - "[!]a-]" matches any character except ']', 'a' and '-'.
+func translateBracketExpression(i *int, glob string) string {
+	regex := string(glob[*i])
+	*i++
+	j := *i
+
+	// Pass bracket expression negation.
+	if j < len(glob) && glob[j] == '!' {
+		j++
+	}
+	// Pass first closing bracket if it is at the beginning of the
+	// expression.
+	if j < len(glob) && glob[j] == ']' {
+		j++
+	}
+	// Find closing bracket. Stop once we reach the end or find it.
+	for j < len(glob) && glob[j] != ']' {
+		j++
+	}
+
+	if j < len(glob) {
+		if glob[*i] == '!' {
+			regex = regex + "^"
+			*i++
+		}
+		regex = regexp.QuoteMeta(glob[*i:j])
+		*i = j
+	} else {
+		// Failed to find closing bracket, treat opening bracket as a
+		// bracket literal instead of as an expression.
+		regex = regexp.QuoteMeta(string(glob[*i]))
+	}
+	return "[" + regex + "]"
+}

--- a/vendor/github.com/shibumi/go-pathspec/go.mod
+++ b/vendor/github.com/shibumi/go-pathspec/go.mod
@@ -1,0 +1,3 @@
+module github.com/shibumi/go-pathspec
+
+go 1.14

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -313,6 +313,8 @@ github.com/hashicorp/vault/sdk/helper/strutil
 github.com/howeyc/gopass
 # github.com/imdario/mergo v0.3.9
 github.com/imdario/mergo
+# github.com/in-toto/in-toto-golang v0.1.1-0.20210505200736-471bd79ebd18
+github.com/in-toto/in-toto-golang/in_toto
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/jedisct1/go-minisign v0.0.0-20210414164026-819d7e2534ac
@@ -399,6 +401,8 @@ github.com/sassoftware/relic/lib/signjar
 github.com/sassoftware/relic/lib/x509tools
 github.com/sassoftware/relic/lib/zipslicer
 github.com/sassoftware/relic/signers/sigerrors
+# github.com/shibumi/go-pathspec v1.2.0
+github.com/shibumi/go-pathspec
 # github.com/sigstore/cosign v0.3.2-0.20210504221908-6a2c836159a9
 github.com/sigstore/cosign/pkg/cosign
 # github.com/sigstore/rekor v0.1.2-0.20210428010952-9e3e56d52dd0


### PR DESCRIPTION
This PR deprecates https://github.com/tektoncd/chains/pull/88. 

This PR implements the basic support for https://github.com/tektoncd/chains/issues/65.
The formatter uses type hinting to be able to extract information to prepare the in-toto attestation.