### PR TITLE
add missing recipe_uri in JSON

### DIFF
--- a/PROVENANCE_SPEC.md
+++ b/PROVENANCE_SPEC.md
@@ -28,9 +28,9 @@ If a build pipeline outputs multiple artifacts, each will have its own attestati
   "predicate": {
     "invocation": {
       "parameters": null,
-      "uri": "",
+      "recipe_uri": "",
       "event_id": "",
-      "id": "",
+      "builder.id": "",
     },
     "recipe": {
       "steps": [


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

we (w/@Dentrax) noticed that in the JSON sample within the PROVENANCE_SPEC.md there is a mistake in one of the fields that is `uri` in this case, so it should be `recipe_uri` based on the [Provenance](https://github.com/tektoncd/chains/blob/dc031abd87a97838b4521d1cfd8abd01014d9195/pkg/chains/provenance/provenance.go#L39) struct.