### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod" 
+    directory: "/" 
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Enable dependabot for notification when one of the dependencies has a vulnerability.

This is just the config file. The setting has to be enabled in the Security setting within the repository.