### PR TITLE
Change default Fulcio URL to match cosign's

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -152,7 +152,7 @@ func defaultConfig() *Config {
 		},
 		Signers: SignerConfigs{
 			X509: X509Signer{
-				FulcioAddr: "https://fulcio.sigstore.dev",
+				FulcioAddr: "https://v1.fulcio.sigstore.dev",
 			},
 		},
 		Builder: BuilderConfig{

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -86,7 +86,7 @@ func TestNewConfigStore(t *testing.T) {
 
 var defaultSigners = SignerConfigs{
 	X509: X509Signer{
-		FulcioAddr: "https://fulcio.sigstore.dev",
+		FulcioAddr: "https://v1.fulcio.sigstore.dev",
 	},
 }
 
@@ -429,7 +429,7 @@ func TestParse(t *testing.T) {
 				},
 				Signers: SignerConfigs{
 					X509: X509Signer{
-						FulcioAddr: "https://fulcio.sigstore.dev",
+						FulcioAddr: "https://v1.fulcio.sigstore.dev",
 					},
 				},
 				Transparency: TransparencyConfig{
@@ -462,7 +462,7 @@ func TestParse(t *testing.T) {
 				},
 				Signers: SignerConfigs{
 					X509: X509Signer{
-						FulcioAddr: "https://fulcio.sigstore.dev",
+						FulcioAddr: "https://v1.fulcio.sigstore.dev",
 					},
 				},
 				Transparency: TransparencyConfig{


### PR DESCRIPTION
Currently *cosign* is using https://v1.fulcio.sigstore.dev as the default. Changing *chains* to use the same.

Signed-off-by: Nghia Tran <tcnghia@gmail.com>