### PR TITLE
Fix bug in storing attestations in OCI registry

### DIFF
--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -157,7 +157,7 @@ func (b *Backend) uploadAttestation(attestation in_toto.Statement, rawPayload []
 		if err != nil {
 			return errors.Wrapf(err, "destination ref for %s", imageName)
 		}
-		if _, err = cremote.UploadSignature([]byte(signature), rawPayload, attRef, cremote.UploadOpts{
+		if _, err = cremote.UploadSignature([]byte{}, []byte(signature), attRef, cremote.UploadOpts{
 			RemoteOpts: []remote.Option{b.auth},
 			Cert:       []byte(storageOpts.Cert),
 			Chain:      []byte(storageOpts.Chain),


### PR DESCRIPTION
`cosign verify-attestation` wasn't working because attestations weren't being uploaded correctly, this should fix it 