### PR TITLE
Use cosign flags with 2 hyphens

### DIFF
--- a/docs/tutorials/signed-provenance-tutorial.md
+++ b/docs/tutorials/signed-provenance-tutorial.md
@@ -113,8 +113,8 @@ kubectl get tr [TASKRUN_NAME] -o json | jq -r .metadata.annotations
 To verify the image and the attestation, we'll use `cosign` again:
 
 ```shell
-cosign verify -key cosign.pub $REGISTRY/kaniko-chains
-cosign verify-attestation -key cosign.pub $REGISTRY/kaniko-chains
+cosign verify --key cosign.pub $REGISTRY/kaniko-chains
+cosign verify-attestation --key cosign.pub $REGISTRY/kaniko-chains
 ```
 
 You should see verification output for both!

--- a/test/kaniko.go
+++ b/test/kaniko.go
@@ -125,10 +125,10 @@ func verifyKanikoTaskRun(namespace, destinationImage, publicKey string) *v1beta1
 echo "%s" > cosign.pub
 
 # verify the image
-cosign verify -allow-insecure-registry -key cosign.pub %s
+cosign verify --allow-insecure-registry --key cosign.pub %s
 
 # verify the attestation
-cosign verify-attestation -allow-insecure-registry -key cosign.pub %s`
+cosign verify-attestation --allow-insecure-registry --key cosign.pub %s`
 	script = fmt.Sprintf(script, publicKey, destinationImage, destinationImage)
 
 	return &v1beta1.TaskRun{


### PR DESCRIPTION
cosign will soon be moving away from flags with a single hyphen to
double hyphens, e.g. `-key` will be deprecated in favor of `--key`.
This commit fixes that.