### PR TITLE
Try to sign a TaskRun a maximum of 3 times

### DIFF
--- a/pkg/chains/annotations.go
+++ b/pkg/chains/annotations.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chains
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/tektoncd/chains/pkg/patch"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// ChainsAnnotation is the standard annotation to indicate a TR has been signed.
+	ChainsAnnotation             = "chains.tekton.dev/signed"
+	RetryAnnotation              = "chains.tekton.dev/retries"
+	ChainsTransparencyAnnotation = "chains.tekton.dev/transparency"
+	MaxRetries                   = 3
+)
+
+// Reconciled determines whether a TaskRun has already passed through the reconcile loops, up to 3x
+func Reconciled(tr *v1beta1.TaskRun) bool {
+	val, ok := tr.ObjectMeta.Annotations[ChainsAnnotation]
+	if !ok {
+		return false
+	}
+	return val == "true" || val == "failed"
+}
+
+// MarkSigned marks a TaskRun as signed.
+func MarkSigned(tr *v1beta1.TaskRun, ps versioned.Interface, annotations map[string]string) error {
+	if _, ok := tr.Annotations[ChainsAnnotation]; ok {
+		return nil
+	}
+	return AddAnnotation(tr, ps, ChainsAnnotation, "true", annotations)
+}
+
+func MarkFailed(tr *v1beta1.TaskRun, ps versioned.Interface, annotations map[string]string) error {
+	return AddAnnotation(tr, ps, ChainsAnnotation, "failed", annotations)
+}
+
+func RetryAvailable(tr *v1beta1.TaskRun) bool {
+	retries, ok := tr.Annotations[RetryAnnotation]
+	if !ok {
+		return true
+	}
+	val, err := strconv.Atoi(retries)
+	if err != nil {
+		return false
+	}
+	return val < MaxRetries
+}
+
+func AddRetry(tr *v1beta1.TaskRun, ps versioned.Interface, annotations map[string]string) error {
+	retries := tr.Annotations[RetryAnnotation]
+	if retries == "" {
+		return AddAnnotation(tr, ps, RetryAnnotation, "0", annotations)
+	}
+	val, err := strconv.Atoi(retries)
+	if err != nil {
+		return errors.Wrap(err, "adding retry")
+	}
+	return AddAnnotation(tr, ps, RetryAnnotation, fmt.Sprintf("%d", val+1), annotations)
+}
+
+func AddAnnotation(tr *v1beta1.TaskRun, ps versioned.Interface, key, value string, annotations map[string]string) error {
+	// Use patch instead of update to help prevent race conditions.
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[key] = value
+	patchBytes, err := patch.GetAnnotationsPatch(annotations)
+	if err != nil {
+		return err
+	}
+	if _, err := ps.TektonV1beta1().TaskRuns(tr.Namespace).Patch(
+		context.TODO(), tr.Name, types.MergePatchType, patchBytes, v1.PatchOptions{}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/chains/annotations_test.go
+++ b/pkg/chains/annotations_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2020 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chains
+
+import (
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestReconciled(t *testing.T) {
+	tests := []struct {
+		name       string
+		annotation string
+		want       bool
+	}{
+		{
+			name:       "signed",
+			want:       true,
+			annotation: "true",
+		},
+		{
+			name:       "signed",
+			want:       true,
+			annotation: "failed",
+		},
+		{
+			name:       "signed with other string",
+			want:       false,
+			annotation: "baz",
+		},
+		{
+			name:       "not signed",
+			want:       false,
+			annotation: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ChainsAnnotation: tt.annotation,
+					},
+				},
+			}
+			got := Reconciled(tr)
+			if got != tt.want {
+				t.Errorf("Reconciled() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryAvailble(t *testing.T) {
+
+	tests := []struct {
+		description string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			description: "no annotation set",
+			expected:    true,
+		}, {
+			description: "annotation < 3",
+			annotations: map[string]string{
+				RetryAnnotation: "2",
+			},
+			expected: true,
+		}, {
+			description: "annotation not a number",
+			annotations: map[string]string{
+				RetryAnnotation: "sfd",
+			},
+		}, {
+			description: "annotation is 3",
+			annotations: map[string]string{
+				RetryAnnotation: "3",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			tr := &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: test.annotations,
+				},
+			}
+			got := RetryAvailable(tr)
+			if got != test.expected {
+				t.Fatalf("RetryAvailble() got %v expected %v", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestAddRetry(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	c := fakepipelineclient.Get(ctx)
+
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "mytaskrun"},
+	}
+	if _, err := c.TektonV1beta1().TaskRuns(tr.Namespace).Create(ctx, tr, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// run it through AddRetry, make sure annotation is added
+	if err := AddRetry(tr, c, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	signed, err := c.TektonV1beta1().TaskRuns(tr.Namespace).Get(ctx, tr.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Get() error = %v", err)
+	}
+
+	if val, ok := signed.Annotations[RetryAnnotation]; !ok || val != "0" {
+		t.Fatalf("annotation isn't correct: %v %v", ok, val)
+	}
+
+	// run it again, make sure we see an increase
+	if err := AddRetry(signed, c, nil); err != nil {
+		t.Fatal(err)
+	}
+	signed, err = c.TektonV1beta1().TaskRuns(tr.Namespace).Get(ctx, tr.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Get() error = %v", err)
+	}
+	if val, ok := signed.Annotations[RetryAnnotation]; val != "1" {
+		t.Fatalf("annotation isn't correct: %v %v", ok, val)
+	}
+}

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -86,45 +86,6 @@ func TestMarkSigned(t *testing.T) {
 	}
 }
 
-func TestIsSigned(t *testing.T) {
-	tests := []struct {
-		name       string
-		annotation string
-		want       bool
-	}{
-		{
-			name:       "signed",
-			want:       true,
-			annotation: "true",
-		},
-		{
-			name:       "signed with other string",
-			want:       false,
-			annotation: "baz",
-		},
-		{
-			name:       "not signed",
-			want:       false,
-			annotation: "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tr := &v1beta1.TaskRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						ChainsAnnotation: tt.annotation,
-					},
-				},
-			}
-			got := IsSigned(tr)
-			if got != tt.want {
-				t.Errorf("IsSigned() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestTaskRunSigner_SignTaskRun(t *testing.T) {
 	// SignTaskRun does three main things:
 	// - generates payloads
@@ -203,8 +164,8 @@ func TestTaskRunSigner_SignTaskRun(t *testing.T) {
 			}
 			// Check it is marked as signed
 			shouldBeSigned := !tt.wantErr
-			if IsSigned(tr) != shouldBeSigned {
-				t.Errorf("IsSigned()=%t, wanted %t", IsSigned(tr), shouldBeSigned)
+			if Reconciled(tr) != shouldBeSigned {
+				t.Errorf("IsSigned()=%t, wanted %t", Reconciled(tr), shouldBeSigned)
 			}
 			// Check the payloads were stored in all the backends.
 			for _, b := range tt.backends {

--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -86,7 +86,14 @@ func (b *Backend) StorePayload(rawPayload []byte, signature string, storageOpts 
 	if err != nil {
 		return errors.Wrap(err, "parsing digest")
 	}
-	cosignDst := cosign.AttachedImageTag(ref.Repository, dgst, cosign.SignatureTagSuffix)
+	repo := ref.Repository
+	if b.cfg.Storage.OCI.Repository != "" {
+		repo, err = name.NewRepository(b.cfg.Storage.OCI.Repository)
+		if err != nil {
+			return errors.Wrapf(err, "%s is not a valid repository", b.cfg.Storage.OCI.Repository)
+		}
+	}
+	cosignDst := cosign.AttachedImageTag(repo, dgst, cosign.SignatureTagSuffix)
 	if err != nil {
 		return errors.Wrap(err, "destination ref")
 	}
@@ -97,7 +104,7 @@ func (b *Backend) StorePayload(rawPayload []byte, signature string, storageOpts 
 	}); err != nil {
 		return errors.Wrap(err, "uploading")
 	}
-	b.logger.Infof("Successfully uploaded signature for %s", imageName)
+	b.logger.Infof("Successfully uploaded signature for %s to %s", imageName, cosignDst)
 	return nil
 }
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -53,8 +53,8 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, tr *v1beta1.TaskRun) pkgr
 		return nil
 	}
 	// Check to see if it has already been signed.
-	if signing.IsSigned(tr) {
-		logging.FromContext(ctx).Infof("taskrun %s/%s has already been signed", tr.Namespace, tr.Name)
+	if signing.Reconciled(tr) {
+		logging.FromContext(ctx).Infof("taskrun %s/%s has been reconciled", tr.Namespace, tr.Name)
 		return nil
 	}
 

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -84,6 +84,11 @@ func waitForCondition(ctx context.Context, t *testing.T, c pipelineclientset.Int
 	}
 }
 
+func failed(tr *v1beta1.TaskRun) bool {
+	failed, ok := tr.Annotations["chains.tekton.dev/signed"]
+	return ok && failed == "failed" && tr.Annotations["chains.tekton.dev/retries"] == "3"
+}
+
 func done(tr *v1beta1.TaskRun) bool {
 	return tr.IsDone()
 }


### PR DESCRIPTION
This PR adds support for up to 3 retries per TaskRun, stored as annotations on the TaskRun.

If after 3 tries the TaskRun is still failing, Chains will mark it as failed and stop trying to sign it.

PR also adds unit tests and an integration test that tries to store the signature in a fake registry, and should be marked as failed after 3 retries.

fixes #191 
fixes #206 
fixes #204 
