### PR TITLE
Drop GCS storage backend from unit testing.

### DIFF
--- a/pkg/chains/storage/storage_test.go
+++ b/pkg/chains/storage/storage_test.go
@@ -31,22 +31,14 @@ func TestInitializeBackends(t *testing.T) {
 		name string
 		cfg  config.Config
 		want []string
-	}{
-		{
-			name: "none",
-			want: []string{},
-		},
-		{
-			name: "tekton",
-			want: []string{"tekton"},
-			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: "tekton"}}},
-		},
-		{
-			name: "gcs",
-			want: []string{"gcs"},
-			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: "gcs"}}},
-		},
-	}
+	}{{
+		name: "none",
+		want: []string{},
+	}, {
+		name: "tekton",
+		want: []string{"tekton"},
+		cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: "tekton"}}},
+	}}
 	logger := logtesting.TestLogger(t)
 	ctx, _ := rtesting.SetupFakeContext(t)
 	ps := fakepipelineclient.Get(ctx)


### PR DESCRIPTION
The GCS storage backend checks auth when it is initialized, which only works if GCP auth is available in the execution environment (e.g. GCE, GCB), and fails if not (e.g. locally, github actions).

I'm attempting to add a "downstream test" to knative/pkg which runs the downstream unit tests on actions after updating PKG and codegen, but with this test things currently fail: https://github.com/knative/pkg/pull/2237

Fixes: https://github.com/tektoncd/chains/issues/211

/kind bug
/assign @priyawadhwa @dlorenc 