### PR TITLE
Fix bugs in provenance implementation for materials.digest

### DIFF
--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -62,7 +62,7 @@ func TestCreatePayload1(t *testing.T) {
 				BuildFinishedOn: &e1BuildFinished,
 			},
 			Materials: []slsa.ProvenanceMaterial{
-				{URI: "https://git.test.com", Digest: slsa.DigestSet{"revision": "abcd"}},
+				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "abcd"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				Parameters: map[string]string{

--- a/pkg/chains/formats/intotoite6/provenance_test.go
+++ b/pkg/chains/formats/intotoite6/provenance_test.go
@@ -90,9 +90,9 @@ status:
 
 	expected := []slsa.ProvenanceMaterial{
 		{
-			URI: "https://github.com/GoogleContainerTools/distroless",
+			URI: "git+https://github.com/GoogleContainerTools/distroless.git",
 			Digest: slsa.DigestSet{
-				"revision": "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
+				"sha1": "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
 			},
 		},
 	}
@@ -142,9 +142,9 @@ status:
 
 	expected := []slsa.ProvenanceMaterial{
 		{
-			URI: "https://github.com/GoogleContainerTools/distroless",
+			URI: "git+https://github.com/GoogleContainerTools/distroless.git",
 			Digest: slsa.DigestSet{
-				"revision": "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
+				"sha1": "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
 			},
 		},
 	}
@@ -170,9 +170,9 @@ spec:
 
 	expected = []slsa.ProvenanceMaterial{
 		{
-			URI: "github.com/something",
+			URI: "git+github.com/something.git",
 			Digest: slsa.DigestSet{
-				"revision": "my-commit",
+				"sha1": "my-commit",
 			},
 		},
 	}

--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+
 	"github.com/tektoncd/chains/pkg/chains/formats"
 
 	"github.com/in-toto/in-toto-golang/in_toto"

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -528,7 +528,7 @@ func TestProvenanceMaterials(t *testing.T) {
 
 	// modify image task run to add in the params we want to check for
 	commit := "my-git-commit"
-	url := "my-git-url"
+	url := "https://my-git-url"
 	imageTaskRun.Spec.Params = []v1beta1.Param{
 		{
 			Name: "CHAINS-GIT_COMMIT", Value: *v1beta1.NewArrayOrString(commit),
@@ -569,9 +569,9 @@ func TestProvenanceMaterials(t *testing.T) {
 	}
 	want := []provenance.ProvenanceMaterial{
 		{
-			URI: url,
+			URI: "git+" + url + ".git",
 			Digest: provenance.DigestSet{
-				"revision": commit,
+				"sha1": commit,
 			},
 		},
 	}

--- a/test/testdata/intoto/task-output-image.json
+++ b/test/testdata/intoto/task-output-image.json
@@ -79,9 +79,9 @@
         },
         "materials": [
             {
-                "uri": "https://github.com/GoogleContainerTools/skaffold",
+                "uri": "git+https://github.com/GoogleContainerTools/skaffold@v0.32.0",
                 "digest": {
-                    "revision": "v0.32.0"
+                    "sha1": "6ed7aad5e8a36052ee5f6079fc91368e362121f7"
                 }
             }
         ]


### PR DESCRIPTION
Makes the following fixes:
1. Replaces the `revision` key with `sha1` for git commits
2. uses the SPDX download locaton format for specifying the git URI 

fixes https://github.com/tektoncd/chains/issues/309