### PR TITLE
Check task status params to create materials for provenance

### DIFF
--- a/pkg/chains/formats/provenance/provenance.go
+++ b/pkg/chains/formats/provenance/provenance.go
@@ -280,6 +280,18 @@ func gitInfo(tr *v1beta1.TaskRun) (commit string, url string) {
 			url = p.Value.StringVal
 		}
 	}
+	if tr.Status.TaskSpec == nil {
+		return
+	}
+	for _, p := range tr.Status.TaskSpec.Params {
+		if p.Name == commitParam {
+			commit = p.Default.StringVal
+			continue
+		}
+		if p.Name == urlParam {
+			url = p.Default.StringVal
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
For tasks that were referenced in TaskRuns, we were missing these params and the `materials` section wasn't getting filled in correctly.

fixes https://github.com/tektoncd/chains/issues/217