### PR TITLE
Add front matter to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
+<!--
+---
+title: "Supply Chain Security"
+linkTitle: "Supply Chain Security"
+weight: 10
+description: >
+  Artifact signatures and attestations for Tekton
+cascade:
+  github_project_repo: https://github.com/tektoncd/chains
+---
+-->
 # Tekton Chains
+
 Supply Chain Security in Tekton Pipelines
 
 <p align="center">
@@ -15,6 +27,7 @@ When `TaskRuns` complete, Chains takes a snapshot of them.
 Chains then converts this snapshot to one or more standard payload formats, signs them and stores them somewhere.
 
 Current features include:
+
 * Signing `TaskRun` results with user provided cryptographic keys, including `TaskRun`s themselves and OCI Images
 * Attestation formats like [intoto](docs/intoto.md)
 * Signing with a variety of cryptograhic key types and services (x509, KMS)
@@ -24,16 +37,19 @@ Current features include:
 Prerequisite: you'll need [Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/main/docs/install.md) installed on your cluster before you install Chains.
 
 To install the latest version of Chains to your Kubernetes cluster, run:
-```
+
+```shell
 kubectl apply --filename https://storage.googleapis.com/tekton-releases/chains/latest/release.yaml
 ```
 
 To install a specific version of Chains, run:
-```
+
+```shell
 kubectl apply -f https://storage.googleapis.com/tekton-releases/chains/previous/${VERSION}/release.yaml
 ```
 
 To verify that installation was successful, wait until all Pods have Status `Running`:
+
 ```shell
 $ kubectl get po -n tekton-chains --watch
 NAME                                       READY   STATUS      RESTARTS   AGE
@@ -41,18 +57,21 @@ tekton-chains-controller-c4f7c57c4-nrjb2   1/1     Running     0          160m
 ```
 
 ### Setup
+
 To finish setting up Chains, please complete the following steps:
+
 * [Add authentication to the Chains controller](docs/authentication.md)
 * [Generate a cryptographic key and configure Chains to use it for signing](docs/signing.md)
 * [Set up any additional configuration](docs/config.md)
 
-
 ## Tutorials
+
 To get started with Chains, try out our [getting started tutorial](docs/tutorials/getting-started-tutorial.md).
 
 To start signing OCI images and generating signed provenance for them, try our [signed provenance tutorial](docs/tutorials/signed-provenance-tutorial.md).
 
 ## Experimental Features
+
 To learn more about experimental features, check out [experimental.md](docs/experimental.md)
 
 ## Want to contribute
@@ -65,5 +84,6 @@ We are so excited to have you!
 Check out our good first issues and our help wanted issues to get started!
 
 To learn more about Chains:
