### PR TITLE
Rely on cosign providers library for fulcio auth

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -101,5 +101,4 @@ chains.tekton.dev/transparency-upload: "true"
 | Key | Description | Supported Values | Default |
 | :--- | :--- | :--- | :--- |
 | `signers.x509.fulcio.enabled` | EXPERIMENTAL. Whether to enable automatic certificates from fulcio. | `true`, `false` | `false`|
-| `signers.x509.fulcio.auth`    | EXPERIMENTAL. Auth mechanism for verifying identity for fulcio, if enabled  | `google`       | `google` |
 | `signers.x509.fulcio.address` | EXPERIMENTAL. Fulcio address to request certificate from, if enabled | |`https://fulcio.sigstore.dev` |

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/secure-systems-lab/go-securesystemslib v0.3.0
 	github.com/sigstore/cosign v1.4.2-0.20220103014340-1a7f9d61a2e9
-	github.com/sigstore/fulcio v0.1.2-0.20220103193424-0df42390d392
+	github.com/sigstore/fulcio v0.1.2-0.20220103193424-0df42390d392 // indirect
 	github.com/sigstore/rekor v0.4.1-0.20220103184137-e86cf37242d3
 	github.com/sigstore/sigstore v1.1.1-0.20220104191147-28bc731b4695
 	github.com/tektoncd/pipeline v0.31.1-0.20220105002759-3e137645be61
@@ -47,7 +47,7 @@ require (
 	go.uber.org/zap v1.19.1
 	gocloud.dev v0.24.1-0.20211119014450-028788aaaa4c
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b
-	google.golang.org/api v0.63.0
+	google.golang.org/api v0.63.0 // indirect
 	google.golang.org/protobuf v1.27.1
 	k8s.io/api v0.22.5
 	k8s.io/apimachinery v0.22.5

--- a/pkg/chains/signing/x509/x509.go
+++ b/pkg/chains/signing/x509/x509.go
@@ -21,19 +21,23 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"path/filepath"
-
-	"google.golang.org/api/idtoken"
 
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/pkg/cosign"
-	"github.com/sigstore/fulcio/pkg/api"
+	"github.com/sigstore/cosign/pkg/providers"
+	_ "github.com/sigstore/cosign/pkg/providers/google"
+
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/chains/pkg/chains/signing"
 	"github.com/tektoncd/chains/pkg/config"
 	"go.uber.org/zap"
+)
+
+const (
+	defaultOIDCIssuer   = "https://oauth2.sigstore.dev/auth"
+	defaultOIDCClientID = "sigstore"
 )
 
 // Signer exposes methods to sign payloads.
@@ -50,7 +54,7 @@ func NewSigner(secretPath string, cfg config.Config, logger *zap.SugaredLogger) 
 	cosignPrivateKeypath := filepath.Join(secretPath, "cosign.key")
 
 	if cfg.Signers.X509.FulcioEnabled {
-		return fulcioSigner(cfg.Signers.X509.FulcioAuth, cfg.Signers.X509.FulcioAddr, logger)
+		return fulcioSigner(cfg.Signers.X509.FulcioAddr, logger)
 	} else if contents, err := ioutil.ReadFile(x509PrivateKeyPath); err == nil {
 		return x509Signer(contents, logger)
 	} else if contents, err := ioutil.ReadFile(cosignPrivateKeypath); err == nil {
@@ -59,27 +63,24 @@ func NewSigner(secretPath string, cfg config.Config, logger *zap.SugaredLogger) 
 	return nil, errors.New("no valid private key found, looked for: [x509.pem, cosign.key]")
 }
 
