### PR TITLE
Add chains finalizer to taskruns.

### DIFF
--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -46,6 +46,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 			// The chains reconciler shouldn't mutate the taskrun's status.
 			SkipStatusUpdates: true,
 			ConfigStore:       cfgStore,
+			FinalizerName:     "chains.tekton.dev",
 		}
 	})
 


### PR DESCRIPTION
This reduces a race condition where the chains controller might not observe the final state of a TaskRun before it is cleaned up.  By installing a finalizer, we ensure (within the KRM) that our controller has a crack at seeing the final state prior to deletion.

Fixes: https://github.com/tektoncd/chains/issues/181

/king bug
cc @priyawadhwa @dlorenc 