### PR TITLE
Make sure released images in mirrors are signed

### DIFF
--- a/release/publish.yaml
+++ b/release/publish.yaml
@@ -199,7 +199,7 @@ spec:
           else
             TAG="$(params.versionTag)"
             crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
-            echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
           fi
+          echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
         done
       done


### PR DESCRIPTION
We weren't signing these if `releaseAsLatest=true`, which is on by default for releases.

ref #241 