### PR TITLE
Fix auth bug for pushing images in release pipeline

### DIFF
--- a/release/publish.yaml
+++ b/release/publish.yaml
@@ -92,7 +92,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       # Change to directory with our .ko.yaml
       cd ${PROJECT_ROOT}
@@ -152,7 +152,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       REGIONS="us eu asia"
 


### PR DESCRIPTION
I think pushing images was failing because credentials weren't stored at the expected `~/.docker/config.json` path

this also now matches how triggers does auth for releases:
https://github.com/tektoncd/triggers/blob/main/tekton/publish.yaml#L95