### PR TITLE
fix: look for materials/git metadata in taskrun results too

### DIFF
--- a/pkg/chains/formats/provenance/provenance.go
+++ b/pkg/chains/formats/provenance/provenance.go
@@ -296,7 +296,6 @@ func gitInfo(tr *v1beta1.TaskRun) (commit string, url string) {
 	for _, r := range tr.Status.TaskRunResults {
 		if r.Name == commitParam {
 			commit = r.Value
-			continue
 		}
 		if r.Name == urlParam {
 			url = r.Value

--- a/pkg/chains/formats/provenance/provenance_test.go
+++ b/pkg/chains/formats/provenance/provenance_test.go
@@ -79,7 +79,7 @@ status:
   taskResults:
   - name: CHAINS-GIT_COMMIT
     value: 50c56a48cfb3a5a80fa36ed91c739bdac8381cbe
-  - value: CHAINS-GIT_URL
+  - name: CHAINS-GIT_URL
     value: https://github.com/GoogleContainerTools/distroless`
 
 	var taskRun *v1beta1.TaskRun


### PR DESCRIPTION
Fixes https://github.com/tektoncd/chains/issues/251

If source code metadata is resolved using 'results', ensure the same is consumed for "materials"

Signed-off-by: Shoubhik Bose <shbose@redhat.com>