### PR TITLE
Fix URL for entry within annotation

### DIFF
--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -215,7 +215,8 @@ func (ts *TaskRunSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) e
 					merr = multierror.Append(merr, err)
 				} else {
 					logger.Infof("Uploaded entry to %s with index %d", cfg.Transparency.URL, *entry.LogIndex)
-					extraAnnotations[ChainsTransparencyAnnotation] = fmt.Sprintf("%s/%d", cfg.Transparency.URL, *entry.LogIndex)
+
+					extraAnnotations[ChainsTransparencyAnnotation] = fmt.Sprintf("%s/api/v1/log/entries?logIndex=%d", cfg.Transparency.URL, *entry.LogIndex)
 				}
 			}
 		}


### PR DESCRIPTION
This ensures the URL has the correct path to fetch the entry directly.

Fixes #280

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>