### PR TITLE
Add IMAGES results type, to be used for releases

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -17,6 +17,15 @@ For example, if **both** `MYIMAGE_IMAGE_URL` AND `MYIMAGE_IMAGE_DIGEST` are corr
 
 Multiple images can be specified by using different prefixes in place of `*`.
 
+Multiple images can also be specified by using the `IMAGES` Result.
+The value of the `IMAGES` result is a list of comma-separates images, each qualified by digest.
+
+```
+- name: IMAGES
+  value: img1@sha256:digest1, img2@sha256:digest2
+```
+
+Chains will parse through the list and sign each image.
 
 For in-toto attestations, see [INTOTO.md](INTOTO.md) for description
 of in-toto specific type hinting.

--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -144,6 +144,27 @@ func ExtractOCIImagesFromResults(tr *v1beta1.TaskRun, logger *zap.SugaredLogger)
 			objs = append(objs, dgst)
 		}
 	}
+
+	// look for a comma separated list of images
+	for _, key := range tr.Status.TaskRunResults {
+		if key.Name != "IMAGES" {
+			continue
+		}
+		imgs := strings.Split(key.Value, ",")
+		for _, img := range imgs {
+			trimmed := strings.TrimSpace(img)
+			if trimmed == "" {
+				continue
+			}
+			dgst, err := name.NewDigest(trimmed)
+			if err != nil {
+				logger.Errorf("error getting digest for img %s: %v", trimmed, err)
+				continue
+			}
+			objs = append(objs, dgst)
+		}
+	}
+
 	return objs
 }
 

--- a/pkg/artifacts/signable_test.go
+++ b/pkg/artifacts/signable_test.go
@@ -233,6 +233,24 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 				},
 			},
 			want: []interface{}{digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
+		}, {
+			name: "images",
+			tr: &v1beta1.TaskRun{
+				Status: v1beta1.TaskRunStatus{
+					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+						TaskRunResults: []v1beta1.TaskRunResult{
+							{
+								Name:  "IMAGES",
+								Value: fmt.Sprintf("  \n \tgcr.io/foo/bar@%s\n,gcr.io/baz/bar@%s", digest1, digest2),
+							},
+						},
+					},
+				},
+			},
+			want: []interface{}{
+				digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"),
+				digest(t, "gcr.io/baz/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"),
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This way, we can easily specify all of the images built during the release build process, and chains can sign all of them