### PR TITLE
Simplify looking up the RekorAnnotation, add Unit Test for HandleRetry failure

### DIFF
--- a/pkg/chains/rekor.go
+++ b/pkg/chains/rekor.go
@@ -95,10 +95,5 @@ func shouldUploadTlog(cfg config.Config, tr *v1beta1.TaskRun) bool {
 		return false
 	}
 	// verify the annotation
-	for k, v := range tr.Annotations {
-		if k == RekorAnnotation && v == "true" {
-			return true
-		}
-	}
-	return false
+	return tr.Annotations[RekorAnnotation] == "true"
 }


### PR DESCRIPTION
Simplify looking up the RekorAnnotation, no need for a for loop.

Add a unit test for making sure that if the retry has been exceeded
the TaskRun gets marked as failed.