### PR TITLE
Fix bug in transparency log uploads

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -179,8 +179,8 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		asBool(ociRepositoryInsecureKey, &cfg.Storage.OCI.Insecure),
 		asString(docDBUrlKey, &cfg.Storage.DocDB.URL),
 
-		asBool(transparencyEnabledKey, &cfg.Transparency.Enabled, "manual"),
-		asBool(transparencyEnabledKey, &cfg.Transparency.VerifyAnnotation, "manual"),
+		oneOf(transparencyEnabledKey, &cfg.Transparency.Enabled, "true", "manual"),
+		oneOf(transparencyEnabledKey, &cfg.Transparency.VerifyAnnotation, "manual"),
 		asString(transparencyURLKey, &cfg.Transparency.URL),
 
 		asString(kmsSignerKMSRef, &cfg.Signers.KMS.KMSRef),
@@ -203,9 +203,28 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 	return NewConfigFromMap(configMap.Data)
 }
 
+// oneOf sets target to true if it maches any of the values
+func oneOf(key string, target *bool, values ...string) cm.ParseFunc {
+	return func(data map[string]string) error {
+		raw, ok := data[key]
+		if !ok {
+			return nil
+		}
+		if values == nil {
+			return nil
+		}
+		for _, v := range values {
+			if v == raw {
+				*target = true
+			}
+		}
+		return nil
+	}
+}
+
 // allow additional supported values for a "true" decision
 // in additional to the usual ones provided by strconv.ParseBool
-func asBool(key string, target *bool, values ...string) cm.ParseFunc {
+func asBool(key string, target *bool) cm.ParseFunc {
 	return func(data map[string]string) error {
 		raw, ok := data[key]
 		if !ok {
@@ -215,13 +234,6 @@ func asBool(key string, target *bool, values ...string) cm.ParseFunc {
 		if err == nil {
 			*target = val
 			return nil
-		}
-		if len(values) > 0 {
-			for _, v := range values {
-				if v == raw {
-					*target = true
-				}
-			}
 		}
 		return nil
 	}

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -231,6 +231,71 @@ func TestParse(t *testing.T) {
 					URL: "https://rekor.sigstore.dev",
 				},
 			},
+		}, {
+			name: "rekor - true",
+			data: map[string]string{
+				"transparency.enabled": "true",
+			},
+			want: Config{
+				Builder: BuilderConfig{
+					"tekton-chains",
+				},
+				Artifacts: ArtifactConfigs{
+					TaskRuns: Artifact{
+						Format:         "tekton",
+						Signer:         "x509",
+						StorageBackend: "tekton",
+					},
+					OCI: Artifact{
+						Format:         "simplesigning",
+						StorageBackend: "oci",
+						Signer:         "x509",
+					},
+				},
+				Signers: SignerConfigs{
+					X509: X509Signer{
+						FulcioAuth: "google",
+						FulcioAddr: "https://fulcio.sigstore.dev",
+					},
+				},
+				Transparency: TransparencyConfig{
+					Enabled: true,
+					URL:     "https://rekor.sigstore.dev",
+				},
+			},
+		}, {
+			name: "rekor - manual",
+			data: map[string]string{
+				"transparency.enabled": "manual",
+			},
+			want: Config{
+				Builder: BuilderConfig{
+					"tekton-chains",
+				},
+				Artifacts: ArtifactConfigs{
+					TaskRuns: Artifact{
+						Format:         "tekton",
+						Signer:         "x509",
+						StorageBackend: "tekton",
+					},
+					OCI: Artifact{
+						Format:         "simplesigning",
+						StorageBackend: "oci",
+						Signer:         "x509",
+					},
+				},
+				Signers: SignerConfigs{
+					X509: X509Signer{
+						FulcioAuth: "google",
+						FulcioAddr: "https://fulcio.sigstore.dev",
+					},
+				},
+				Transparency: TransparencyConfig{
+					Enabled:          true,
+					VerifyAnnotation: true,
+					URL:              "https://rekor.sigstore.dev",
+				},
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
If `transparency.enabled=true`, we were setting both transparency.Enabled and transparency.VerifyAnnotation to true. transparency.VerifyAnnotation should only be true if `transparency.enabled=manual`.

This should fix the bug.

fixes https://github.com/tektoncd/chains/issues/221