### PR TITLE
Save all images built during release process as a result

### DIFF
--- a/pkg/chains/provenance/provenance.go
+++ b/pkg/chains/provenance/provenance.go
@@ -60,7 +60,7 @@ type ProvenanceMetadata struct {
 	BuildStartedOn  *time.Time `json:"buildStartedOn,omitempty"`
 	BuildFinishedOn *time.Time `json:"buildFinishedOn,omitempty"`
 	// removed: Completeness
-	Reproducible bool `json:"reproducible"`
+	Reproducible bool `json:"reproducible,omitempty"`
 }
 
 // ProvenanceMaterial defines the materials used to build an artifact.

--- a/release/publish.yaml
+++ b/release/publish.yaml
@@ -29,6 +29,8 @@ spec:
     default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
   - name: serviceAccountPath
     description: The name of the service account path within the release-secret workspace
+  results:
+  - name: IMAGES
   workspaces:
   - name: source
     description: >-
@@ -161,6 +163,8 @@ spec:
         IMAGE_WITHOUT_SHA_AND_TAG=${IMAGE_WITHOUT_SHA%%:*}
         IMAGE_WITH_SHA=${IMAGE_WITHOUT_SHA_AND_TAG}@${IMAGE##*@}
 
+        echo $IMAGE_WITH_SHA, >> $(results.IMAGES.path)
+
         if [[ "$(params.releaseAsLatest)" == "true" ]]
         then
           crane cp ${IMAGE_WITH_SHA} ${IMAGE_WITHOUT_SHA_AND_TAG}:latest
@@ -177,6 +181,7 @@ spec:
           else
             TAG="$(params.versionTag)"
             crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
+            echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
           fi
         done
       done


### PR DESCRIPTION
save as comma separated result so chains can pick it up and sign each image

also, omit the reproducible annotation until we can figure out how to set it