### PR TITLE
Add `chains-info` ConfigMap with version info

### DIFF
--- a/config/100-rolebinding.yaml
+++ b/config/100-rolebinding.yaml
@@ -138,3 +138,42 @@ roleRef:
   kind: Role
   name: tekton-chains-leader-election
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tekton-chains-info
+  namespace: tekton-chains
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-chains
+rules:
+  # All system:authenticated users need to have access
+  # to the chains-info ConfigMap even if they don't
+  # have access to other resources present in the
+  # installed namespace
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["chains-info"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-chains-info
+  namespace: tekton-chains
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-chains
+subjects:
+  # Giving all system:authenticated users the access to the
+  # ConfigMap which contains version information
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-chains-info

--- a/config/config-info.yaml
+++ b/config/config-info.yaml
@@ -1,0 +1,30 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chains-info
+  namespace: tekton-chains
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-chains
+data:
+  # Contains chains version which can be queried by external
+  # tools such as CLI. Elevated permissions are given to
+  # this ConfigMap such that even if we don't have access to
+  # other resources in the namespace, we can still access
+  # this ConfigMap.
+  version: "devel"


### PR DESCRIPTION
This commit adds a `chains-info` ConfigMap which contains the version of
Chains installed on the cluster. This is meant to be primarily read by
other tools like `tkn` to display component version.

This ConfigMap can be read by someone who does not even have permissions
to view other resources in the `tekton-chains` namespace, hence making
it easier to advertise the version instead of having tools wrangle with
labels on deployments to which permissions might be limited.

This is in line with similar `<component>-info` ConfigMaps used in other
Tekton components like Pipeline and Triggers.

Fix #336

FYI: @priyawadhwa the `version` field will be updated during release here - https://github.com/tektoncd/chains/blob/61c344977ae3edbd7827e649c6d6126f30649969/release/publish.yaml#L133-L134

CC: @vinamra28 since you implemented this for other components, LMK if I missed something.