### PR TITLE
Add GCP specific kaniko task

### DIFF
--- a/examples/kaniko/gcp/kaniko.yaml
+++ b/examples/kaniko/gcp/kaniko.yaml
@@ -1,0 +1,68 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kaniko-gcp
+spec:
+  description: >-
+    This Task builds a simple Dockerfile with kaniko and pushes to a registry.
+    This Task stores the image name and digest as results, allowing Tekton Chains to pick up
+    that an image was built & sign it.
+    This task is designed to work with GCP, and push to a GCR registry.
+  params:
+  - name: IMAGE
+    description: Name (reference) of the image to build.
+  - name: DOCKERFILE
+    description: Path to the Dockerfile to build.
+    default: ./Dockerfile
+  - name: CONTEXT
+    description: The build context used by Kaniko.
+    default: ./
+  - name: EXTRA_ARGS
+    default: ""
+  - name: CREDENTIALS_FILE
+    default: "credentials.json"
+  - name: BUILDER_IMAGE
+    description: The image on which builds will run (default is v1.5.1)
+    default: gcr.io/kaniko-project/executor:v1.5.1@sha256:c6166717f7fe0b7da44908c986137ecfeab21f31ec3992f6e128fff8a94be8a5
+  workspaces:
+  - name: source
+    description: Holds the context and Dockerfile
+  - name: credentials
+    optional: true
+    mountPath: /kaniko/credentials
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
+  - name: IMAGE_URL
+    description: URL of the image just built.
+  steps:
+  - name: add-dockerfile
+    workingDir: $(workspaces.source.path)
+    image: bash
+    script: |
+      set -e
+      echo "FROM alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f" | tee $(params.DOCKERFILE)
+  - name: build-and-push
+    workingDir: $(workspaces.source.path)
+    image: $(params.BUILDER_IMAGE)
+    args:
+    - $(params.EXTRA_ARGS)
+    - --dockerfile=$(params.DOCKERFILE)
+    - --context=$(workspaces.source.path)/$(params.CONTEXT)  # The user does not need to care the workspace and the source.
+    - --destination=$(params.IMAGE)
+    - --digest-file=$(results.IMAGE_DIGEST.path)
+    # kaniko assumes it is running as root, which means this example fails on platforms
+    # that default to run containers as random uid (like OpenShift). Adding this securityContext
+    # makes it explicit that it needs to run as root.
+    securityContext:
+      runAsUser: 0
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /kaniko/credentials/$(params.CREDENTIALS_FILE)
+  - name: write-url
+    image: bash
+    script: |
+      set -e
+      echo $(params.IMAGE) | tee $(results.IMAGE_URL.path)
+    securityContext:
+      runAsUser: 0

--- a/examples/kaniko/gcp/taskrun.yaml
+++ b/examples/kaniko/gcp/taskrun.yaml
@@ -1,0 +1,16 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: kaniko-gcp
+spec:
+  taskRef:
+    name: kaniko-gcp
+  params:
+  - name: IMAGE
+    value: <your image>
+  workspaces:
+  - name: source
+    emptyDir: {}
+  - name: credentials
+    secret:
+      secretName: <your credentials secret>


### PR DESCRIPTION
It would be awesome if we could add other providers as well, so that we have a bunch of simple examples for pushing an image & signing with Chains.