### PR TITLE
Make builder id for SLSA provenance valid URI

### DIFF
--- a/pkg/chains/formats/provenance/provenance_test.go
+++ b/pkg/chains/formats/provenance/provenance_test.go
@@ -274,10 +274,10 @@ spec:
 			"my-param={string string-param []}",
 			"my-array-param={array  [my array]}",
 		},
-		ID: "tekton-chains",
+		ID: "https://tekton.dev/chains/v2",
 	}
 
-	got := invocation("tekton-chains", taskRun)
+	got := invocation("https://tekton.dev/chains/v2", taskRun)
 	if !reflect.DeepEqual(expected, got) {
 		if d := cmp.Diff(expected, got); d != "" {
 			t.Log(d)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,7 +156,7 @@ func defaultConfig() *Config {
 			},
 		},
 		Builder: BuilderConfig{
-			ID: "tekton-chains",
+			ID: "https://tekton.dev/chains/v2",
 		},
 	}
 }

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -105,7 +105,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     true,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -132,7 +132,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     true,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -159,7 +159,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     true,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -186,7 +186,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     true,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -213,7 +213,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     false,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -240,7 +240,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     false,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -267,7 +267,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     true,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -294,7 +294,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     true,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -321,7 +321,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     true,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -350,7 +350,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     true,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -380,7 +380,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     true,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -413,7 +413,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     true,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
@@ -446,7 +446,7 @@ func TestParse(t *testing.T) {
 			ociEnbaled:     true,
 			want: Config{
 				Builder: BuilderConfig{
-					"tekton-chains",
+					"https://tekton.dev/chains/v2",
 				},
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{

--- a/test/testdata/intoto/task-output-image.json
+++ b/test/testdata/intoto/task-output-image.json
@@ -11,7 +11,7 @@
     ],
     "predicate": {
         "builder": {
-            "id": "tekton-chains"
+            "id": "https://tekton.dev/chains/v2"
         },
         "buildType": "https://tekton.dev/attestations/chains@v2",
         "invocation": {


### PR DESCRIPTION
The SLSA provenance v0.2 spec requires that the builder.id be a
valid URI. It was just "tekton-chains" this changes it to
"https://tekton.dev/chains/v2"