### PR TITLE
Fix docdb behavior on retries

### DIFF
--- a/pkg/chains/storage/docdb/docdb.go
+++ b/pkg/chains/storage/docdb/docdb.go
@@ -77,7 +77,7 @@ func (b *Backend) StorePayload(signed []byte, signature string, key string) erro
 		Name:      key,
 	}
 
-	if err := b.coll.Create(context.Background(), &entry); err != nil {
+	if err := b.coll.Put(context.Background(), &entry); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Replaces `Create` with `Put`, which will create the document if it doesn't exist or replace it if it does.

Now, on retries, this storage backend shouldn't fail if the document already exists. This also mimics what we do in other storage backends.

fixes https://github.com/tektoncd/chains/issues/100