### PR TITLE
Minor ite-6 fixes.

### DIFF
--- a/INTOTO.md
+++ b/INTOTO.md
@@ -1,4 +1,4 @@
-# In-toto attestation formater
+# In-toto attestation formatter
 
 ## Overview
 

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -118,29 +118,29 @@ func allSigners(sp string, cfg config.Config, l *zap.SugaredLogger) map[string]s
 	return all
 }
 
-func allFormaters(cfg config.Config, l *zap.SugaredLogger) map[formats.PayloadType]formats.Payloader {
+func allFormatters(cfg config.Config, l *zap.SugaredLogger) map[formats.PayloadType]formats.Payloader {
 	all := map[formats.PayloadType]formats.Payloader{}
 
 	for _, f := range formats.AllFormatters {
 		switch f {
 		case formats.PayloadTypeTekton:
-			formater, err := tekton.NewFormatter()
+			formatter, err := tekton.NewFormatter()
 			if err != nil {
-				l.Warnf("error configuring tekton formater: %s", err)
+				l.Warnf("error configuring tekton formatter: %s", err)
 			}
-			all[f] = formater
+			all[f] = formatter
 		case formats.PayloadTypeSimpleSigning:
-			formater, err := simple.NewFormatter()
+			formatter, err := simple.NewFormatter()
 			if err != nil {
-				l.Warnf("error configuring tekton formater: %s", err)
+				l.Warnf("error configuring tekton formatter: %s", err)
 			}
-			all[f] = formater
+			all[f] = formatter
 		case formats.PayloadTypeInTotoIte6:
-			formater, err := intotoite6.NewFormatter(cfg)
+			formatter, err := intotoite6.NewFormatter(cfg)
 			if err != nil {
-				l.Warnf("error configuring tekton formater: %s", err)
+				l.Warnf("error configuring tekton formatter: %s", err)
 			}
-			all[f] = formater
+			all[f] = formatter
 		}
 	}
 
@@ -165,7 +165,7 @@ func (ts *TaskRunSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) e
 	}
 
 	signers := allSigners(ts.SecretPath, cfg, ts.Logger)
-	allFormats := allFormaters(cfg, ts.Logger)
+	allFormats := allFormatters(cfg, ts.Logger)
 
 	var merr *multierror.Error
 	for _, signableType := range enabledSignableTypes {

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -110,6 +110,8 @@ var defaults = map[string]string{
 	ociFormatKey:      "simplesigning",
 	ociStorageKey:     "oci",
 	ociSignerKey:      "x509",
+
+	builderIDKey: "tekton-chains",
 }
 
 var supportedValues = map[string][]string{

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -72,6 +72,9 @@ func TestParse(t *testing.T) {
 			name: "empty",
 			data: map[string]string{},
 			want: Config{
+				Builder: BuilderConfig{
+					"tekton-chains",
+				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
 						Format:         "tekton",
@@ -90,6 +93,9 @@ func TestParse(t *testing.T) {
 			name: "single",
 			data: map[string]string{taskrunSignerKey: "pgp"},
 			want: Config{
+				Builder: BuilderConfig{
+					"tekton-chains",
+				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
 						Format:         "tekton",
@@ -108,6 +114,9 @@ func TestParse(t *testing.T) {
 			name: "extra",
 			data: map[string]string{taskrunSignerKey: "pgp", "other-key": "foo"},
 			want: Config{
+				Builder: BuilderConfig{
+					"tekton-chains",
+				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
 						Format:         "tekton",


### PR DESCRIPTION
Fix a typo "formater->formatter"
Add a default builder.id, we panic otherwise
Add a default entrypoint name for cases where there is no taskref.

Signed-off-by: Dan Lorenc <dlorenc@google.com>