### PR TITLE
Fix bug uploading slsa-provenance attestations to oci

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v0.22.1
 	k8s.io/code-generator v0.22.1
+	k8s.io/utils v0.0.0-20210802155522-efc7438f0176
 	knative.dev/pkg v0.0.0-20210908025933-71508fc69a57
 )
 

--- a/pkg/chains/formats/provenance/provenance.go
+++ b/pkg/chains/formats/provenance/provenance.go
@@ -66,7 +66,7 @@ func (i *Provenance) CreatePayload(obj interface{}) (interface{}, error) {
 	default:
 		return nil, fmt.Errorf("intoto does not support type: %s", v)
 	}
-	subjects := getSubjectDigests(tr, i.logger)
+	subjects := GetSubjectDigests(tr, i.logger)
 	att, err := i.generateProvenanceFromSubject(tr, subjects)
 	if err != nil {
 		return nil, errors.Wrapf(err, "generating provenance for subject %s", subjects)
@@ -295,7 +295,7 @@ func gitInfo(tr *v1beta1.TaskRun) (commit string, url string) {
 	return
 }
 
-// getSubjectDigests depends on taskResults with names ending with
+// GetSubjectDigests depends on taskResults with names ending with
 // _DIGEST.
 // To be able to find the resource that matches the digest, it relies on a
 // naming schema for an input parameter.
@@ -308,7 +308,7 @@ func gitInfo(tr *v1beta1.TaskRun) (commit string, url string) {
 // Digests can be on two formats: $alg:$digest (commonly used for container
 // image hashes), or $alg:$digest $path, which is used when a step is
 // calculating a hash of a previous step.
-func getSubjectDigests(tr *v1beta1.TaskRun, logger *zap.SugaredLogger) []in_toto.Subject {
+func GetSubjectDigests(tr *v1beta1.TaskRun, logger *zap.SugaredLogger) []in_toto.Subject {
 	var subjects []in_toto.Subject
 
 	imgs := artifacts.ExtractOCIImagesFromResults(tr, logger)

--- a/pkg/chains/formats/provenance/provenance_test.go
+++ b/pkg/chains/formats/provenance/provenance_test.go
@@ -307,7 +307,7 @@ func TestGetSubjectDigests(t *testing.T) {
 			},
 		},
 	}
-	got := getSubjectDigests(tr, logtesting.TestLogger(t))
+	got := GetSubjectDigests(tr, logtesting.TestLogger(t))
 	if !reflect.DeepEqual(expected, got) {
 		if d := cmp.Diff(expected, got); d != "" {
 			t.Log(d)

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -95,7 +95,7 @@ func allFormatters(cfg config.Config, l *zap.SugaredLogger) map[formats.PayloadT
 			}
 			all[f] = formatter
 		case formats.PayloadTypeInTotoIte6:
-			formatter, err := intotoite6.NewFormatter(cfg)
+			formatter, err := intotoite6.NewFormatter(cfg, l)
 			if err != nil {
 				l.Warnf("error configuring intoto formatter: %s", err)
 			}

--- a/test/testdata/intoto/task-output-image.json
+++ b/test/testdata/intoto/task-output-image.json
@@ -1,7 +1,14 @@
 {
     "_type": "https://in-toto.io/Statement/v0.1",
     "predicateType": "https://slsa.dev/provenance/v0.1",
-    "subject": null,
+    "subject": [
+        {
+            "name": "gcr.io/foo/bar",
+            "digest": {
+                "sha256": "05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"
+            }
+        }
+    ],
     "predicate": {
         "builder": {
             "id": "tekton-chains"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1757,6 +1757,7 @@ k8s.io/kube-openapi/pkg/util/proto
 k8s.io/legacy-cloud-providers/azure/auth
 k8s.io/legacy-cloud-providers/gce/gcpcredential
 # k8s.io/utils v0.0.0-20210802155522-efc7438f0176
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer


### PR DESCRIPTION
We were incorrectly parsing the image name because the subject wasn't in the OCI image reference format.

Based on docs, I think that is an acceptable format for these attestations, so I'm switching it to match the tekton-provenance subjects. This should fix the bug.

Fixes https://github.com/tektoncd/chains/issues/253