### PR TITLE
Add securityContext to controller pod

### DIFF
--- a/config/100-deployment.yaml
+++ b/config/100-deployment.yaml
@@ -98,6 +98,11 @@ spec:
               fieldPath: metadata.namespace
         - name: METRICS_DOMAIN
           value: tekton.dev/chains
+        securityContext:
+          allowPrivilegeEscalation: false
+          # User 65532 is the distroless nonroot user ID
+          runAsUser: 65532
+          runAsGroup: 65532
       volumes:
       - name: signing-secrets
         secret:


### PR DESCRIPTION
This commit adds securityContext to the controller pod which has been
missing till now. This is in line with securityContext in other Tekton
components like pipeline and triggers.

There are a few reasons why securityContext is important to add to the
controller:
- the securityContext specifies the user and group as 65532 which is
  what is used by the distroless nonroot image that ko uses in the
  controller image.
- securityContext is also useful in distributions like OpenShift which
  assign a random user while running a pod. If securityContext is not
  set, the controller fails with permission denied errors like in #320