-func fulcioSigner(auth, addr string, logger *zap.SugaredLogger) (*Signer, error) {
-	if auth != "google" {
-		return nil, errors.New(fmt.Sprintf("%s is not yet implemented as an authorization scheme for the fulcio signer", auth))
+func fulcioSigner(addr string, logger *zap.SugaredLogger) (*Signer, error) {
+	ctx := context.Background()
+
+	if !providers.Enabled(ctx) {
+		return nil, fmt.Errorf("no auth provider for fulcio is enabled")
+	}
+
+	tok, err := providers.Provide(ctx, "sigstore")
+	if err != nil {
+		return nil, errors.Wrap(err, "getting provider")
 	}
 	logger.Info("Signing with fulcio ...")
 
-	ts, err := idtoken.NewTokenSource(context.Background(), "sigstore")
+	fClient, err := fulcio.NewClient(addr)
 	if err != nil {
-		return nil, errors.Wrap(err, "new token source")
+		return nil, errors.Wrap(err, "creating Fulcio client")
 	}
-	tok, err := ts.Token()
-	if err != nil {
-		return nil, errors.Wrap(err, "getting token")
-	}
-
-	u, err := url.Parse(addr)
-	if err != nil {
-		return nil, errors.Wrap(err, "new fulcio client")
-	}
-	client := api.NewClient(u)
-	k, err := fulcio.NewSigner(context.Background(), tok.AccessToken, "https://oauth2.sigstore.dev/auth", "sigstore", client)
+	k, err := fulcio.NewSigner(ctx, tok, defaultOIDCIssuer, defaultOIDCClientID, fClient)
 	if err != nil {
 		return nil, errors.Wrap(err, "new signer")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,7 +68,6 @@ type BuilderConfig struct {
 type X509Signer struct {
 	FulcioEnabled bool
 	FulcioAddr    string
-	FulcioAuth    string
 }
 
 type KMSSigner struct {
@@ -153,7 +152,6 @@ func defaultConfig() *Config {
 		},
 		Signers: SignerConfigs{
 			X509: X509Signer{
-				FulcioAuth: "google",
 				FulcioAddr: "https://fulcio.sigstore.dev",
 			},
 		},
@@ -191,7 +189,6 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		asString(kmsSignerKMSRef, &cfg.Signers.KMS.KMSRef),
 
 		asBool(x509SignerFulcioEnabled, &cfg.Signers.X509.FulcioEnabled),
-		asString(x509SignerFulcioAuth, &cfg.Signers.X509.FulcioAuth),
 		asString(x509SignerFulcioAddr, &cfg.Signers.X509.FulcioAddr),
 
 		// Build config

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -86,7 +86,6 @@ func TestNewConfigStore(t *testing.T) {
 
 var defaultSigners = SignerConfigs{
 	X509: X509Signer{
-		FulcioAuth: "google",
 		FulcioAddr: "https://fulcio.sigstore.dev",
 	},
 }
@@ -398,7 +397,6 @@ func TestParse(t *testing.T) {
 				Signers: SignerConfigs{
 					X509: X509Signer{
 						FulcioEnabled: true,
-						FulcioAuth:    "google",
 						FulcioAddr:    "fulcio-address",
 					},
 				},
@@ -431,7 +429,6 @@ func TestParse(t *testing.T) {
 				},
 				Signers: SignerConfigs{
 					X509: X509Signer{
-						FulcioAuth: "google",
 						FulcioAddr: "https://fulcio.sigstore.dev",
 					},
 				},
@@ -465,7 +462,6 @@ func TestParse(t *testing.T) {
 				},
 				Signers: SignerConfigs{
 					X509: X509Signer{
-						FulcioAuth: "google",
 						FulcioAddr: "https://fulcio.sigstore.dev",
 					},
 				},

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -241,7 +241,7 @@ func TestFulcio(t *testing.T) {
 	resetConfig := setConfigMap(ctx, t, c, map[string]string{
 		"artifacts.taskrun.storage":   "tekton",
 		"artifacts.taskrun.signer":    "x509",
-		"artifacts.taskrun.format":    "tekton-provenance",
+		"artifacts.taskrun.format":    "in-toto",
 		"artifacts.oci.signer":        "x509",
 		"signers.x509.fulcio.enabled": "true",
 		"transparency.enabled":        "false",

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -122,7 +122,7 @@ var simpleTaskspec = v1beta1.TaskSpec{
 
 var simpleTaskRun = v1beta1.TaskRun{
 	ObjectMeta: metav1.ObjectMeta{
-		GenerateName: "test-task",
+		GenerateName: "test-task-",
 	},
 	Spec: v1beta1.TaskRunSpec{
 		TaskSpec: &simpleTaskspec,

--- a/vendor/github.com/sigstore/cosign/pkg/providers/doc.go
+++ b/vendor/github.com/sigstore/cosign/pkg/providers/doc.go
@@ -1,0 +1,18 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package providers defines the APIs for providers to detect their relevance
+// and register themselves to furnish OIDC tokens within a given environment.
+package providers

--- a/vendor/github.com/sigstore/cosign/pkg/providers/google/doc.go
+++ b/vendor/github.com/sigstore/cosign/pkg/providers/google/doc.go
@@ -1,0 +1,17 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package google defines a google implementation of the providers.Interface.
+package google

--- a/vendor/github.com/sigstore/cosign/pkg/providers/google/google.go
+++ b/vendor/github.com/sigstore/cosign/pkg/providers/google/google.go
@@ -1,0 +1,98 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"google.golang.org/api/idtoken"
+	"google.golang.org/api/impersonate"
+
+	"github.com/sigstore/cosign/pkg/providers"
+)
+
+func init() {
+	providers.Register("google-workload-identity", &googleWorkloadIdentity{})
+	providers.Register("google-impersonate", &googleImpersonate{})
+}
+
+type googleWorkloadIdentity struct{}
+
+var _ providers.Interface = (*googleWorkloadIdentity)(nil)
+
+// gceProductNameFile is the product file path that contains the cloud service name.
+// This is a variable instead of a const to enable testing.
+var gceProductNameFile = "/sys/class/dmi/id/product_name"
+
+// Enabled implements providers.Interface
+// This is based on k8s.io/kubernetes/pkg/credentialprovider/gcp
+func (gwi *googleWorkloadIdentity) Enabled(ctx context.Context) bool {
+	data, err := os.ReadFile(gceProductNameFile)
+	if err != nil {
+		return false
+	}
+	name := strings.TrimSpace(string(data))
+	if name == "Google" || name == "Google Compute Engine" {
+		// Just because we're on Google, does not mean workload identity is available.
+		// TODO(mattmoor): do something better than this.
+		_, err := gwi.Provide(ctx, "garbage")
+		return err == nil
+	}
+	return false
+}
+
+// Provide implements providers.Interface
+func (gwi *googleWorkloadIdentity) Provide(ctx context.Context, audience string) (string, error) {
+	ts, err := idtoken.NewTokenSource(ctx, audience)
+	if err != nil {
+		return "", err
+	}
+	tok, err := ts.Token()
+	if err != nil {
+		return "", err
+	}
+	return tok.AccessToken, nil
+}
+
+type googleImpersonate struct{}
+
+var _ providers.Interface = (*googleImpersonate)(nil)
+
+// Enabled implements providers.Interface
+func (gi *googleImpersonate) Enabled(ctx context.Context) bool {
+	// The "impersonate" method requires a target service account to impersonate.
+	return os.Getenv("GOOGLE_SERVICE_ACCOUNT_NAME") != ""
+}
+
+// Provide implements providers.Interface
+func (gi *googleImpersonate) Provide(ctx context.Context, audience string) (string, error) {
+	target := os.Getenv("GOOGLE_SERVICE_ACCOUNT_NAME")
+	ts, err := impersonate.IDTokenSource(ctx, impersonate.IDTokenConfig{
+		Audience:        "sigstore",
+		TargetPrincipal: target,
+		IncludeEmail:    true,
+	})
+	if err != nil {
+		return "", err
+	}
+	tok, err := ts.Token()
+	if err != nil {
+		return "", err
+	}
+	return tok.AccessToken, nil
+}

--- a/vendor/github.com/sigstore/cosign/pkg/providers/interface.go
+++ b/vendor/github.com/sigstore/cosign/pkg/providers/interface.go
@@ -1,0 +1,85 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	m         sync.Mutex
+	providers = make(map[string]Interface)
+)
+
+// Interface is what providers need to implement to participate in furnishing OIDC tokens.
+type Interface interface {
+	// Enabled returns true if the provider is enabled.
+	Enabled(ctx context.Context) bool
+
+	// Provide returns an OIDC token scoped to the provided audience.
+	Provide(ctx context.Context, audience string) (string, error)
+}
+
+// Register is used by providers to participate in furnishing OIDC tokens.
+func Register(name string, p Interface) {
+	m.Lock()
+	defer m.Unlock()
+
+	if prev, ok := providers[name]; ok {
+		panic(fmt.Sprintf("duplicate provider for name %q, %T and %T", name, prev, p))
+	}
+	providers[name] = p
+}
+
+// Enabled checks whether any of the registered providers are enabled in this execution context.
+func Enabled(ctx context.Context) bool {
+	m.Lock()
+	defer m.Unlock()
+
+	for _, provider := range providers {
+		if provider.Enabled(ctx) {
+			return true
+		}
+	}
+	return false
+}
+
+// Provide fetches an OIDC token from one of the active providers.
+func Provide(ctx context.Context, audience string) (string, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	var id string
+	var err error
+	for _, provider := range providers {
+		if !provider.Enabled(ctx) {
+			continue
+		}
+		id, err = provider.Provide(ctx, audience)
+		if err == nil {
+			return id, err
+		}
+	}
+	// return the last id/err combo, unless there wasn't an error in
+	// which case provider.Enabled() wasn't checked.
+	if err == nil {
+		err = errors.New("no providers are enabled, check providers.Enabled() before providers.Provide()")
+	}
+	return id, err
+}

--- a/vendor/google.golang.org/api/impersonate/doc.go
+++ b/vendor/google.golang.org/api/impersonate/doc.go
@@ -1,0 +1,32 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package impersonate is used to impersonate Google Credentials.
+//
+// Required IAM roles
+//
+// In order to impersonate a service account the base service account must have
+// the Service Account Token Creator role, roles/iam.serviceAccountTokenCreator,
+// on the service account being impersonated. See
+// https://cloud.google.com/iam/docs/understanding-service-accounts.
+//
+// Optionally, delegates can be used during impersonation if the base service
+// account lacks the token creator role on the target. When using delegates,
+// each service account must be granted roles/iam.serviceAccountTokenCreator
+// on the next service account in the delgation chain.
+//
+// For example, if a base service account of SA1 is trying to impersonate target
+// service account SA2 while using delegate service accounts DSA1 and DSA2,
+// the following must be true:
+//
+//   1. Base service account SA1 has roles/iam.serviceAccountTokenCreator on
+//      DSA1.
+//   2. DSA1 has roles/iam.serviceAccountTokenCreator on DSA2.
+//   3. DSA2 has roles/iam.serviceAccountTokenCreator on target SA2.
+//
+// If the base credential is an authorized user and not a service account, or if
+// the option WithQuotaProject is set, the target service account must have a
+// role that grants the serviceusage.services.use permission such as
+// roles/serviceusage.serviceUsageConsumer.
+package impersonate

--- a/vendor/google.golang.org/api/impersonate/idtoken.go
+++ b/vendor/google.golang.org/api/impersonate/idtoken.go
@@ -1,0 +1,129 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package impersonate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+	htransport "google.golang.org/api/transport/http"
+)
+
+// IDTokenConfig for generating an impersonated ID token.
+type IDTokenConfig struct {
+	// Audience is the `aud` field for the token, such as an API endpoint the
+	// token will grant access to. Required.
+	Audience string
+	// TargetPrincipal is the email address of the service account to
+	// impersonate. Required.
+	TargetPrincipal string
+	// IncludeEmail includes the service account's email in the token. The
+	// resulting token will include both an `email` and `email_verified`
+	// claim.
+	IncludeEmail bool
+	// Delegates are the service account email addresses in a delegation chain.
+	// Each service account must be granted roles/iam.serviceAccountTokenCreator
+	// on the next service account in the chain. Optional.
+	Delegates []string
+}
+
+// IDTokenSource creates an impersonated TokenSource that returns ID tokens
+// configured with the provided config and using credentials loaded from
+// Application Default Credentials as the base credentials. The tokens provided
+// by the source are valid for one hour and are automatically refreshed.
+func IDTokenSource(ctx context.Context, config IDTokenConfig, opts ...option.ClientOption) (oauth2.TokenSource, error) {
+	if config.Audience == "" {
+		return nil, fmt.Errorf("impersonate: an audience must be provided")
+	}
+	if config.TargetPrincipal == "" {
+		return nil, fmt.Errorf("impersonate: a target service account must be provided")
+	}
+
+	clientOpts := append(defaultClientOptions(), opts...)
+	client, _, err := htransport.NewClient(ctx, clientOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	its := impersonatedIDTokenSource{
+		client:          client,
+		targetPrincipal: config.TargetPrincipal,
+		audience:        config.Audience,
+		includeEmail:    config.IncludeEmail,
+	}
+	for _, v := range config.Delegates {
+		its.delegates = append(its.delegates, formatIAMServiceAccountName(v))
+	}
+	return oauth2.ReuseTokenSource(nil, its), nil
+}
+
+type generateIDTokenRequest struct {
+	Audience     string   `json:"audience"`
+	IncludeEmail bool     `json:"includeEmail"`
+	Delegates    []string `json:"delegates,omitempty"`
+}
+
+type generateIDTokenResponse struct {
+	Token string `json:"token"`
+}
+
+type impersonatedIDTokenSource struct {
+	client *http.Client
+
+	targetPrincipal string
+	audience        string
+	includeEmail    bool
+	delegates       []string
+}
+
+func (i impersonatedIDTokenSource) Token() (*oauth2.Token, error) {
+	now := time.Now()
+	genIDTokenReq := generateIDTokenRequest{
+		Audience:     i.audience,
+		IncludeEmail: i.includeEmail,
+		Delegates:    i.delegates,
+	}
+	bodyBytes, err := json.Marshal(genIDTokenReq)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to marshal request: %v", err)
+	}
+
+	url := fmt.Sprintf("%s/v1/%s:generateIdToken", iamCredentailsEndpoint, formatIAMServiceAccountName(i.targetPrincipal))
+	req, err := http.NewRequest("POST", url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := i.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to generate ID token: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to read body: %v", err)
+	}
+	if c := resp.StatusCode; c < 200 || c > 299 {
+		return nil, fmt.Errorf("impersonate: status code %d: %s", c, body)
+	}
+
+	var generateIDTokenResp generateIDTokenResponse
+	if err := json.Unmarshal(body, &generateIDTokenResp); err != nil {
+		return nil, fmt.Errorf("impersonate: unable to parse response: %v", err)
+	}
+	return &oauth2.Token{
+		AccessToken: generateIDTokenResp.Token,
+		// Generated ID tokens are good for one hour.
+		Expiry: now.Add(1 * time.Hour),
+	}, nil
+}

--- a/vendor/google.golang.org/api/impersonate/impersonate.go
+++ b/vendor/google.golang.org/api/impersonate/impersonate.go
@@ -1,0 +1,184 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package impersonate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
+	htransport "google.golang.org/api/transport/http"
+)
+
+var (
+	iamCredentailsEndpoint = "https://iamcredentials.googleapis.com"
+	oauth2Endpoint         = "https://oauth2.googleapis.com"
+)
+
+// CredentialsConfig for generating impersonated credentials.
+type CredentialsConfig struct {
+	// TargetPrincipal is the email address of the service account to
+	// impersonate. Required.
+	TargetPrincipal string
+	// Scopes that the impersonated credential should have. Required.
+	Scopes []string
+	// Delegates are the service account email addresses in a delegation chain.
+	// Each service account must be granted roles/iam.serviceAccountTokenCreator
+	// on the next service account in the chain. Optional.
+	Delegates []string
+	// Lifetime is the amount of time until the impersonated token expires. If
+	// unset the token's lifetime will be one hour and be automatically
+	// refreshed. If set the token may have a max lifetime of one hour and will
+	// not be refreshed. Service accounts that have been added to an org policy
+	// with constraints/iam.allowServiceAccountCredentialLifetimeExtension may
+	// request a token lifetime of up to 12 hours. Optional.
+	Lifetime time.Duration
+	// Subject is the sub field of a JWT. This field should only be set if you
+	// wish to impersonate as a user. This feature is useful when using domain
+	// wide delegation. Optional.
+	Subject string
+}
+
+// defaultClientOptions ensures the base credentials will work with the IAM
+// Credentials API if no scope or audience is set by the user.
+func defaultClientOptions() []option.ClientOption {
+	return []option.ClientOption{
+		internaloption.WithDefaultAudience("https://iamcredentials.googleapis.com/"),
+		internaloption.WithDefaultScopes("https://www.googleapis.com/auth/cloud-platform"),
+	}
+}
+
+// CredentialsTokenSource returns an impersonated CredentialsTokenSource configured with the provided
+// config and using credentials loaded from Application Default Credentials as
+// the base credentials.
+func CredentialsTokenSource(ctx context.Context, config CredentialsConfig, opts ...option.ClientOption) (oauth2.TokenSource, error) {
+	if config.TargetPrincipal == "" {
+		return nil, fmt.Errorf("impersonate: a target service account must be provided")
+	}
+	if len(config.Scopes) == 0 {
+		return nil, fmt.Errorf("impersonate: scopes must be provided")
+	}
+	if config.Lifetime.Hours() > 12 {
+		return nil, fmt.Errorf("impersonate: max lifetime is 12 hours")
+	}
+
+	var isStaticToken bool
+	// Default to the longest acceptable value of one hour as the token will
+	// be refreshed automatically if not set.
+	lifetime := 3600 * time.Second
+	if config.Lifetime != 0 {
+		lifetime = config.Lifetime
+		// Don't auto-refresh token if a lifetime is configured.
+		isStaticToken = true
+	}
+
+	clientOpts := append(defaultClientOptions(), opts...)
+	client, _, err := htransport.NewClient(ctx, clientOpts...)
+	if err != nil {
+		return nil, err
+	}
+	// If a subject is specified a different auth-flow is initiated to
+	// impersonate as the provided subject (user).
+	if config.Subject != "" {
+		return user(ctx, config, client, lifetime, isStaticToken)
+	}
+
+	its := impersonatedTokenSource{
+		client:          client,
+		targetPrincipal: config.TargetPrincipal,
+		lifetime:        fmt.Sprintf("%.fs", lifetime.Seconds()),
+	}
+	for _, v := range config.Delegates {
+		its.delegates = append(its.delegates, formatIAMServiceAccountName(v))
+	}
+	its.scopes = make([]string, len(config.Scopes))
+	copy(its.scopes, config.Scopes)
+
+	if isStaticToken {
+		tok, err := its.Token()
+		if err != nil {
+			return nil, err
+		}
+		return oauth2.StaticTokenSource(tok), nil
+	}
+	return oauth2.ReuseTokenSource(nil, its), nil
+}
+
+func formatIAMServiceAccountName(name string) string {
+	return fmt.Sprintf("projects/-/serviceAccounts/%s", name)
+}
+
+type generateAccessTokenReq struct {
+	Delegates []string `json:"delegates,omitempty"`
+	Lifetime  string   `json:"lifetime,omitempty"`
+	Scope     []string `json:"scope,omitempty"`
+}
+
+type generateAccessTokenResp struct {
+	AccessToken string `json:"accessToken"`
+	ExpireTime  string `json:"expireTime"`
+}
+
+type impersonatedTokenSource struct {
+	client *http.Client
+
+	targetPrincipal string
+	lifetime        string
+	scopes          []string
+	delegates       []string
+}
+
+// Token returns an impersonated Token.
+func (i impersonatedTokenSource) Token() (*oauth2.Token, error) {
+	reqBody := generateAccessTokenReq{
+		Delegates: i.delegates,
+		Lifetime:  i.lifetime,
+		Scope:     i.scopes,
+	}
+	b, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to marshal request: %v", err)
+	}
+	url := fmt.Sprintf("%s/v1/%s:generateAccessToken", iamCredentailsEndpoint, formatIAMServiceAccountName(i.targetPrincipal))
+	req, err := http.NewRequest("POST", url, bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := i.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to generate access token: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to read body: %v", err)
+	}
+	if c := resp.StatusCode; c < 200 || c > 299 {
+		return nil, fmt.Errorf("impersonate: status code %d: %s", c, body)
+	}
+
+	var accessTokenResp generateAccessTokenResp
+	if err := json.Unmarshal(body, &accessTokenResp); err != nil {
+		return nil, fmt.Errorf("impersonate: unable to parse response: %v", err)
+	}
+	expiry, err := time.Parse(time.RFC3339, accessTokenResp.ExpireTime)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to parse expiry: %v", err)
+	}
+	return &oauth2.Token{
+		AccessToken: accessTokenResp.AccessToken,
+		Expiry:      expiry,
+	}, nil
+}

--- a/vendor/google.golang.org/api/impersonate/user.go
+++ b/vendor/google.golang.org/api/impersonate/user.go
@@ -1,0 +1,169 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package impersonate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func user(ctx context.Context, c CredentialsConfig, client *http.Client, lifetime time.Duration, isStaticToken bool) (oauth2.TokenSource, error) {
+	u := userTokenSource{
+		client:          client,
+		targetPrincipal: c.TargetPrincipal,
+		subject:         c.Subject,
+		lifetime:        lifetime,
+	}
+	u.delegates = make([]string, len(c.Delegates))
+	for i, v := range c.Delegates {
+		u.delegates[i] = formatIAMServiceAccountName(v)
+	}
+	u.scopes = make([]string, len(c.Scopes))
+	copy(u.scopes, c.Scopes)
+	if isStaticToken {
+		tok, err := u.Token()
+		if err != nil {
+			return nil, err
+		}
+		return oauth2.StaticTokenSource(tok), nil
+	}
+	return oauth2.ReuseTokenSource(nil, u), nil
+}
+
+type claimSet struct {
+	Iss   string `json:"iss"`
+	Scope string `json:"scope,omitempty"`
+	Sub   string `json:"sub,omitempty"`
+	Aud   string `json:"aud"`
+	Iat   int64  `json:"iat"`
+	Exp   int64  `json:"exp"`
+}
+
+type signJWTRequest struct {
+	Payload   string   `json:"payload"`
+	Delegates []string `json:"delegates,omitempty"`
+}
+
+type signJWTResponse struct {
+	// KeyID is the key used to sign the JWT.
+	KeyID string `json:"keyId"`
+	// SignedJwt contains the automatically generated header; the
+	// client-supplied payload; and the signature, which is generated using
+	// the key referenced by the `kid` field in the header.
+	SignedJWT string `json:"signedJwt"`
+}
+
+type exchangeTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int64  `json:"expires_in"`
+}
+
+type userTokenSource struct {
+	client *http.Client
+
+	targetPrincipal string
+	subject         string
+	scopes          []string
+	lifetime        time.Duration
+	delegates       []string
+}
+
+func (u userTokenSource) Token() (*oauth2.Token, error) {
+	signedJWT, err := u.signJWT()
+	if err != nil {
+		return nil, err
+	}
+	return u.exchangeToken(signedJWT)
+}
+
+func (u userTokenSource) signJWT() (string, error) {
+	now := time.Now()
+	exp := now.Add(u.lifetime)
+	claims := claimSet{
+		Iss:   u.targetPrincipal,
+		Scope: strings.Join(u.scopes, " "),
+		Sub:   u.subject,
+		Aud:   fmt.Sprintf("%s/token", oauth2Endpoint),
+		Iat:   now.Unix(),
+		Exp:   exp.Unix(),
+	}
+	payloadBytes, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("impersonate: unable to marshal claims: %v", err)
+	}
+	signJWTReq := signJWTRequest{
+		Payload:   string(payloadBytes),
+		Delegates: u.delegates,
+	}
+
+	bodyBytes, err := json.Marshal(signJWTReq)
+	if err != nil {
+		return "", fmt.Errorf("impersonate: unable to marshal request: %v", err)
+	}
+	reqURL := fmt.Sprintf("%s/v1/%s:signJwt", iamCredentailsEndpoint, formatIAMServiceAccountName(u.targetPrincipal))
+	req, err := http.NewRequest("POST", reqURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("impersonate: unable to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	rawResp, err := u.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("impersonate: unable to sign JWT: %v", err)
+	}
+	body, err := ioutil.ReadAll(io.LimitReader(rawResp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("impersonate: unable to read body: %v", err)
+	}
+	if c := rawResp.StatusCode; c < 200 || c > 299 {
+		return "", fmt.Errorf("impersonate: status code %d: %s", c, body)
+	}
+
+	var signJWTResp signJWTResponse
+	if err := json.Unmarshal(body, &signJWTResp); err != nil {
+		return "", fmt.Errorf("impersonate: unable to parse response: %v", err)
+	}
+	return signJWTResp.SignedJWT, nil
+}
+
+func (u userTokenSource) exchangeToken(signedJWT string) (*oauth2.Token, error) {
+	now := time.Now()
+	v := url.Values{}
+	v.Set("grant_type", "assertion")
+	v.Set("assertion_type", "http://oauth.net/grant_type/jwt/1.0/bearer")
+	v.Set("assertion", signedJWT)
+	rawResp, err := u.client.PostForm(fmt.Sprintf("%s/token", oauth2Endpoint), v)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to exchange token: %v", err)
+	}
+	body, err := ioutil.ReadAll(io.LimitReader(rawResp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to read body: %v", err)
+	}
+	if c := rawResp.StatusCode; c < 200 || c > 299 {
+		return nil, fmt.Errorf("impersonate: status code %d: %s", c, body)
+	}
+
+	var tokenResp exchangeTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("impersonate: unable to parse response: %v", err)
+	}
+
+	return &oauth2.Token{
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+		Expiry:      now.Add(time.Second * time.Duration(tokenResp.ExpiresIn)),
+	}, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -916,6 +916,8 @@ github.com/sigstore/cosign/pkg/oci/mutate
 github.com/sigstore/cosign/pkg/oci/remote
 github.com/sigstore/cosign/pkg/oci/signed
 github.com/sigstore/cosign/pkg/oci/static
+github.com/sigstore/cosign/pkg/providers
+github.com/sigstore/cosign/pkg/providers/google
 github.com/sigstore/cosign/pkg/signature
 github.com/sigstore/cosign/pkg/types
 github.com/sigstore/cosign/pkg/version
@@ -1340,6 +1342,7 @@ google.golang.org/api/googleapi
 google.golang.org/api/googleapi/transport
 google.golang.org/api/iamcredentials/v1
 google.golang.org/api/idtoken
+google.golang.org/api/impersonate
 google.golang.org/api/internal
 google.golang.org/api/internal/gensupport
 google.golang.org/api/internal/impersonate


### PR DESCRIPTION
The Fulcio integration test doesn't run in CI right now, but I ran it locally and it passed so hopefully it should be ok 🤞🏽 

```
$ go test -tags=e2e -run TestFulcio -v ./test/...
=== RUN   TestFulcio
--- PASS: TestFulcio (39.76s)
PASS
ok      github.com/tektoncd/chains/test 39.939s

```

fixes https://github.com/tektoncd/chains/issues/317