### PR TITLE
WIP: differentiate payload types on tekton storage

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -47,14 +47,14 @@ In this mode, instead of setting up a signing key, Chains would request an ident
 This identity token will be used to authorize a Fulcio certificate for a Tekton artifact (OCI image or TaskRun).
 Currently, this experimental feature only works on a GKE cluster with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) configured (Workload Identity is required for Chains to be able to request an identity token).
 
-Once Chains has successfully requested a certificate, it will store the cert as a base64 encoded annotation on the TaskRun, along with the payload and signature.
+Once Chains has successfully requested a certificate, it will store the cert as a base64 encoded annotation on the TaskRun, along with the payload(attestation or taskrun) and signature.
 
 This can look like:
 
 ```yaml
 Annotations:  chains.tekton.dev/cert-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
               chains.tekton.dev/chain-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
-              chains.tekton.dev/payload-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
+              chains.tekton.dev/attestation-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
                 eyJfdHlwZSI6ImJ1aWxkLWNoYWlucy01dnhycyIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3Rla3Rvbi5kZXYvY2hhaW5zL3Byb3ZlbmFuY2UiLCJzdWJqZWN0IjpbeyJuYW1lIj...
               chains.tekton.dev/signature-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
                 eyJwYXlsb2FkVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5pbi10b3RvK2pzb24iLCJwYXlsb2FkIjoiZXlKZmRIbHdaU0k2SW1KMWFXeGtMV05vWVdsdWN5MDFkbmh5Y3lJc0luQnlaV1...

--- a/docs/tutorials/getting-started-tutorial.md
+++ b/docs/tutorials/getting-started-tutorial.md
@@ -56,7 +56,7 @@ Next, retrieve the signature and payload from the object (they are stored as bas
 
 ```shell
 $ export TASKRUN_UID=$(kubectl get taskrun $TASKRUN -o=json | jq -r '.metadata.uid')
