### PR TITLE
Add manual option for uploads to transparency log

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -82,9 +82,15 @@ Supported keys include:
 
 | Key | Description | Supported Values | Default |
 | :--- | :--- | :--- | :--- |
-| `transparency.enabled` | EXPERIMENTAL. Whether to enable automatic binary transparency uploads. | `true`, `false` | `false` |
+| `transparency.enabled` | EXPERIMENTAL. Whether to enable automatic binary transparency uploads. | `true`, `false`, `manual` | `false` |
 | `transparency.url` | EXPERIMENTAL. The URL to upload binary transparency attestations to, if enabled. | |`https://rekor.sigstore.dev`|
 
+
+**Note**: If `transparency.enabled` is set to `manual`, then only TaskRuns with the following annotation will be uploaded to the transparency log:
+
+```yaml
+chains.tekton.dev/transparency-upload: "true"
+```
 
 #### Keyless Signing with Fulcio
 

--- a/pkg/chains/rekor_test.go
+++ b/pkg/chains/rekor_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chains
+
+import (
+	"testing"
+
+	"github.com/tektoncd/chains/pkg/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestShouldUploadTlog(t *testing.T) {
+	tests := []struct {
+		description string
+		cfg         config.TransparencyConfig
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			description: "transparency disabled",
+			cfg: config.TransparencyConfig{
+				Enabled:          false,
+				VerifyAnnotation: true,
+			},
+			annotations: map[string]string{RekorAnnotation: "true"},
+			expected:    false,
+		},
+		{
+			description: "transparency enabled, verify annotation disabled",
+			cfg: config.TransparencyConfig{
+				Enabled:          true,
+				VerifyAnnotation: false,
+			},
+			expected: true,
+		},
+		{
+			description: "annotation doesn't exist",
+			cfg: config.TransparencyConfig{
+				Enabled:          true,
+				VerifyAnnotation: true,
+			},
+			annotations: map[string]string{RekorAnnotation: "f"},
+			expected:    false,
+		},
+		{
+			description: "annotation exists",
+			cfg: config.TransparencyConfig{
+				Enabled:          true,
+				VerifyAnnotation: true,
+			},
+			annotations: map[string]string{RekorAnnotation: "true"},
+			expected:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			tr := &v1beta1.TaskRun{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: test.annotations,
+				},
+			}
+			cfg := config.Config{Transparency: test.cfg}
+			got := shouldUploadTlog(cfg, tr)
+			if got != test.expected {
+				t.Fatalf("got (%v) doesn't match expected (%v)", got, test.expected)
+			}
+		})
+	}
+}

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -240,7 +240,7 @@ func (ts *TaskRunSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) e
 				merr = multierror.Append(merr, err)
 			}
 
-			if cfg.Transparency.Enabled {
+			if shouldUploadTlog(cfg, tr) {
 				entry, err := rekorClient.UploadTlog(ctx, signer, signature, rawPayload, signer.Cert(), string(payloadFormat))
 				if err != nil {
 					logger.Error(err)

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -147,6 +147,33 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name: "manual transparency",
+			data: map[string]string{transparencyEnabledKey: "manual"},
+			want: Config{
+				Builder: BuilderConfig{
+					"tekton-chains",
+				},
+				Artifacts: ArtifactConfigs{
+					TaskRuns: Artifact{
+						Format:         "tekton",
+						Signer:         "x509",
+						StorageBackend: "tekton",
+					},
+					OCI: Artifact{
+						Format:         "simplesigning",
+						StorageBackend: "oci",
+						Signer:         "x509",
+					},
+				},
+				Signers: defaultSigners,
+				Transparency: TransparencyConfig{
+					Enabled:          true,
+					VerifyAnnotation: true,
+					URL:              "https://rekor.sigstore.dev",
+				},
+			},
+		},
+		{
 			name: "extra",
 			data: map[string]string{taskrunSignerKey: "x509", "other-key": "foo"},
 			want: Config{

--- a/release/publish.yaml
+++ b/release/publish.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: publish-chains-release
+  annotations:
+    chains.tekton.dev/transparency-upload: "true"
 spec:
   params:
   - name: package

--- a/release/release-pipeline.yaml
+++ b/release/release-pipeline.yaml
@@ -4,6 +4,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: chains-release
+  annotations:
+    chains.tekton.dev/transparency-upload: "true"
 spec:
   params:
   - name: package


### PR DESCRIPTION
When `manual` is specified, then we check for this attestation on the TaskRun before uploading to the tlog:

```yaml
chains.tekton.dev/transparency-upload: true
```

We'll use this for releasing, so that only releases are added to the transparency log, instead of everything that runs in the CI cluster

closes #174 