### PR TITLE
Capture step information in`recipe.arguments` for in-toto/slsa Provenance 

### DIFF
--- a/pkg/chains/formats/intotoite6/intotoite6.go
+++ b/pkg/chains/formats/intotoite6/intotoite6.go
@@ -97,6 +97,7 @@ func (i *InTotoIte6) generateAttestationFromTaskRun(tr *v1beta1.TaskRun) (interf
 			Recipe: intoto.ProvenanceRecipe{
 				Type:       tektonID,
 				EntryPoint: name,
+				Arguments:  provenance.Steps(tr),
 			},
 		},
 	}

--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/provenance"
 	"github.com/tektoncd/chains/pkg/config"
 	"k8s.io/utils/pointer"
 
@@ -193,6 +194,29 @@ var expected1 = in_toto.ProvenanceStatement{
 			Type:              tektonID,
 			EntryPoint:        "test-task",
 			DefinedInMaterial: pointer.Int(0),
+			Arguments: []provenance.RecipeStep{
+				{
+					Arguments: []string(nil),
+					Environment: map[string]interface{}{
+						"container": string("step1"),
+						"image":     string("docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"),
+					},
+				},
+				{
+					Arguments: []string(nil),
+					Environment: map[string]interface{}{
+						"container": string("step2"),
+						"image":     string("docker-pullable://gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"),
+					},
+				},
+				{
+					Arguments: []string(nil),
+					Environment: map[string]interface{}{
+						"container": string("step3"),
+						"image":     string("docker-pullable://gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"),
+					},
+				},
+			},
 		},
 	},
 }
@@ -274,6 +298,15 @@ var expected2 = in_toto.ProvenanceStatement{
 		Recipe: in_toto.ProvenanceRecipe{
 			Type:       tektonID,
 			EntryPoint: "test-task",
+			Arguments: []provenance.RecipeStep{
+				{
+					Arguments: []string(nil),
+					Environment: map[string]interface{}{
+						"container": string("step1"),
+						"image":     string("docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"),
+					},
+				},
+			},
 		},
 	},
 }
@@ -371,6 +404,15 @@ var expectedMultipleSubjects = in_toto.ProvenanceStatement{
 		Recipe: in_toto.ProvenanceRecipe{
 			Type:       tektonID,
 			EntryPoint: "test-task",
+			Arguments: []provenance.RecipeStep{
+				{
+					Arguments: []string(nil),
+					Environment: map[string]interface{}{
+						"container": string("step1"),
+						"image":     string("docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"),
+					},
+				},
+			},
 		},
 	},
 }

--- a/pkg/chains/formats/provenance/provenance.go
+++ b/pkg/chains/formats/provenance/provenance.go
@@ -87,7 +87,7 @@ func (i *Provenance) generateProvenanceFromSubject(tr *v1beta1.TaskRun, subjects
 		Metadata:   metadata(tr),
 		Invocation: invocation(i.builderID, tr),
 		Materials:  materials(tr),
-		Recipe:     recipe(tr),
+		Recipe:     provenance.ProvenanceRecipe{Steps: Steps(tr)},
 	}
 
 	att.Predicate = pred
@@ -220,7 +220,7 @@ func recipeURI(tr *v1beta1.TaskRun) string {
 	return ""
 }
 
