### PR TITLE
Move the underscore import to `package main`.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -20,6 +20,12 @@ import (
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/signals"
+
+	// Run with all of the upstream providers.
+	// We link this here to give downstreams greater choice/control over
+	// which providers they pull in, by linking their own variants in their
+	// own binary entrypoint.
+	_ "github.com/sigstore/cosign/pkg/providers/all"
 )
 
 var namespace = flag.String("namespace", "", "Namespace to restrict informer to. Optional, defaults to all namespaces.")

--- a/pkg/chains/signing/x509/x509.go
+++ b/pkg/chains/signing/x509/x509.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/providers"
-	_ "github.com/sigstore/cosign/pkg/providers/all"
 
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/chains/pkg/chains/signing"


### PR DESCRIPTION
It occurred to me that this is a kind of "code smell" akin to logging or defining flags in a library, so I moved the underscore import into the `package main` to make things a bit nicer for folks to consume downstream.

cc @dlorenc @priyawadhwa 