-$ kubectl get taskrun $TASKRUN -o=json | jq  -r ".metadata.annotations[\"chains.tekton.dev/payload-taskrun-$TASKRUN_UID\"]" | base64 --decode > payload
+$ kubectl get taskrun $TASKRUN -o=json | jq  -r ".metadata.annotations[\"chains.tekton.dev/TODO_FIGURE_OUT_PAYLOAD_TYPE-taskrun-$TASKRUN_UID\"]" | base64 --decode > payload
 $ kubectl get taskrun $TASKRUN -o=json | jq  -r ".metadata.annotations[\"chains.tekton.dev/signature-taskrun-$TASKRUN_UID\"]" | base64 --decode > signature
 ```
 

--- a/pkg/chains/storage/tekton/tekton.go
+++ b/pkg/chains/storage/tekton/tekton.go
@@ -31,7 +31,8 @@ import (
 
 const (
 	StorageBackendTekton        = "tekton"
-	TaskRunAnnotationFormat     = "chains.tekton.dev/taskrun-%s"     // payload type
+	PayloadAnnotationFormat     = "chains.tekton.dev/payload-%s"     // TODO: remove deprecated payload annotation
+	TektonAnnotationFormat      = "chains.tekton.dev/tekton-%s"      // payload type
 	AttestationAnnotationFormat = "chains.tekton.dev/attestation-%s" // payload type
 	SignatureAnnotationFormat   = "chains.tekton.dev/signature-%s"
 	CertAnnotationsFormat       = "chains.tekton.dev/cert-%s"
@@ -69,6 +70,9 @@ func (b *Backend) StorePayload(rawPayload []byte, signature string, opts config.
 		return err
 	}
 	patchMap[payloadKey] = base64.StdEncoding.EncodeToString([]byte(rawPayload))
+	// TODO: remove deprecated
+	// TODO: currently commented out so I can verify the new annotations in e2e (DO NOT SUBMIT)
+	// patchMap[fmt.Sprintf(SignatureAnnotationFormat, opts.Key)] = base64.StdEncoding.EncodeToString([]byte(rawPayload))
 
 	// Use patch instead of update to prevent race conditions.
 	patchBytes, err := patch.GetAnnotationsPatch(patchMap)
@@ -139,7 +143,7 @@ func (b *Backend) RetrievePayload(opts config.StorageOpts) (string, error) {
 
 func (b *Backend) payloadKey(opts config.StorageOpts) (string, error) {
 	if opts.PayloadFormat == formats.PayloadTypeTekton {
-		return fmt.Sprintf(TaskRunAnnotationFormat, opts.Key), nil
+		return fmt.Sprintf(TektonAnnotationFormat, opts.Key), nil
 	} else if opts.PayloadFormat == formats.PayloadTypeInTotoIte6 {
 		return fmt.Sprintf(AttestationAnnotationFormat, opts.Key), nil
 	} else {

--- a/pkg/chains/storage/tekton/tekton_test.go
+++ b/pkg/chains/storage/tekton/tekton_test.go
@@ -38,12 +38,12 @@ func TestBackend_StorePayload(t *testing.T) {
 		wantErr           bool
 	}{
 		{
-			name: "simple taskrun payload",
+			name: "simple tekton payload",
 			payload: mockPayload{
 				A: "foo",
 				B: 3,
 			},
-			payloadAnnotation: "chains.tekton.dev/taskrun-mockpayload",
+			payloadAnnotation: "chains.tekton.dev/tekton-mockpayload",
 			opts: config.StorageOpts{
 				Key:           "mockpayload",
 				PayloadFormat: formats.PayloadTypeTekton,

--- a/pkg/chains/storage/tekton/tekton_test.go
+++ b/pkg/chains/storage/tekton/tekton_test.go
@@ -31,10 +31,11 @@ func TestBackend_StorePayload(t *testing.T) {
 	// The Tekton storage backend JSON serializes, base64 encodes, and attaches the result as an annotation
 
 	tests := []struct {
-		name    string
-		payload interface{}
-		opts    config.StorageOpts
-		wantErr bool
+		name              string
+		payload           interface{}
+		payloadAnnotation string
+		opts              config.StorageOpts
+		wantErr           bool
 	}{
 		{
 			name: "simple taskrun payload",
@@ -42,6 +43,7 @@ func TestBackend_StorePayload(t *testing.T) {
 				A: "foo",
 				B: 3,
 			},
+			payloadAnnotation: "chains.tekton.dev/taskrun-mockpayload",
 			opts: config.StorageOpts{
 				Key:           "mockpayload",
 				PayloadFormat: formats.PayloadTypeTekton,
@@ -53,6 +55,7 @@ func TestBackend_StorePayload(t *testing.T) {
 				A: "foo",
 				B: 3,
 			},
+			payloadAnnotation: "chains.tekton.dev/attestation-mockpayload",
 			opts: config.StorageOpts{
 				Key:           "mockpayload",
 				PayloadFormat: formats.PayloadTypeInTotoIte6,
@@ -69,6 +72,10 @@ func TestBackend_StorePayload(t *testing.T) {
 			mockSignature := "mocksignature"
 			if err := b.StorePayload(payload, mockSignature, tt.opts); (err != nil) != tt.wantErr {
 				t.Errorf("Backend.StorePayload() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if _, err := b.retrieveAnnotationValue(tt.payloadAnnotation, false); err != nil {
+				t.Errorf("Backend could not retrieve expected annotation %q", tt.payloadAnnotation)
 			}
 
 			// The rest is invalid if we wanted an error.

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -167,7 +167,7 @@ func TestOCISigning(t *testing.T) {
 			// Let's fetch the signature and body:
 			t.Log(tr.Annotations)
 
-			sig, body := tr.Annotations["chains.tekton.dev/signature-05f95b26ed10"], tr.Annotations["chains.tekton.dev/payload-05f95b26ed10"]
+			sig, body := tr.Annotations["chains.tekton.dev/signature-05f95b26ed10"], tr.Annotations["chains.tekton.dev/tekton-05f95b26ed10"]
 			// base64 decode them
 			sigBytes, err := base64.StdEncoding.DecodeString(sig)
 			if err != nil {
@@ -241,7 +241,7 @@ func TestFulcio(t *testing.T) {
 	resetConfig := setConfigMap(ctx, t, c, map[string]string{
 		"artifacts.taskrun.storage":   "tekton",
 		"artifacts.taskrun.signer":    "x509",
-		"artifacts.taskrun.format":    "tekton-provenance",
+		"artifacts.taskrun.format":    "in-toto",
 		"artifacts.oci.signer":        "x509",
 		"signers.x509.fulcio.enabled": "true",
 		"transparency.enabled":        "false",
@@ -262,7 +262,7 @@ func TestFulcio(t *testing.T) {
 	// verify the cert against the signature and payload
 
 	sigKey := fmt.Sprintf("chains.tekton.dev/signature-taskrun-%s", tr.UID)
-	payloadKey := fmt.Sprintf("chains.tekton.dev/payload-taskrun-%s", tr.UID)
+	payloadKey := fmt.Sprintf("chains.tekton.dev/attestion-taskrun-%s", tr.UID)
 	certKey := fmt.Sprintf("chains.tekton.dev/cert-taskrun-%s", tr.UID)
 
 	envelopeBytes := base64Decode(t, tr.Annotations[sigKey])
@@ -496,7 +496,7 @@ func TestProvenanceMaterials(t *testing.T) {
 	tr = waitForCondition(ctx, t, c.PipelineClient, tr.Name, ns, signed, 120*time.Second)
 
 	// get provenance, and make sure it has a materials section
-	payloadKey := fmt.Sprintf("chains.tekton.dev/payload-taskrun-%s", tr.UID)
+	payloadKey := fmt.Sprintf("chains.tekton.dev/attestation-taskrun-%s", tr.UID)
 	body := tr.Annotations[payloadKey]
 	bodyBytes, err := base64.StdEncoding.DecodeString(body)
 	if err != nil {

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -88,7 +88,7 @@ func runInTotoFormatterTests(ctx context.Context, t *testing.T, ns string, c *cl
 
 			// now validate the in-toto attestation
 			completed := waitForCondition(ctx, t, c.PipelineClient, taskRun.Name, ns, signed, 120*time.Second)
-			payload, _ := base64.StdEncoding.DecodeString(completed.Annotations[fmt.Sprintf("chains.tekton.dev/payload-taskrun-%s", completed.UID)])
+			payload, _ := base64.StdEncoding.DecodeString(completed.Annotations[fmt.Sprintf("chains.tekton.dev/attestation-taskrun-%s", completed.UID)])
 			signature, _ := base64.StdEncoding.DecodeString(completed.Annotations[fmt.Sprintf("chains.tekton.dev/signature-taskrun-%s", completed.UID)])
 			t.Logf("Got attestation: %s", string(payload))
 


### PR DESCRIPTION
Adds two new annotations
```
+	chains.tekton.dev/taskrun-%s
+	chains.tekton.dev/attestation-%s
```
and removes the old typeless payload annotation
```
-       chains.tekton.dev/payload-%s
```
Storage on tekton now expects a payload type and will fail if not intoto or a taskrun

Signed-off-by: Appu Goundan <appu@google.com>