### PR TITLE
Remove un-used options from `artifacts.oci.format` and `artifacts.oci.storage`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -57,7 +57,7 @@ Supported keys include:
 
 | Key | Description | Supported Values | Default |
 | :--- | :--- | :--- | :--- |
-| `artifacts.oci.format` | The format to store `OCI` payloads in. | `tekton`, `simplesigning` | `simplesigning` |
+| `artifacts.oci.format` | The format to store `OCI` payloads in. | `simplesigning` | `simplesigning` |
 | `artifacts.oci.storage` | The storage backend to store `OCI` signatures in. Multiple backends can be specified with comma-separated list ("oci,tekton"). To disable the `OCI` artifact input an empty string ("").| `tekton`, `oci`, `gcs`, `docdb` | `oci` |
 | `artifacts.oci.signer` | The signature backend to sign `OCI` payloads with. | `x509`, `kms` | `x509` |
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -172,7 +172,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		asStringSet(taskrunStorageKey, &cfg.Artifacts.TaskRuns.StorageBackend, sets.NewString("tekton", "oci", "gcs", "docdb")),
 		asString(taskrunSignerKey, &cfg.Artifacts.TaskRuns.Signer, "x509", "kms"),
 		// OCI
-		asString(ociFormatKey, &cfg.Artifacts.OCI.Format, "tekton", "simplesigning"),
+		asString(ociFormatKey, &cfg.Artifacts.OCI.Format, "simplesigning"),
 		asStringSet(ociStorageKey, &cfg.Artifacts.OCI.StorageBackend, sets.NewString("tekton", "oci", "gcs", "docdb")),
 		asString(ociSignerKey, &cfg.Artifacts.OCI.Signer, "x509", "kms"),
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -70,7 +70,7 @@ func TestTektonStorage(t *testing.T) {
 		"artifacts.taskrun.format":  "tekton",
 		"artifacts.taskrun.signer":  "x509",
 		"artifacts.taskrun.storage": "tekton",
-		"artifacts.oci.format":      "tekton",
+		"artifacts.oci.format":      "simplesigning",
 		"artifacts.oci.signer":      "x509",
 		"artifacts.oci.storage":     "tekton",
 	})
@@ -101,7 +101,7 @@ func TestRekor(t *testing.T) {
 		"artifacts.taskrun.format":  "tekton",
 		"artifacts.taskrun.signer":  "x509",
 		"artifacts.taskrun.storage": "tekton",
-		"artifacts.oci.format":      "tekton",
+		"artifacts.oci.format":      "simplesigning",
 		"artifacts.oci.signer":      "x509",
 		"artifacts.oci.storage":     "tekton",
 		"transparency.enabled":      "manual",


### PR DESCRIPTION
Address issue #332

Removing the `tekton` option for `artifacts.oci.format` as it causes the errors with signature validation via cosign.
Change to have `oci` as an the only option for `artifacts.oci.storage`