### PR TITLE
docs: generate keypair using k8s://foo/bar

### DIFF
--- a/docs/signing.md
+++ b/docs/signing.md
@@ -36,7 +36,7 @@ Chains also has the following requirements:
 
 To create a cosign keypair, `cosign.key` and `cosign.pub`, install [cosign](https://github.com/sigstore/cosign) and run the following:
 ```shell
-cosign generate-key-pair tekton-chains/signing-secrets
+cosign generate-key-pair k8s://tekton-chains/signing-secrets
 ```
 
 Cosign will prompt you for a password, and create the Kubernetes secret for you.


### PR DESCRIPTION
Really minor change, but I did think for a few minutes if the keypair was being created in my local directory. Therefore, this makes the location explicit :)