-func recipe(tr *v1beta1.TaskRun) provenance.ProvenanceRecipe {
+func Steps(tr *v1beta1.TaskRun) []provenance.RecipeStep {
 	steps := []provenance.RecipeStep{}
 
 	for _, step := range tr.Status.Steps {
@@ -244,7 +244,7 @@ func recipe(tr *v1beta1.TaskRun) provenance.ProvenanceRecipe {
 		// append to all of the steps
 		steps = append(steps, s)
 	}
-	return provenance.ProvenanceRecipe{Steps: steps}
+	return steps
 }
 
 func container(stepState v1beta1.StepState, tr *v1beta1.TaskRun) v1beta1.Step {

--- a/pkg/chains/formats/provenance/provenance_test.go
+++ b/pkg/chains/formats/provenance/provenance_test.go
@@ -238,7 +238,7 @@ status:
 		},
 	}
 
-	got := recipe(taskRun)
+	got := provenance.ProvenanceRecipe{Steps: Steps(taskRun)}
 	if !reflect.DeepEqual(expected, got) {
 		if d := cmp.Diff(expected, got); d != "" {
 			t.Log(d)

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -148,15 +148,28 @@ func expectedProvenance(t *testing.T, example string, tr *v1beta1.TaskRun) intot
 		Entrypoint      string
 		BuildStartedOn  string
 		BuildFinishedOn string
+		ContainerNames  []string
+		StepImages      []string
 	}
+
 	name := tr.Name
 	if tr.Spec.TaskRef != nil {
 		name = tr.Spec.TaskRef.Name
 	}
+
+	var stepNames []string
+	var images []string
+	for _, step := range tr.Status.Steps {
+		stepNames = append(stepNames, step.Name)
+		images = append(images, step.ImageID)
+	}
+
 	f := Format{
 		Entrypoint:      name,
 		BuildStartedOn:  tr.Status.StartTime.Time.UTC().Format(time.RFC3339),
 		BuildFinishedOn: tr.Status.CompletionTime.Time.UTC().Format(time.RFC3339),
+		ContainerNames:  stepNames,
+		StepImages:      images,
 	}
 
 	contents, err := ioutil.ReadFile(path)

--- a/test/testdata/intoto/task-output-image.json
+++ b/test/testdata/intoto/task-output-image.json
@@ -15,7 +15,59 @@
         },
         "recipe": {
             "type": "https://tekton.dev/attestations/chains@v1",
-            "entryPoint": "{{.Entrypoint}}"
+            "entryPoint": "{{.Entrypoint}}",
+            "arguments": [
+                {
+                    "entryPoint": "",
+                    "arguments": null,
+                    "environment":
+                    {
+                        "container": "{{index .ContainerNames 0}}",
+                        "image": "{{index .StepImages 0}}"
+                    },
+                    "annotations": null
+                },
+                {
+                    "entryPoint": "",
+                    "arguments": null,
+                    "environment":
+                    {
+                        "container": "{{index .ContainerNames 1}}",
+                        "image": "{{index .StepImages 1}}"
+                    },
+                    "annotations": null
+                },
+                {
+                    "entryPoint": "set -e\ncat \u003c\u003cEOF \u003e $(inputs.resources.sourcerepo.path)/index.json\n{\n\"schemaVersion\": 2,\n\"manifests\": [\n    {\n    \"mediaType\": \"application/vnd.oci.image.index.v1+json\",\n    \"size\": 314,\n    \"digest\": \"sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5\"\n    }\n]\n}\n",
+                    "arguments": null,
+                    "environment":
+                    {
+                        "container": "{{index .ContainerNames 2}}",
+                        "image": "{{index .StepImages 2}}"
+                    },
+                    "annotations": null
+                },
+                {
+                    "entryPoint": "cat $(inputs.resources.sourcerepo.path)/index.json",
+                    "arguments": null,
+                    "environment":
+                    {
+                        "container": "{{index .ContainerNames 3}}",
+                        "image": "{{index .StepImages 3}}"
+                    },
+                    "annotations": null
+                },
+                {
+                    "entryPoint": "",
+                    "arguments": null,
+                    "environment":
+                    {
+                        "container": "{{index .ContainerNames 4}}",
+                        "image": "{{index .StepImages 4}}"
+                    },
+                    "annotations": null
+                }
+            ]
         },
         "metadata": {
             "buildStartedOn": "{{.BuildStartedOn}}",


### PR DESCRIPTION
POC for #271 for adding further detail into the `environment` for each step within a taksrun. (https://slsa.dev/provenance/v0.1)

`    "recipe": {
      "type": "<URI>",
      "definedInMaterial": /* integer */,
      "entryPoint": "<STRING>",
      "arguments": { /* object */ },
      "environment": { /* object */ }`

This added information would provide more information for each step within the taskrun and capture proper entrypoints for each step. This update would allow for better verfication via` in-toto verify ` in the future. 

