### PR TITLE
Add SPIRE verification to chains

### DIFF
--- a/pkg/chains/formats/tekton/tekton.go
+++ b/pkg/chains/formats/tekton/tekton.go
@@ -16,29 +16,41 @@ package tekton
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/spire"
+	"github.com/tektoncd/chains/pkg/config"
+	"go.uber.org/zap"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
 // Tekton is a formatter that just captures the TaskRun Status with no modifications.
 type Tekton struct {
+	logger       *zap.SugaredLogger
+	spireEnabled bool
 }
 
-func NewFormatter() (formats.Payloader, error) {
-	return &Tekton{}, nil
+func NewFormatter(cfg config.Config, l *zap.SugaredLogger) (formats.Payloader, error) {
+	return &Tekton{
+		logger:       l,
+		spireEnabled: cfg.SPIRE.Enabled,
+	}, nil
 }
 
 // CreatePayload implements the Payloader interface.
 func (i *Tekton) CreatePayload(obj interface{}) (interface{}, error) {
-
 	switch v := obj.(type) {
 	case *v1beta1.TaskRun:
+		if i.spireEnabled {
+			if err := spire.Verify(v, i.logger); err != nil {
+				return nil, errors.Wrap(err, "verifying SPIRE")
+			}
+		}
 		return v.Status, nil
 	default:
 		return nil, fmt.Errorf("unsupported type %s", v)
 	}
-
 }
 
 func (i *Tekton) Type() formats.PayloadType {

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -128,7 +128,7 @@ func allFormatters(cfg config.Config, l *zap.SugaredLogger) map[formats.PayloadT
 	for _, f := range formats.AllFormatters {
 		switch f {
 		case formats.PayloadTypeTekton:
-			formatter, err := tekton.NewFormatter()
+			formatter, err := tekton.NewFormatter(cfg, l)
 			if err != nil {
 				l.Warnf("error configuring tekton formatter: %s", err)
 			}

--- a/pkg/chains/spire/spire.go
+++ b/pkg/chains/spire/spire.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spire
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
+)
+
+// Verify checks if the TaskRun has an SVID cert
+// it then verifies the provided signatures against the cert
+func Verify(tr *v1beta1.TaskRun, logger *zap.SugaredLogger) error {
+	results := tr.Status.TaskRunResults
+	if err := validateResults(results, logger); err != nil {
+		return errors.Wrap(err, "validating results")
+	}
+	logger.Info("Successfully verified all results against SPIRE")
+	return nil
+}
+
+func validateResults(rs []v1beta1.TaskRunResult, logger *zap.SugaredLogger) error {
+	resultMap := map[string]v1beta1.TaskRunResult{}
+	for _, r := range rs {
+		resultMap[r.Name] = r
+	}
+	svid, ok := resultMap["SVID"]
+	if !ok {
+		return errors.New("No SVID found")
+	}
+	block, _ := pem.Decode([]byte(svid.Value))
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("invalid SVID: %s", err)
+	}
+	var keysToVerify []string
+	for key := range resultMap {
+		if strings.HasSuffix(key, ".sig") || key == "SVID" {
+			continue
+		}
+		keysToVerify = append(keysToVerify, key)
+	}
+
+	if len(keysToVerify) == 0 {
+		return errors.New("no results to validate with SPIRE found")
+	}
+
+	for _, key := range keysToVerify {
+		logger.Infof("Trying to verify result %s against SPIRE", key)
+		if err := verifyKey(cert.PublicKey, key, resultMap); err != nil {
+			return err
+		}
+		logger.Infof("Successfully verified result %s against SPIRE", key)
+
+	}
+	return nil
+}
+
+func verifyKey(pub interface{}, key string, results map[string]v1beta1.TaskRunResult) error {
+	signature, ok := results[key+".sig"]
+	if !ok {
+		return fmt.Errorf("no signature found for %s", key)
+	}
+	b, err := base64.StdEncoding.DecodeString(signature.Value)
+	if err != nil {
+		return fmt.Errorf("invalid signature: %s", err)
+	}
+	h := sha256.Sum256([]byte(results[key].Value))
+	// Check val against sig
+	switch t := pub.(type) {
+	case *ecdsa.PublicKey:
+		if !ecdsa.VerifyASN1(t, h[:], b) {
+			return errors.New("invalid signature")
+		}
+		return nil
+	case *rsa.PublicKey:
+		return rsa.VerifyPKCS1v15(t, crypto.SHA256, h[:], b)
+	case ed25519.PublicKey:
+		if !ed25519.Verify(t, []byte(results[key].Value), b) {
+			return errors.New("invalid signature")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported key type: %s", t)
+	}
+}

--- a/pkg/chains/spire/spire_test.go
+++ b/pkg/chains/spire/spire_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spire
+
+import (
+	"testing"
+
+	logtesting "knative.dev/pkg/logging/testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+func TestVerify(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunResults: []v1beta1.TaskRunResult{
+					{
+						Name:  "SVID",
+						Value: svid,
+					},
+				},
+			},
+		},
+	}
+	logger := logtesting.TestLogger(t)
+	if err := Verify(tr, logger); err == nil {
+		t.Fatal("no results to verify, this should fail")
+	}
+
+	digestTaskRunResults := []v1beta1.TaskRunResult{
+		{
+			Name:  "IMAGE_DIGEST",
+			Value: "sha256:52a9b14f0938cd8b0b1bc29776fb52b6f108ee47363a572d5d07fbbd3f12e0b3",
+		}, {
+			Name:  "IMAGE_DIGEST.sig",
+			Value: "MEUCIBcrPe52qLou+vDlaJ3sOCi1e1soT7IYbK0Guc8NVcWOAiEAtJDi6mqAY1O3L/AP0fNhWUvqii4bXs+XezGwtHo5VPQ=",
+		},
+	}
+	tr.Status.TaskRunResults = append(tr.Status.TaskRunResults, digestTaskRunResults...)
+	if err := Verify(tr, logger); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const svid = `-----BEGIN CERTIFICATE-----
+MIICtzCCAZ+gAwIBAgIQGaiyrxX0Zvf7Bv+CU123qDANBgkqhkiG9w0BAQsFADAe
+MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGU1BJRkZFMB4XDTIxMDYxNjIwMjcxOVoX
+DTIxMDYxNjIxMjcyOVowHTELMAkGA1UEBhMCVVMxDjAMBgNVBAoTBVNQSVJFMFkw
+EwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENygiz0a2vL2Q0Pg/Sl7I9ab/VX+ZGzjU
+yDlmEA2ANpYlpaR4u8NuhiI7SSajC95aeiRAG7Wv1EHfjcI4fJthuqOBvDCBuTAO
+BgNVHQ8BAf8EBAMCA6gwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAwG
+A1UdEwEB/wQCMAAwHQYDVR0OBBYEFIM3W+xFL1Dn0BQ890zLbq3c/twsMB8GA1Ud
+IwQYMBaAFOgVB4NKkNjLX0KK2nwCAcPYYMDyMDoGA1UdEQQzMDGGL3NwaWZmZTov
+L29pZGMuZGxvcmVuYy5kZXYvbnMvZGVmYXVsdC9zYS9kZWZhdWx0MA0GCSqGSIb3
+DQEBCwUAA4IBAQAp6nRqhULi4mjZ7JIFxrabo0xPCGwCoOXW8IVHYCkyROZXZWrq
+JLHKkxur0iJqjOjhUqXhtGZ/TWdhL0oNEGCBs543dOnBYYYje+41jyPLR4QbKyJg
+juFnBH3xOD0w9hHIkDzTBn7aQmIkETmMzeYFtfFUTAClgi7ATZwm9kGGK82L2oBi
+YuHXBuxBkadO8yKN21tPrNLVMvhGEg9igJgY3Rs6coVwlNBCwINUe6Eql20+exzO
+nz4AZIihdYP9a2W7qpPdiUk7pUvA6i9nepMVBCIY5LXRU5YhD4TSJxOPacwQP6IB
+bQMsVW0vU7HuMxsI/kZZwN4I0knvGThCrMdp
+-----END CERTIFICATE-----`

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -17,6 +17,7 @@ type Config struct {
 	Signers      SignerConfigs
 	Builder      BuilderConfig
 	Transparency TransparencyConfig
+	SPIRE        SPIREConfig
 }
 
 // ArtifactConfig contains the configuration for how to sign/store/format the signatures for each artifact type
@@ -82,6 +83,10 @@ type TransparencyConfig struct {
 	URL     string
 }
 
+type SPIREConfig struct {
+	Enabled bool
+}
+
 const (
 	taskrunFormatKey  = "artifacts.taskrun.format"
 	taskrunStorageKey = "artifacts.taskrun.storage"
@@ -108,6 +113,9 @@ const (
 
 	transparencyEnabledKey = "transparency.enabled"
 	transparencyURLKey     = "transparency.url"
+
+	// SPIRE config
+	spireEnabledKey = "spire.enabled"
 
 	chainsConfig = "chains-config"
 )
@@ -157,6 +165,8 @@ func parse(data map[string]string, logger *zap.SugaredLogger) Config {
 
 	cfg.Transparency.Enabled = (valueOrDefault(transparencyEnabledKey, data, logger) == "true")
 	cfg.Transparency.URL = valueOrDefault(transparencyURLKey, data, logger)
+
+	cfg.SPIRE.Enabled = (valueOrDefault(spireEnabledKey, data, logger) == "true")
 
 	cfg.Signers.KMS.KMSRef = valueOrDefault(kmsSignerKMSRef, data, logger)
 


### PR DESCRIPTION
I might write docs for this later, once we've figured out how we want to provide the entrypointer image with SPIRE support -- I don't think anyone else can really use this right now.