### PR TITLE
Add kaniko Task and TaskRun example

### DIFF
--- a/examples/kaniko/kaniko.yaml
+++ b/examples/kaniko/kaniko.yaml
@@ -1,0 +1,63 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kaniko-chains
+spec:
+  description: >-
+    This Task builds a simple Dockerfile with kaniko and pushes to a registry.
+    This Task stores the image name and digest as results, allowing Tekton Chains to pick up
+    that an image was built & sign it.
+  params:
+  - name: IMAGE
+    description: Name (reference) of the image to build.
+  - name: DOCKERFILE
+    description: Path to the Dockerfile to build.
+    default: ./Dockerfile
+  - name: CONTEXT
+    description: The build context used by Kaniko.
+    default: ./
+  - name: EXTRA_ARGS
+    default: ""
+  - name: BUILDER_IMAGE
+    description: The image on which builds will run (default is v1.5.1)
+    default: gcr.io/kaniko-project/executor:v1.5.1@sha256:c6166717f7fe0b7da44908c986137ecfeab21f31ec3992f6e128fff8a94be8a5
+  workspaces:
+  - name: source
+    description: Holds the context and Dockerfile
+  - name: dockerconfig
+    description: Includes a docker `config.json`
+    optional: true
+    mountPath: /kaniko/.docker
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
+  - name: IMAGE_URL
+    description: URL of the image just built.
+  steps:
+  - name: add-dockerfile
+    workingDir: $(workspaces.source.path)
+    image: bash
+    script: |
+      set -e
+      echo "FROM alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f" | tee $(params.DOCKERFILE)
+  - name: build-and-push
+    workingDir: $(workspaces.source.path)
+    image: $(params.BUILDER_IMAGE)
+    args:
+    - $(params.EXTRA_ARGS)
+    - --dockerfile=$(params.DOCKERFILE)
+    - --context=$(workspaces.source.path)/$(params.CONTEXT)  # The user does not need to care the workspace and the source.
+    - --destination=$(params.IMAGE)
+    - --digest-file=$(results.IMAGE_DIGEST.path)
+    # kaniko assumes it is running as root, which means this example fails on platforms
+    # that default to run containers as random uid (like OpenShift). Adding this securityContext
+    # makes it explicit that it needs to run as root.
+    securityContext:
+      runAsUser: 0
+  - name: write-url
+    image: bash
+    script: |
+      set -e
+      echo $(params.IMAGE) | tee $(results.IMAGE_URL.path)
+    securityContext:
+      runAsUser: 0

--- a/examples/kaniko/taskrun.yaml
+++ b/examples/kaniko/taskrun.yaml
@@ -1,0 +1,16 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: kaniko-run
+spec:
+  taskRef:
+    name: kaniko-chains
+  params:
+  - name: IMAGE
+    value: ${REGISTRY}/kaniko-chains
+  workspaces:
+  - name: source
+    emptyDir: {}
+  - name: dockerconfig
+    secret:
+      secretName: ${DOCKERCONFIG_SECRET}


### PR DESCRIPTION
I figured it would be nice to have a kaniko task that works with Chains as an example in the repo, and for any blog posts/tutorials we may write.

This task basically:
- Creates a dockerfile as the first step
- builds + pushes the image with kaniko
- writes the IMAGE_URL so that Chains picks up the image that was built and signs it

It would be nice if we added the IMAGE_URL to the official kaniko task as well so that it would just work with chains
