### PR TITLE
Structure the reconciler in a more consistent fashion.

### DIFF
--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
+
+import (
+	"context"
+
+	"github.com/tektoncd/chains/pkg/chains"
+	"github.com/tektoncd/chains/pkg/config"
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
+	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/taskrun"
+	"k8s.io/client-go/tools/cache"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/system"
+)
+
+func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	// TODO: store and use the cmw
+	logger := logging.FromContext(ctx)
+	taskRunInformer := taskruninformer.Get(ctx)
+	kubeclientset := kubeclient.Get(ctx)
+	pipelineclientset := pipelineclient.Get(ctx)
+	cfgStore, err := config.NewConfigStore(ctx, kubeclientset, system.Namespace(), logger)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	c := &Reconciler{
+		KubeClientSet:     kubeclientset,
+		PipelineClientSet: pipelineclientset,
+		Logger:            logger,
+		TaskRunLister:     taskRunInformer.Lister(),
+		TaskRunSigner: &chains.TaskRunSigner{
+			Pipelineclientset: pipelineclientset,
+			Logger:            logger,
+			SecretPath:        SecretPath,
+			ConfigStore:       cfgStore,
+		},
+	}
+	impl := controller.NewImpl(c, c.Logger, "chains")
+
+	taskRunInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    impl.Enqueue,
+		UpdateFunc: controller.PassNew(impl.Enqueue),
+	})
+
+	return impl
+}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package taskrun
 
 import (
 	"context"

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1,4 +1,17 @@
-package controller
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
 
 import (
 	"context"


### PR DESCRIPTION
The general layout followed by Knative-style controllers is to have:
  `pkg/reconciler/{resource name}/`

Then within that the reconciler logic lives within `{resource name}.go` and the logic to wrap that in a `controller.Impl` lives within `controller.go`

This PR should be purely organizational without any semantic changes.

/assign @dlorenc 
/kind cleanup