### PR TITLE
Add extension to gcs storage payload

### DIFF
--- a/pkg/chains/formats/format.go
+++ b/pkg/chains/formats/format.go
@@ -22,6 +22,7 @@ type Payloader interface {
 
 type PayloadType string
 
+// If you update this, remember to update AllFormatters
 const (
 	PayloadTypeTekton        PayloadType = "tekton"
 	PayloadTypeSimpleSigning PayloadType = "simplesigning"

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -201,7 +201,7 @@ func (ts *TaskRunSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) e
 				Key:           signableType.Key(obj),
 				Cert:          signer.Cert(),
 				Chain:         signer.Chain(),
-				PayloadFormat: string(payloadFormat),
+				PayloadFormat: payloadFormat,
 			}
 			if err := b.StorePayload(rawPayload, string(signature), storageOpts); err != nil {
 				logger.Error(err)

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -16,10 +16,12 @@ limitations under the License.
 
 package config
 
+import "github.com/tektoncd/chains/pkg/chains/formats"
+
 // StorageOpts contains additional information required when storing signatures
 type StorageOpts struct {
 	Key           string
 	Cert          string
 	Chain         string
-	PayloadFormat string
+	PayloadFormat formats.PayloadType
 }


### PR DESCRIPTION
This also uses the type PayloadType instead of a string in the storageOptions

currently adds the extension 
- `.tkn` for taskrun payloads
- `.att` for intoto attestations


Signed-off-by: Appu Goundan <appu@google.com>