### PR TITLE
Fix namespace typo

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,7 +89,7 @@ ko delete -f config/
 To look at the controller logs, run:
 
 ```shell
-kubectl -n tekton-pipelines logs deployment/tekton-chains-controller
+kubectl -n tekton-chains logs deployment/tekton-chains-controller
 ```
 
 ## Running Tests


### PR DESCRIPTION
This commit changes the namespace mentioned in the docs from
`tekton-pipelines` to `tekton-chains`.