### PR TITLE
Change the ServiceAccount identity used for OCI storage backend.

### DIFF
--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -29,7 +29,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
-	"knative.dev/pkg/system"
 )
 
 const (
@@ -49,7 +48,7 @@ type Backend struct {
 // NewStorageBackend returns a new OCI StorageBackend that stores signatures in an OCI registry
 func NewStorageBackend(logger *zap.SugaredLogger, client kubernetes.Interface, tr *v1beta1.TaskRun, cfg config.Config) (*Backend, error) {
 	kc, err := k8schain.New(context.TODO(), client,
-		k8schain.Options{Namespace: system.Namespace(), ServiceAccountName: "tekton-chains-controller"})
+		k8schain.Options{Namespace: tr.Namespace, ServiceAccountName: tr.Spec.ServiceAccountName})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Rather than hardcoding the chains controller as the service account identity used for OCI-based signing, use the task's service account identity.

This should just simplify things because users are already configuring the Task with credentials to push the image, but currently need to grant access to the chains controller as well.

Fixes: #161

```release-notes
The chains controller now uses the taskrun's serviceAccountName for credentials when using OCI storage, instead of the chains controller's service account.
```


WIP until https://github.com/tektoncd/chains/pull/162 lands