### PR TITLE
Make SLSA provenance v0.2 invocation.parameters compliant with spec

### DIFF
--- a/pkg/chains/formats/intotoite6/intotoite6.go
+++ b/pkg/chains/formats/intotoite6/intotoite6.go
@@ -118,9 +118,9 @@ func metadata(tr *v1beta1.TaskRun) *slsa.ProvenanceMetadata {
 func invocation(tr *v1beta1.TaskRun) slsa.ProvenanceInvocation {
 	i := slsa.ProvenanceInvocation{}
 	// get parameters
-	var params []string
+	params := make(map[string]string)
 	for _, p := range tr.Spec.Params {
-		params = append(params, fmt.Sprintf("%s=%v", p.Name, p.Value))
+		params[p.Name] = fmt.Sprintf("%v", p.Value)
 	}
 	// add params
 	if ts := tr.Status.TaskSpec; ts != nil {
@@ -130,7 +130,7 @@ func invocation(tr *v1beta1.TaskRun) slsa.ProvenanceInvocation {
 				if v == "" {
 					v = fmt.Sprintf("%v", p.Default.ArrayVal)
 				}
-				params = append(params, fmt.Sprintf("%s=%s", p.Name, v))
+				params[p.Name] = fmt.Sprintf("%s", v)
 			}
 		}
 	}

--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -65,10 +65,11 @@ func TestCreatePayload1(t *testing.T) {
 				{URI: "https://git.test.com", Digest: slsa.DigestSet{"revision": "abcd"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
-				Parameters: []string{
-					"IMAGE={string test.io/test/image []}", "CHAINS-GIT_COMMIT={string abcd []}",
-					"CHAINS-GIT_URL={string https://git.test.com []}",
-					"filename={string /bin/ls []}",
+				Parameters: map[string]string{
+					"IMAGE":             "{string test.io/test/image []}",
+					"CHAINS-GIT_COMMIT": "{string abcd []}",
+					"CHAINS-GIT_URL":    "{string https://git.test.com []}",
+					"filename":          "{string /bin/ls []}",
 				},
 			},
 			Builder: slsa.ProvenanceBuilder{
@@ -133,7 +134,7 @@ func TestCreatePayload2(t *testing.T) {
 				ID: "test_builder-2",
 			},
 			Invocation: slsa.ProvenanceInvocation{
-				Parameters: []string(nil),
+				Parameters: map[string]string{},
 			},
 			BuildType: "https://tekton.dev/attestations/chains@v2",
 			BuildConfig: BuildConfig{
@@ -213,7 +214,7 @@ func TestMultipleSubjects(t *testing.T) {
 				ID: "test_builder-multiple",
 			},
 			Invocation: slsa.ProvenanceInvocation{
-				Parameters: []string(nil),
+				Parameters: map[string]string{},
 			},
 			BuildConfig: BuildConfig{
 				Steps: []Step{

--- a/pkg/chains/formats/intotoite6/provenance_test.go
+++ b/pkg/chains/formats/intotoite6/provenance_test.go
@@ -203,9 +203,9 @@ spec:
 	}
 
 	expected := slsa.ProvenanceInvocation{
-		Parameters: []string{
-			"my-param={string string-param []}",
-			"my-array-param={array  [my array]}",
+		Parameters: map[string]string{
+			"my-param":       "{string string-param []}",
+			"my-array-param": "{array  [my array]}",
 		},
 	}
 

--- a/pkg/chains/provenance/provenance.go
+++ b/pkg/chains/provenance/provenance.go
@@ -32,7 +32,7 @@ type ProvenancePredicate struct {
 
 // Invocation describes how the Taskrun was created
 type Invocation struct {
-	Parameters []string `json:"parameters"`
+	Parameters interface{} `json:"parameters"`
 	// This would be nil for an "inline task", a URI for the Task definition itself
 	// if it was created in-cluster, or an OCI uri if it came from OCI
 	// Something else if it came from a pipeline

--- a/test/testdata/intoto/task-output-image.json
+++ b/test/testdata/intoto/task-output-image.json
@@ -16,7 +16,7 @@
         "buildType": "https://tekton.dev/attestations/chains@v2",
         "invocation": {
             "configSource": {},
-            "parameters": null
+            "parameters": {}
         },
         "buildConfig": {
             "steps": [


### PR DESCRIPTION
The SLSA provenance v0.2 spec states that invocation.parameters
must be an arbitrary JSON object. This modifies the format
implementation to comply with that requirement.

For more info: https://github.com/tektoncd/chains/issues/306

---

This should fix: #306 

@priyawadhwa Want to get your input on whether the output makes sense and if you think it breaks anything because people expect strings of key=value.

There's a lot of options we can take to make the parameters output nicer, but I kept it simple for now until I get input from others.