### PR TITLE
Support the ITE-5 signing spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,10 @@ require (
 	github.com/google/go-containerregistry v0.5.1
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20210216200643-d81088d9983e
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/in-toto/in-toto-golang v0.1.1-0.20210505200736-471bd79ebd18
+	github.com/in-toto/in-toto-golang v0.1.1-0.20210528150343-f7dc21abaccf
 	github.com/pkg/errors v0.9.1
 	github.com/sigstore/cosign v0.5.0
+	github.com/sigstore/rekor v0.1.2-0.20210519014330-b5480728bde6
 	github.com/sigstore/sigstore v0.0.0-20210530211317-99216b8b86a6
 	github.com/tektoncd/pipeline v0.23.0
 	github.com/tektoncd/plumbing v0.0.0-20210514044347-f8a9689d5bd5
@@ -23,7 +24,6 @@ require (
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v0.19.7
 	knative.dev/pkg v0.0.0-20210127163530-0d31134d5f4e
-
 )
 
 // Knative deps (release-0.20)

--- a/go.sum
+++ b/go.sum
@@ -369,6 +369,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
+github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1pT8KYB3TCXK/ocprsh7MAkoW8bZVzPdih9snmM=
 github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340/go.mod h1:s5q4SojHctfxANBDvMeIaIovkq29IP48TKAxnhYRxvo=
@@ -1109,8 +1111,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/in-toto/in-toto-golang v0.1.1-0.20210505200736-471bd79ebd18 h1:eof0G7NssBxSPzUZstI8ofmf1sOZ44dZy7rmEnSF+GM=
-github.com/in-toto/in-toto-golang v0.1.1-0.20210505200736-471bd79ebd18/go.mod h1:CV6wDPIrRheCXNQXxrr+x6Ued1MLKbe2z7wU56SlVQc=
+github.com/in-toto/in-toto-golang v0.1.1-0.20210528150343-f7dc21abaccf h1:yysOUUcpkuGZ0BZUtL+whU22H56Hqya/p636tGceacc=
+github.com/in-toto/in-toto-golang v0.1.1-0.20210528150343-f7dc21abaccf/go.mod h1:kOcoAhaukFZpRm6D53dd2xB++q065UxKi938k81l1aM=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=

--- a/pkg/chains/formats/format.go
+++ b/pkg/chains/formats/format.go
@@ -17,6 +17,7 @@ package formats
 type Payloader interface {
 	CreatePayload(obj interface{}) (interface{}, error)
 	Type() PayloadType
+	Wrap() bool
 }
 
 type PayloadType string

--- a/pkg/chains/formats/intotoite6/intotoite6.go
+++ b/pkg/chains/formats/intotoite6/intotoite6.go
@@ -45,6 +45,10 @@ func NewFormatter(cfg config.Config) (formats.Payloader, error) {
 	return &InTotoIte6{builderID: cfg.Builder.ID}, nil
 }
 
+func (i *InTotoIte6) Wrap() bool {
+	return true
+}
+
 func (i *InTotoIte6) CreatePayload(obj interface{}) (interface{}, error) {
 	var tr *v1beta1.TaskRun
 	switch v := obj.(type) {

--- a/pkg/chains/formats/simple/simple.go
+++ b/pkg/chains/formats/simple/simple.go
@@ -38,7 +38,10 @@ func (i *SimpleSigning) CreatePayload(obj interface{}) (interface{}, error) {
 	default:
 		return nil, fmt.Errorf("unsupported type %s", v)
 	}
+}
 
+func (i *SimpleSigning) Wrap() bool {
+	return false
 }
 
 func NewFormatter() (formats.Payloader, error) {

--- a/pkg/chains/formats/tekton/tekton.go
+++ b/pkg/chains/formats/tekton/tekton.go
@@ -44,3 +44,7 @@ func (i *Tekton) CreatePayload(obj interface{}) (interface{}, error) {
 func (i *Tekton) Type() formats.PayloadType {
 	return formats.PayloadTypeTekton
 }
+
+func (i *Tekton) Wrap() bool {
+	return false
+}

--- a/pkg/chains/signing/wrap.go
+++ b/pkg/chains/signing/wrap.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"crypto"
+	"encoding/json"
+
+	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/pkg/ssl"
+)
+
+func Wrap(ctx context.Context, s Signer) (Signer, error) {
+	adapter := sslAdapter{
+		wrapped: s,
+	}
+
+	envelope, err := ssl.NewEnvelopeSigner(&adapter)
+	if err != nil {
+		return nil, err
+	}
+
+	pub, err := s.PublicKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &sslSigner{
+		wrapper: envelope,
+		typ:     s.Type(),
+		pub:     pub,
+	}, nil
+}
+
+// sslAdapter converts our signing objects into the type expected by the Envelope signer for wrapping.
+type sslAdapter struct {
+	wrapped Signer
+	KeyID   string
+}
+
+func (w *sslAdapter) Sign(data []byte) ([]byte, string, error) {
+	sig, _, err := w.wrapped.Sign(context.Background(), data)
+	return sig, w.KeyID, err
+}
+
+func (w *sslAdapter) Verify(keyID string, data, sig []byte) (bool, error) {
+	panic("unimplemented")
+}
+
+// sslSigner converts the EnvelopeSigners back into our types, after wrapping.
+type sslSigner struct {
+	wrapper *ssl.EnvelopeSigner
+	typ     string
+	pub     crypto.PublicKey
+}
+
+func (s *sslSigner) Type() string {
+	return s.typ
+}
+func (s *sslSigner) PublicKey(ctx context.Context) (crypto.PublicKey, error) {
+	return s.pub, nil
+}
+
+func (s *sslSigner) Sign(ctx context.Context, payload []byte) ([]byte, []byte, error) {
+	env, err := s.wrapper.SignPayload(in_toto.PayloadType, payload)
+	if err != nil {
+		return nil, nil, err
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		return nil, nil, err
+	}
+	return b, []byte(env.Payload), nil
+}

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -98,6 +98,7 @@ const (
 	// No config needed for Tekton object storage
 
 	// No config needed for pgp signer
+
 	// No config needed for x509 signer
 
 	// KMS

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -209,6 +209,8 @@ func TestOCIStorage(t *testing.T) {
 
 	resetConfig := setConfigMap(ctx, t, c, map[string]string{
 		"storage.oci.repository.insecure": "true",
+		"artifacts.oci.storage":           "oci",
+		"artifacts.taskrun.storage":       "tekton",
 	})
 	defer resetConfig()
 	time.Sleep(3 * time.Second)

--- a/vendor/github.com/in-toto/in-toto-golang/pkg/ssl/sign.go
+++ b/vendor/github.com/in-toto/in-toto-golang/pkg/ssl/sign.go
@@ -1,0 +1,193 @@
+/*
+Package ssl implements the Secure Systems Lab signing-spec (sometimes
+abbreviated SSL Siging spec.
+https://github.com/secure-systems-lab/signing-spec
+*/
+package ssl
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+)
+
+// ErrUnknownKey indicates that the implementation does not recognize the
+// key.
+var ErrUnknownKey = errors.New("unknown key")
+
+// ErrNoSignature indicates that an envelope did not contain any signatures.
+var ErrNoSignature = errors.New("no signature found")
+
+// ErrNoSigners indicates that no signer was provided.
+var ErrNoSigners = errors.New("no signers provided")
+
+/*
+Envelope captures an envelope as described by the Secure Systems Lab
+Signing Specification. See here:
+https://github.com/secure-systems-lab/signing-spec/blob/master/envelope.md
+*/
+type Envelope struct {
+	PayloadType string      `json:"payloadType"`
+	Payload     string      `json:"payload"`
+	Signatures  []Signature `json:"signatures"`
+}
+
+/*
+Signature represents a generic in-toto signature that contains the identifier
+of the key which was used to create the signature.
+The used signature scheme has to be agreed upon by the signer and verifer
+out of band.
+The signature is a base64 encoding of the raw bytes from the signature
+algorithm.
+*/
+type Signature struct {
+	KeyID string `json:"keyid"`
+	Sig   string `json:"sig"`
+}
+
+/*
+PAE implementes PASETO Pre-Authentic Encoding
+https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding
+*/
+func PAE(data [][]byte) ([]byte, error) {
+	var buf = bytes.Buffer{}
+	var l = len(data)
+	var err error
+
+	if err = binary.Write(&buf, binary.LittleEndian, uint64(l)); err != nil {
+		return nil, err
+	}
+
+	for _, b := range data {
+		l = len(b)
+
+		if err = binary.Write(&buf, binary.LittleEndian, uint64(l)); err != nil {
+			return nil, err
+		}
+
+		if _, err = buf.Write(b); err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+/*
+Signer defines the interface for an abstract signing algorithm.
+The Signer interface is used to inject signature algorithm implementations
+into the EnevelopeSigner. This decoupling allows for any signing algorithm
+and key management system can be used.
+The full message is provided as the parameter. If the signature algorithm
+depends on hashing of the message prior to signature calculation, the
+implementor of this interface must perform such hashing.
+The function must return raw bytes representing the calculated signature
+using the current algorithm, and the key used (if applicable).
+For an example see EcdsaSigner in sign_test.go.
+*/
+type Signer interface {
+	Sign(data []byte) ([]byte, string, error)
+}
+
+// SignVerifer provides both the signing and verification interface.
+type SignVerifier interface {
+	Signer
+	Verifier
+}
+
+// EnvelopeSigner creates signed Envelopes.
+type EnvelopeSigner struct {
+	providers []SignVerifier
+	ev        EnvelopeVerifier
+}
+
+/*
+NewEnvelopeSigner creates an EnvelopeSigner that uses 1+ Signer
+algorithms to sign the data.
+*/
+func NewEnvelopeSigner(p ...SignVerifier) (*EnvelopeSigner, error) {
+	var providers []SignVerifier
+
+	for _, sv := range p {
+		if sv != nil {
+			providers = append(providers, sv)
+		}
+	}
+
+	if len(providers) == 0 {
+		return nil, ErrNoSigners
+	}
+
+	evps := []Verifier{}
+	for _, p := range providers {
+		evps = append(evps, p.(Verifier))
+	}
+
+	return &EnvelopeSigner{
+		providers: providers,
+		ev: EnvelopeVerifier{
+			providers: evps,
+		},
+	}, nil
+}
+
+/*
+SignPayload signs a payload and payload type according to the SSL signing spec.
+Returned is an envelope as defined here:
+https://github.com/secure-systems-lab/signing-spec/blob/master/envelope.md
+One signature will be added for each Signer in the EnvelopeSigner.
+*/
+func (es *EnvelopeSigner) SignPayload(payloadType string, body []byte) (*Envelope, error) {
+	var e = Envelope{
+		Payload:     base64.StdEncoding.EncodeToString(body),
+		PayloadType: payloadType,
+	}
+
+	paeEnc, err := PAE([][]byte{
+		[]byte(payloadType),
+		body,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, signer := range es.providers {
+		sig, keyID, err := signer.Sign(paeEnc)
+		if err != nil {
+			return nil, err
+		}
+
+		e.Signatures = append(e.Signatures, Signature{
+			KeyID: keyID,
+			Sig:   base64.StdEncoding.EncodeToString(sig),
+		})
+	}
+
+	return &e, nil
+}
+
+/*
+Verify decodes the payload and verifies the signature.
+Any domain specific validation such as parsing the decoded body and
+validating the payload type is left out to the caller.
+*/
+func (es *EnvelopeSigner) Verify(e *Envelope) (bool, error) {
+	return es.ev.Verify(e)
+}
+
+/*
+Both standard and url encoding are allowed:
+https://github.com/secure-systems-lab/signing-spec/blob/master/envelope.md
+*/
+func b64Decode(s string) ([]byte, error) {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		b, err = base64.URLEncoding.DecodeString(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return b, nil
+}

--- a/vendor/github.com/in-toto/in-toto-golang/pkg/ssl/verify.go
+++ b/vendor/github.com/in-toto/in-toto-golang/pkg/ssl/verify.go
@@ -1,0 +1,78 @@
+/*
+Package ssl implements the Secure Systems Lab signing-spec (sometimes
+abbreviated SSL Siging spec.
+https://github.com/secure-systems-lab/signing-spec
+*/
+package ssl
+
+/*
+Verifier verifies a complete message against a signature and key.
+If the message was hashed prior to signature generation, the verifier
+must perform the same steps.
+If the key is not recognized ErrUnknownKey shall be returned.
+*/
+type Verifier interface {
+	Verify(keyID string, data, sig []byte) (bool, error)
+}
+
+type EnvelopeVerifier struct {
+	providers []Verifier
+}
+
+func (ev *EnvelopeVerifier) Verify(e *Envelope) (bool, error) {
+	if len(e.Signatures) == 0 {
+		return false, ErrNoSignature
+	}
+
+	// Decode payload (i.e serialized body)
+	body, err := b64Decode(e.Payload)
+	if err != nil {
+		return false, err
+	}
+	// Generate PAE(payloadtype, serialized body)
+	paeEnc, err := PAE([][]byte{
+		[]byte(e.PayloadType),
+		body,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	// If *any* signature is found to be incorrect, the entire verification
+	// step fails even if *some* signatures are correct.
+	verified := false
+	for _, s := range e.Signatures {
+		sig, err := b64Decode(s.Sig)
+		if err != nil {
+			return false, err
+		}
+
+		// Loop over the providers. If a provider recognizes the key, we exit
+		// the loop and use the result.
+		for _, v := range ev.providers {
+			ok, err := v.Verify(s.KeyID, paeEnc, sig)
+			if err != nil {
+				if err == ErrUnknownKey {
+					continue
+				}
+				return false, err
+			}
+
+			if !ok {
+				return false, nil
+			}
+
+			verified = true
+			break
+		}
+	}
+
+	return verified, nil
+}
+
+func NewEnvelopeVerifier(p ...Verifier) EnvelopeVerifier {
+	ev := EnvelopeVerifier{
+		providers: p,
+	}
+	return ev
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -324,9 +324,10 @@ github.com/hashicorp/vault/sdk/helper/strutil
 github.com/howeyc/gopass
 # github.com/imdario/mergo v0.3.9
 github.com/imdario/mergo
-# github.com/in-toto/in-toto-golang v0.1.1-0.20210505200736-471bd79ebd18
+# github.com/in-toto/in-toto-golang v0.1.1-0.20210528150343-f7dc21abaccf
 ## explicit
 github.com/in-toto/in-toto-golang/in_toto
+github.com/in-toto/in-toto-golang/pkg/ssl
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/jedisct1/go-minisign v0.0.0-20210414164026-819d7e2534ac
@@ -421,6 +422,7 @@ github.com/shibumi/go-pathspec
 github.com/sigstore/cosign/pkg/cosign
 github.com/sigstore/cosign/pkg/cosign/remote
 # github.com/sigstore/rekor v0.1.2-0.20210519014330-b5480728bde6
+## explicit
 github.com/sigstore/rekor/cmd/rekor-cli/app
 github.com/sigstore/rekor/cmd/rekor-cli/app/format
 github.com/sigstore/rekor/cmd/rekor-cli/app/state


### PR DESCRIPTION
This is now on by default for the intoto payloads.


Ref #75 