### PR TITLE
Switch the linter from golint to revive.

### DIFF
--- a/.golang-ci.yaml
+++ b/.golang-ci.yaml
@@ -7,7 +7,7 @@ linters-settings:
     - goimports
     - gosec
     - gocritic
-    - golint
+    - revive
   output:
     uniq-by-line: false
   issues:


### PR DESCRIPTION
golint is deprecated and archived, golangci-lint now recommends
switching to revive. There are no new lint errors, so it's a simple
bump.

Signed-off-by: Dan Lorenc <dlorenc@google.com>