+
 * Chat with us in the [#chains](https://tektoncd.slack.com/messages/chains) Slack channel
 * Attend the Chains Working Group meeting, details [here](https://github.com/tektoncd/community/blob/main/working-groups.md#chains)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,27 +1,35 @@
+<!--
+---
+linkTitle: "Authentication for Chains"
+weight: 10
+---
+-->
+
 # Authentication for Chains
 
 Authentication must be set up to take advantage of the following features in Chains:
+
 * Pushing signatures to an OCI registry after signing an image
 
 This doc will cover how to set this up!
 
 ## Authenticating to an OCI Registry
+
 The Chains controller will use the same service account your Task runs under as credentials for pushing signatures to an OCI registry. This section will cover how to set up a service account that has the necessary credentials.
 
 First, you will need access to credentials for your registry (they are in a file called `credentials.json` in this example).
 Next, create a [Docker config type Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets), which will contain the credentials required to push signatures:
 
-
 Set the namespace and name of the Kubernetes service account:
 
-```
+```shell
 export NAMESPACE=<your namespace>
 export SERVICE_ACCOUNT_NAME=<service account name>
 ```
 
 Then, create a `.dockerconfig` type secret:
 
-```
+```shell
 kubectl create secret docker-registry registry-credentials \
   --docker-server=gcr.io \
   --docker-username=_json_key \
@@ -29,12 +37,12 @@ kubectl create secret docker-registry registry-credentials \
   --docker-password="$(cat credentials.json)" \
   -n $NAMESPACE
 ```
-More details around creating this secret can be found [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials).
 
+More details around creating this secret can be found [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials).
 
 Finally, give the service account access to the secret above:
 
-```
+```shell
 kubectl patch serviceaccount $SERVICE_ACCOUNT_NAME \
   -p "{\"imagePullSecrets\": [{\"name\": \"registry-credentials\"}]}" -n $NAMESPACE
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,26 +1,33 @@
+<!--
+---
+linkTitle: "Chains Configuration"
+weight: 20
+---
+-->
+
 # Chains Configuration
 
 `Chains` works by observing `TaskRun` executions, capturing relevant information, and storing it in a cryptographically-signed format.
 
 `TaskRuns` can indicate inputs and outputs which are then captured and surfaced in the `Chains` payload formats, where relevant.
-`Chains` uses the standard mechanisms (`Results` and `PipelineResouces`) where possible, and provides a few other mechanisms to *hint* at the correct inputs and outputs. These are outlined below:
+`Chains` uses the standard mechanisms (`Results` and `PipelineResources`) where possible, and provides a few other mechanisms to *hint* at the correct inputs and outputs. These are outlined below:
 
 ## Chains Type Hinting
 
-When outputing an OCI image without using a `PipelineResource`, `Chains` will look for the following Results:
+When outputting an OCI image without using a `PipelineResource`, `Chains` will look for the following Results:
 
 * `*IMAGE_URL` - The URL to the built OCI image
 * `*IMAGE_DIGEST` - The Digest of the built OCI image
 
 where `*` indicates any expression.
-For example, if **both** `MYIMAGE_IMAGE_URL` AND `MYIMAGE_IMAGE_DIGEST` are correcty formatted to point to an OCI image, then `chains` will pick up on it and try to sign the image.
+For example, if **both** `MYIMAGE_IMAGE_URL` AND `MYIMAGE_IMAGE_DIGEST` are correctly formatted to point to an OCI image, then `chains` will pick up on it and try to sign the image.
 
 Multiple images can be specified by using different prefixes in place of `*`.
 
 Multiple images can also be specified by using the `IMAGES` Result.
 The value of the `IMAGES` result is a list of comma-separates images, each qualified by digest.
 
-```
+```shell
 - name: IMAGES
   value: img1@sha256:digest1, img2@sha256:digest2
 ```
@@ -31,7 +38,6 @@ For in-toto attestations, see [intoto.md](intoto.md) for description
 of in-toto specific type hinting.
 
 Note that these are provided automatically when using `PipelineResources`.
-
 
 ## Chains Configuration
 
@@ -54,7 +60,6 @@ Supported keys include:
 | `artifacts.oci.storage` | The storage backend to store `OCI` signatures in. | `tekton`, `oci`, `gcs`, `docdb` | `oci` |
 | `artifacts.oci.signer` | The signature backend to sign `OCI` payloads with. | `x509`, `kms` | `x509` |
 
-
 ### KMS Configuration
 
 | Key | Description | Supported Values | Default |
@@ -68,7 +73,6 @@ Supported keys include:
 | `storage.gcs.bucket` | The GCS bucket for storage | | |
 | `storage.oci.repository` | The OCI repo to store OCI signatures in  | | |
 | `storage.docdb.url` | The go-cloud URI reference to a docstore collection | `firestore://projects/[PROJECT]/databases/(default)/documents/[COLLECTION]?name_field=name`| |
-
 
 ### In-toto Configuration
 
@@ -85,7 +89,6 @@ Supported keys include:
 | `transparency.enabled` | EXPERIMENTAL. Whether to enable automatic binary transparency uploads. | `true`, `false`, `manual` | `false` |
 | `transparency.url` | EXPERIMENTAL. The URL to upload binary transparency attestations to, if enabled. | |`https://rekor.sigstore.dev`|
 
-
 **Note**: If `transparency.enabled` is set to `manual`, then only TaskRuns with the following annotation will be uploaded to the transparency log:
 
 ```yaml
@@ -99,4 +102,3 @@ chains.tekton.dev/transparency-upload: "true"
 | `signers.x509.fulcio.enabled` | EXPERIMENTAL. Whether to enable automatic certificates from fulcio. | `true`, `false` | `false`|
 | `signers.x509.fulcio.auth`    | EXPERIMENTAL. Auth mechanism for verifying identity for fulcio, if enabled  | `google`       | `google` |
 | `signers.x509.fulcio.address` | EXPERIMENTAL. Fulcio address to request certificate from, if enabled | |`https://fulcio.sigstore.dev` |
-

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,8 +1,16 @@
+<!--
+---
+linkTitle: "Chains Configuration"
+weight: 60
+---
+-->
+
 # Experimental Features
 
 This doc covers experimental features in Tekton Chains.
 
 Currently, experimental features include:
+
 * [Transparency Log Support](#Transparency-Log-Support)
 * [Keyless Signing Mode](#Keyless-Signing-Mode)
 
@@ -12,7 +20,7 @@ Chains supports automatic binary uploads to a transparency log and defaults to u
 If enabled, all signatures and attestations will be logged.
 The entry ID will be appended as an annotation on a TaskRun once Chains has uploaded it:
 
-```
+```yaml
 chains.tekton.dev/transparency: https://rekor.sigstore.dev/7599
 ```
 
@@ -20,31 +28,32 @@ chains.tekton.dev/transparency: https://rekor.sigstore.dev/7599
 
 To enable, run:
 
-```
+```shell
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"transparency.enabled": "true"}}'
 ```
 
 Right now, Chains default to storing entries in Rekor (https://rekor.sigstore.dev).
 To customize where entries are stored, run:
 
-```
+```shell
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"transparency.url": "<YOUR URL>"}}'
 ```
 
 ## Keyless Signing Mode
+
 Chains also supports a keyless signing mode with [Fulcio](https://github.com/sigstore/fulcio), sigstore's free root certificate authority.
 
 In this mode, instead of setting up a signing key, Chains would request an identity token from the cluster it is running in.
 This identity token will be used to authorize a Fulcio certificate for a Tekton artifact (OCI image or TaskRun).
-Currently, this experiemental feature only works on a GKE cluster with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) configured (Workload Identity is required for Chains to be able to request an identity token).
+Currently, this experimental feature only works on a GKE cluster with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) configured (Workload Identity is required for Chains to be able to request an identity token).
 
 Once Chains has successfully requested a certificate, it will store the cert as a base64 encoded annotation on the TaskRun, along with the payload and signature.
 
 This can look like:
 
 ```yaml
-Annotations:  chains.tekton.dev/cert-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4: 
-              chains.tekton.dev/chain-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4: 
+Annotations:  chains.tekton.dev/cert-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
+              chains.tekton.dev/chain-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
               chains.tekton.dev/payload-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
                 eyJfdHlwZSI6ImJ1aWxkLWNoYWlucy01dnhycyIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3Rla3Rvbi5kZXYvY2hhaW5zL3Byb3ZlbmFuY2UiLCJzdWJqZWN0IjpbeyJuYW1lIj...
               chains.tekton.dev/signature-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
@@ -58,7 +67,6 @@ Annotations:  chains.tekton.dev/cert-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc
 
 To enable singing with Fulcio, run:
 
-```
+```shell
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"signers.x509.fulcio.enabled": "true"}}'
 ```
-

--- a/docs/intoto.md
+++ b/docs/intoto.md
@@ -1,3 +1,10 @@
+<!--
+---
+linkTitle: "In-toto Attestation Formatter"
+weight: 40
+---
+-->
+
 # In-toto attestation formatter
 
 ## Overview

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -1,47 +1,61 @@
-# Signing Secrets
+<!--
+---
+linkTitle: "Signing"
+weight: 30
+---
+-->
+
+# Signing Artifacts
+
+## Signing Secrets
 
 To get started signing things in Chains, you will need to generate a keypair and instruct Chains to sign with it via a Kubernetes secret.
-Chains expects a private key, and password if the key is encrypted, to exist in a Kubernetes secret `signing-secrets` in the `tekon-chains` namespace. 
+Chains expects a private key, and password if the key is encrypted, to exist in a Kubernetes secret `signing-secrets` in the `tekton-chains` namespace.
 
 Chains supports a few different signature schemes, including x509 and KMS systems.
 
 This doc explains how to generate keys and configure Chains for each type.
 Note, **only one** of the following keys needs to be set up for Chains to work:
-- [x509](#x509)
-- [Cosign](#cosign)
-- [KMS](#KMS)
-- [EXPERIMENTAL: Keyless signing](experimental.md#Keyless-Signing-Mode)
 
-# x509
+* [x509](#x509)
+* [Cosign](#cosign)
+* [KMS](#KMS)
+* [EXPERIMENTAL: Keyless signing](experimental.md#Keyless-Signing-Mode)
+
+## x509
+
 For x509, Chains expects the private key to be stored in a secret called `signing-secrets` with the following structure:
 
 * x509.pem (the private key)
 
 Chains also has the following requirements:
-* The private key to be stored as an unencrpyted PKCS8 PEM file (`BEGIN PRIVATE KEY`)
+
+* The private key to be stored as an unencrypted PKCS8 PEM file (`BEGIN PRIVATE KEY`)
 * The key is of type `ed25519` or `ecdsa`
 
+## Cosign
 
-
-# Cosign
 For cosign, Chains expects the encrypted private key to be stored in a secret called `signing-secrets` with the following structure:
 
 * `cosign.key` (the cosign-generated private key)
 * `cosign.password` (the password to decrypt the private key)
 
 Chains also has the following requirements:
+
 * The private key must be stored as an encrypted PEM file of type `ENCRYPTED COSIGN PRIVATE KEY`
 
-## Generate cosign Keypair
+### Generate cosign Keypair
 
 To create a cosign keypair, `cosign.key` and `cosign.pub`, install [cosign](https://github.com/sigstore/cosign) and run the following:
+
 ```shell
 cosign generate-key-pair k8s://tekton-chains/signing-secrets
 ```
 
 Cosign will prompt you for a password, and create the Kubernetes secret for you.
 
-# KMS
+## KMS
+
 Chains uses a ["go-cloud"](https://github.com/google/go-cloud) URI like scheme for KMS references.
 Chains supports GCP KMS and Hashicorp Vault today, but we would love to add support for more.
 
@@ -56,13 +70,13 @@ For AWS, this should have the structure of `awskms://[ENDPOINT]/[ID/ALIAS/ARN]` 
 
 For Azure, this should have the structure of `azurekms://[VAULT_NAME][VAULT_URL]/[KEY_NAME]`.
 
-## Authentication
+### Authentication
 
 Most likely, you will need to set up some additional authentication so that the `chains-controller` deployment has access to your KMS service for signing.
 For GCP/GKE, we suggest enabling [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity), and giving your service account `Cloud KMS Admin` permissions.
 Other Service Account techniques would work as well.
 
-# Troubleshooting
+## Troubleshooting
 
 If your signing secrets is already populated, you may get the following error:
 
@@ -73,5 +87,5 @@ Error from server (AlreadyExists): secrets "signing-secrets" already exists
 Simply delete the secret and then recreate as described above:
 
 ```shell
-kubectl delete secret signing-secrets -n tekton-chains 
+kubectl delete secret signing-secrets -n tekton-chains
 ```

--- a/docs/tutorials/getting-started-tutorial.md
+++ b/docs/tutorials/getting-started-tutorial.md
@@ -1,5 +1,14 @@
+<!--
+---
+linkTitle: "Tutorial: Getting Started"
+weight: 100
+---
+-->
+
 # Chains Getting Started Tutorial
+
 This tutorial will guide you through:
+
 * Generating your own keypair and storing it as a Kubernetes Secret
 * Creating a sample TaskRun
 * Retrieving the signature and payload from the signed TaskRun
@@ -9,9 +18,11 @@ We'll be creating a `TaskRun`, signing it, and storing the signature and the pay
 So, no additional authentication should be required!
 
 You can opt to try the tutorial with either of the following key types:
+
 * [x509 (Default)](#x509)
 
 ## x509
+
 To generate your own encrypted x509 keypair and save it as a Kubernetes secret, install [cosign](https://github.com/sigstore/cosign) and run the following:
 
 ```shell
@@ -21,12 +32,14 @@ cosign generate-key-pair k8s://tekton-chains/signing-secrets
 cosign will prompt you for a password, which will be stored in a Kubernetes secret named signing-secrets in the tekton-chains namespace.
 
 To create a simple `TaskRun`, run:
+
 ```shell
 $ kubectl create -f https://raw.githubusercontent.com/tektoncd/chains/main/examples/taskruns/task-output-image.yaml
 taskrun.tekton.dev/build-push-run-output-image-qbjvh created
 ```
 
 Save the name of your `TaskRun` as an environment variable:
+
 ```shell
 $ export TASKRUN=<Name of your TaskRun> # Replace with your taskrun name
 ```
@@ -40,6 +53,7 @@ build-push-run-output-image-qbjvh   True        Succeeded   36m         36m
 ```
 
 Next, retrieve the signature and payload from the object (they are stored as base64-encoded annotations):
+
 ```shell
 $ export TASKRUN_UID=$(kubectl get taskrun $TASKRUN -o=json | jq -r '.metadata.uid')
 $ kubectl get taskrun $TASKRUN -o=json | jq  -r ".metadata.annotations[\"chains.tekton.dev/payload-taskrun-$TASKRUN_UID\"]" | base64 --decode > payload

--- a/docs/tutorials/signed-provenance-tutorial.md
+++ b/docs/tutorials/signed-provenance-tutorial.md
@@ -1,9 +1,17 @@
+<!--
+---
+linkTitle: "Tutorial: Signed Provenance"
+weight: 200
+---
+-->
+
 # Chains Signed Provenance Tutorial
 
 This tutorial will cover how to set up Chains to sign OCI images built in Tekton, and how to automatically generate and sign in-toto attestations for each image.
 This tutorial will also cover how to store these attestations in a transparency log and query the log for the attestation.
 
 This tutorial will guide you through:
+
 * Generating your own keypair and storing it as a Kubernetes Secret
 * Setting up authentication for your OCI registry to store images, image signatures and signed image attestations
 * Configuring Tekton Chains to generate and sign provenance
@@ -11,12 +19,14 @@ This tutorial will guide you through:
 * Verifying the signed image and the signed provenance
 
 ## Prerequisites
+
 A Kubernetes cluster with the following installed:
+
 * Tekton Chains
 * Tekton Pipelines
 
-
 ## Generate a Key Pair
+
 First, we'll generate an encrypted x509 keypair and save it as a Kubernetes secret.
 Install [cosign](https://github.com/sigstore/cosign) and run the following:
 
@@ -28,8 +38,8 @@ cosign will prompt you for a password, which will be stored in a Kubernetes secr
 
 The public key will be written to a local file called `cosign.pub`.
 
-
 ## Set up Authentication
+
 There are two forms of authentication that need to be set up:
 1. The Chains controller will be pushing signatures to an OCI registry using the credentials linked to your `TaskRun`'s service account. See our [authentication doc](../authentication.md)
 2. The Kaniko Task that will build and push the image needs push permissions for your registry.
@@ -37,19 +47,21 @@ There are two forms of authentication that need to be set up:
 To set up auth for the Kaniko Task, you'll need a Kubernetes secret of a docker `config.json` file which contains the required auth.
 You can create the secret by running:
 
-```
+```shell
 kubectl create secret generic [DOCKERCONFIG_SECRET_NAME] --from-file [PATH TO CONFIG.JSON]
 ```
 
 ## Configuring Tekton Chains
+
 You'll need to make these changes to the Tekton Chains Config:
+
 * `artifacts.taskrun.format=tekton-provenance`
 * `artifacts.taskrun.storage=oci`
 * `transparency.enabled=true`
 
 You can set these fields by running
 
-```
+```shell
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.taskrun.format": "tekton-provenance"}}'
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.taskrun.storage": "oci"}}'
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"transparency.enabled": "true"}}'
@@ -59,36 +71,37 @@ This tells Chains to generate an in-toto attestation and store it in the specifi
 Attestations will also be stored in [rekor](https://github.com/sigstore/rekor) since transparency is enabled.
 
 ## Start the Kaniko Task
+
 Great, now that the setup is done we're finally ready to build an image with kaniko!
 
 First, apply the [Kaniko Task](../../examples/kaniko/kaniko.yaml) to your cluster:
 
-```
+```shell
 kubectl apply -f examples/kaniko/kaniko.yaml
 ```
 
 and set the following environment variables:
 
-```
+```shell
 REGISTRY=[The registry you'll be pushing to]
 DOCKERCONFIG_SECRET_NAME=[The name of the secret with the docker config.json]
 ```
 
 Then, you can start the Kaniko Task with the Tekton CLI tool, [tkn](https://github.com/tektoncd/cli):
 
-```
+```shell
 tkn task start --param IMAGE=$REGISTRY/kaniko-chains --use-param-defaults --workspace name=source,emptyDir="" --workspace name=dockerconfig,secret=$DOCKERCONFIG_SECRET_NAME kaniko-chains
 ```
 
 You can watch the logs of this Task until they complete; if authentication is set up correctly than the final image should be pushed to `$REGISTRY/kaniko-chains`.
 
-
 ## Verifying the Image and Attestation
+
 Once the TaskRun has successfully completed, you'll need to wait a few seconds for Chains to generate provenance and sign it.
 
 Once you see the `chains.tekton.dev/signed=true` annotation on your TaskRun you know that Chains has completed the signing process and you're ready to move on to verification:
 
-```
+```shell
 kubectl get tr [TASKRUN_NAME] -o json | jq -r .metadata.annotations
 
 {
@@ -99,7 +112,7 @@ kubectl get tr [TASKRUN_NAME] -o json | jq -r .metadata.annotations
 
 To verify the image and the attestation, we'll use `cosign` again:
 
-```
+```shell
 cosign verify -key cosign.pub $REGISTRY/kaniko-chains
 cosign verify-attestation -key cosign.pub $REGISTRY/kaniko-chains
 ```
@@ -107,12 +120,13 @@ cosign verify-attestation -key cosign.pub $REGISTRY/kaniko-chains
 You should see verification output for both!
 
 ## Finding Provenance in Rekor
+
 To find provenance for the image in Rekor, first get the digest of the `$REGISTRY/kaniko-chains` image you just built.
 You can look this up in the TaskRun, or pull the image to get the digest. 
 
 You can then search rekor to find all entries that match the sha256 digest of the image you just built with the [rekor-cli](https://github.com/sigstore/rekor/releases/) tool:
 
-```
+```shell
 rekor-cli search --sha [IMAGE_DIGEST]
 
 [UUID1]
@@ -123,7 +137,7 @@ The search will print out the UUIDs of matching entries.
 It may take a little guessing, but one of those UUIDs holds the attestation.
 You can see the attestation by using [jq](https://github.com/stedolan/jq):
 
-```
+```shell
 rekor-cli get --uuid [UUID] --format json | jq -r .Attestation | base64 --decode | jq
 ```
 


### PR DESCRIPTION
In preparation for publishing the docs to tekton.dev/docs, we need
front-matter on documents that will be published.

Fixed a couple of typos and linter issues too.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

/kind documentation