### PR TITLE
Configure release to include materials section in provenance

### DIFF
--- a/release/publish.yaml
+++ b/release/publish.yaml
@@ -29,6 +29,9 @@ spec:
     default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
   - name: serviceAccountPath
     description: The name of the service account path within the release-secret workspace
+  - name: CHAINS-GIT_COMMIT
+  - name: CHAINS-GIT_URL
+    default: https://github.com/tektoncd/chains
   results:
   - name: IMAGES
   workspaces:

--- a/release/release-pipeline.yaml
+++ b/release/release-pipeline.yaml
@@ -118,6 +118,8 @@ spec:
       value: $(params.platforms)
     - name: serviceAccountPath
       value: $(params.serviceAccountPath)
+    - name: CHAINS-GIT_COMMIT
+      value: $(tasks.git-clone.results.commit)
     workspaces:
     - name: source
       workspace: workarea


### PR DESCRIPTION
Right now info about the git repo isn't included because we aren't using a Git pipeline resource or including the commit/url in the params

this PR updates the release process to include the commit/url as params, which Chains can pick up on to generate the materials section in provenance

closes https://github.com/tektoncd/chains/issues/173