### PR TITLE
Adding Spire OIDC for Vault authentication

### DIFF
--- a/config/100-deployment.yaml
+++ b/config/100-deployment.yaml
@@ -92,6 +92,8 @@ spec:
           mountPath: /etc/signing-secrets
         - name: oidc-info
           mountPath: /var/run/sigstore/cosign
+        - name: spire-agent-socket
+          mountPath: /tmp/spire-agent/public
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -120,3 +122,7 @@ spec:
                 path: oidc-token
                 expirationSeconds: 600 # Use as short-lived as possible.
                 audience: sigstore
+      - name: spire-agent-socket
+        hostPath:
+          path: /run/spire/sockets
+          type: DirectoryOrCreate

--- a/config/100-deployment.yaml
+++ b/config/100-deployment.yaml
@@ -92,8 +92,6 @@ spec:
           mountPath: /etc/signing-secrets
         - name: oidc-info
           mountPath: /var/run/sigstore/cosign
-        - name: spire-agent-socket
-          mountPath: /tmp/spire-agent/public
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -122,7 +120,3 @@ spec:
                 path: oidc-token
                 expirationSeconds: 600 # Use as short-lived as possible.
                 audience: sigstore
-      - name: spire-agent-socket
-        hostPath:
-          path: /run/spire/sockets
-          type: DirectoryOrCreate

--- a/docs/config.md
+++ b/docs/config.md
@@ -68,6 +68,11 @@ Supported keys include:
 | Key | Description | Supported Values | Default |
 | :--- | :--- | :--- | :--- |
 | `signers.kms.kmsref` | The URI reference to a KMS service to use in `KMS` signers. | `gcpkms://projects/[PROJECT]/locations/[LOCATION]>/keyRings/[KEYRING]/cryptoKeys/[KEY]`| |
+| `signers.kms.auth.address` | URI of KMS server (e.g. the value of `VAULT_TOKEN`) | |
+| `signers.kms.auth.path` | Path used for authentication (e.g. `jwt` for Vault) | |
+| `signers.kms.auth.role` | Role used for authentication | |
+| `signers.kms.auth.spire.sock` | URI of the Spire socket used for KMS auth (e.g. `unix:///run/spire/sockets/agent.sock`) | |
+| `signers.kms.auth.spire.audience` | Audience for requesting a SVID from Spire | |
 
 ### Storage Configuration
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -68,11 +68,6 @@ Supported keys include:
 | Key | Description | Supported Values | Default |
 | :--- | :--- | :--- | :--- |
 | `signers.kms.kmsref` | The URI reference to a KMS service to use in `KMS` signers. | `gcpkms://projects/[PROJECT]/locations/[LOCATION]>/keyRings/[KEYRING]/cryptoKeys/[KEY]`| |
-| `signers.kms.auth.address` | URI of KMS server (e.g. the value of `VAULT_TOKEN`) | |
-| `signers.kms.auth.path` | Path used for authentication (e.g. `jwt` for Vault) | |
-| `signers.kms.auth.role` | Role used for authentication | |
-| `signers.kms.auth.spire.sock` | URI of the Spire socket used for KMS auth (e.g. `unix:///run/spire/sockets/agent.sock`) | |
-| `signers.kms.auth.spire.audience` | Audience for requesting a SVID from Spire | |
 
 ### Storage Configuration
 
@@ -111,3 +106,14 @@ chains.tekton.dev/transparency-upload: "true"
 | :--- | :--- | :--- | :--- |
 | `signers.x509.fulcio.enabled` | EXPERIMENTAL. Whether to enable automatic certificates from fulcio. | `true`, `false` | `false`|
 | `signers.x509.fulcio.address` | EXPERIMENTAL. Fulcio address to request certificate from, if enabled | |`https://v1.fulcio.sigstore.dev` |
+
+#### KMS OIDC and Spire Configuration
+
+| Key | Description | Supported Values | Default |
+| :--- | :--- | :--- | :--- |
+| `signers.kms.auth.address` | URI of KMS server (e.g. the value of `VAULT_ADDR`) | |
+| `signers.kms.auth.token` | Auth token KMS server (e.g. the value of `VAULT_TOKEN`) | |
+| `signers.kms.auth.oidc.path` | Path used for OIDC authentication (e.g. `jwt` for Vault) | |
+| `signers.kms.auth.oidc.role` | Role used for OIDC authentication | |
+| `signers.kms.auth.spire.sock` | URI of the Spire socket used for KMS token (e.g. `unix:///tmp/spire-agent/public/api.sock`) | |
+| `signers.kms.auth.spire.audience` | Audience for requesting a SVID from Spire | |

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/sigstore/cosign v1.6.1-0.20220401112351-80034ba3b905
 	github.com/sigstore/rekor v0.4.1-0.20220114213500-23f583409af3
 	github.com/sigstore/sigstore v1.2.1-0.20220330193110-d7475aecf1db
+	github.com/spiffe/go-spiffe/v2 v2.0.0
 	github.com/tektoncd/pipeline v0.31.1-0.20220105002759-3e137645be61
 	github.com/tektoncd/plumbing v0.0.0-20211012143332-c7cc43d9bc0c
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399
@@ -305,7 +306,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.10.1 // indirect
-	github.com/spiffe/go-spiffe/v2 v2.0.0 // indirect
 	github.com/src-d/gcfg v1.4.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,6 +73,19 @@ type X509Signer struct {
 
 type KMSSigner struct {
 	KMSRef string
+	Auth   KMSAuth
+}
+
+type KMSAuth struct {
+	Spire   KMSAuthSpire
+	Address string
+	Path    string
+	Role    string
+}
+
+type KMSAuthSpire struct {
+	Sock     string
+	Audience string
 }
 
 type GCSStorageConfig struct {
@@ -124,7 +137,13 @@ const (
 	// No config needed for x509 signer
 
 	// KMS
-	kmsSignerKMSRef = "signers.kms.kmsref"
+	kmsSignerKMSRef      = "signers.kms.kmsref"
+	kmsAuthAddress       = "signers.kms.auth.address"
+	kmsAuthPath          = "signers.kms.auth.path"
+	kmsAuthRole          = "signers.kms.auth.role"
+	kmsAuthSpireSock     = "signers.kms.auth.spire.sock"
+	kmsAuthSpireAudience = "signers.kms.auth.spire.audience"
+
 	// Fulcio
 	x509SignerFulcioEnabled = "signers.x509.fulcio.enabled"
 	x509SignerFulcioAuth    = "signers.x509.fulcio.auth"
@@ -199,6 +218,11 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		asString(transparencyURLKey, &cfg.Transparency.URL),
 
 		asString(kmsSignerKMSRef, &cfg.Signers.KMS.KMSRef),
+		asString(kmsAuthSpireSock, &cfg.Signers.KMS.Auth.Spire.Sock),
+		asString(kmsAuthSpireAudience, &cfg.Signers.KMS.Auth.Spire.Audience),
+		asString(kmsAuthAddress, &cfg.Signers.KMS.Auth.Address),
+		asString(kmsAuthPath, &cfg.Signers.KMS.Auth.Path),
+		asString(kmsAuthRole, &cfg.Signers.KMS.Auth.Role),
 
 		asBool(x509SignerFulcioEnabled, &cfg.Signers.X509.FulcioEnabled),
 		asString(x509SignerFulcioAddr, &cfg.Signers.X509.FulcioAddr),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,13 +76,21 @@ type KMSSigner struct {
 	Auth   KMSAuth
 }
 
+// KMSAuth configures authentication to the KMS server
 type KMSAuth struct {
-	Spire   KMSAuthSpire
 	Address string
-	Path    string
-	Role    string
+	Token   string
+	OIDC    KMSAuthOIDC
+	Spire   KMSAuthSpire
 }
 
+// KMSAuthOIDC configures settings to authenticate with OIDC
+type KMSAuthOIDC struct {
+	Path string
+	Role string
+}
+
+// KMSAuthSpire configures settings to get an auth token from spire
 type KMSAuthSpire struct {
 	Sock     string
 	Audience string
@@ -139,8 +147,9 @@ const (
 	// KMS
 	kmsSignerKMSRef      = "signers.kms.kmsref"
 	kmsAuthAddress       = "signers.kms.auth.address"
-	kmsAuthPath          = "signers.kms.auth.path"
-	kmsAuthRole          = "signers.kms.auth.role"
+	kmsAuthToken         = "signers.kms.auth.token"
+	kmsAuthOIDCPath      = "signers.kms.auth.oidc.path"
+	kmsAuthOIDCRole      = "signers.kms.auth.oidc.role"
 	kmsAuthSpireSock     = "signers.kms.auth.spire.sock"
 	kmsAuthSpireAudience = "signers.kms.auth.spire.audience"
 
@@ -218,11 +227,12 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		asString(transparencyURLKey, &cfg.Transparency.URL),
 
 		asString(kmsSignerKMSRef, &cfg.Signers.KMS.KMSRef),
+		asString(kmsAuthAddress, &cfg.Signers.KMS.Auth.Address),
+		asString(kmsAuthToken, &cfg.Signers.KMS.Auth.Token),
+		asString(kmsAuthOIDCPath, &cfg.Signers.KMS.Auth.OIDC.Path),
+		asString(kmsAuthOIDCRole, &cfg.Signers.KMS.Auth.OIDC.Role),
 		asString(kmsAuthSpireSock, &cfg.Signers.KMS.Auth.Spire.Sock),
 		asString(kmsAuthSpireAudience, &cfg.Signers.KMS.Auth.Spire.Audience),
-		asString(kmsAuthAddress, &cfg.Signers.KMS.Auth.Address),
-		asString(kmsAuthPath, &cfg.Signers.KMS.Auth.Path),
-		asString(kmsAuthRole, &cfg.Signers.KMS.Auth.Role),
 
 		asBool(x509SignerFulcioEnabled, &cfg.Signers.X509.FulcioEnabled),
 		asString(x509SignerFulcioAddr, &cfg.Signers.X509.FulcioAddr),

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -67,6 +67,13 @@ function install_chains() {
   wait_until_pods_running tekton-chains || fail_test "Tekton Chains did not come up"
 }
 
+function chains_patch_spire() {
+  kubectl patch -n tekton-chains deployment tekton-chains-controller \
+    --patch-file "$(dirname $0)/testdata/chains-patch-spire.json"
+  # Wait for pods to be running in the namespaces we are deploying to
+  wait_until_pods_running tekton-chains || fail_test "Tekton Chains did not come up after patching"
+}
+
 function dump_logs() {
   echo ">> Tekton Chains Logs"
   kubectl logs deployment/tekton-chains-controller -n tekton-chains

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -71,3 +71,92 @@ function dump_logs() {
   echo ">> Tekton Chains Logs"
   kubectl logs deployment/tekton-chains-controller -n tekton-chains
 }
+
+function spire_apply() {
+  if [ $# -lt 2 -o "$1" != "-spiffeID" ]; then
+    echo "spire_apply requires a spiffeID as the first arg" >&2
+    exit 1
+  fi
+  show=$(kubectl exec -n spire spire-server-0 -c spire-server -- \
+    /opt/spire/bin/spire-server entry show $1 $2)
+  if [ "$show" != "Found 0 entries" ]; then
+    # delete to recreate
+    entryid=$(echo "$show" | grep "^Entry ID" | cut -f2 -d:)
+    kubectl exec -n spire spire-server-0 -c spire-server -- \
+      /opt/spire/bin/spire-server entry delete -entryID $entryid
+  fi
+  kubectl exec -n spire spire-server-0 -c spire-server -- \
+    /opt/spire/bin/spire-server entry create "$@"
+}
+
+function install_spire() {
+  echo ">> Deploying Spire"
+  kubectl create ns spire --dry-run=client -o yaml | kubectl apply -f -
+  kubectl -n spire apply -f "$(dirname $0)/testdata/spire.yaml"
+  wait_until_pods_running spire || fail_test "Spire did not come up"
+  spire_apply \
+    -spiffeID spiffe://example.org/ns/spire/node/example \
+    -selector k8s_psat:cluster:example \
+    -selector k8s_psat:agent_ns:spire \
+    -selector k8s_psat:agent_sa:spire-agent \
+    -node
+  spire_apply \
+    -spiffeID spiffe://example.org/ns/tekton-chains/sa/tekton-chains-controller \
+    -parentID spiffe://example.org/ns/spire/node/example \
+    -selector k8s:ns:tekton-chains \
+    -selector k8s:sa:tekton-chains-controller  
+}
+
+function vault_exec() {
+  envcmd=""
+  if [ -n "$ROOT_TOKEN" ]; then
+    envcmd="env VAULT_TOKEN=$ROOT_TOKEN"
+  fi
+  kubectl exec -i -n vault vault-0 -- $envcmd vault "$@"
+}
+
+function install_vault() {
+  echo ">> Deploying Vault"
+  kubectl create ns vault --dry-run=client -o yaml | kubectl apply -f -
+  kubectl -n vault apply -f "$(dirname $0)/testdata/vault.yaml"
+  wait_until_pods_running vault || fail_test "Vault did not come up"
+  ROOT_TOKEN=token12345
+  vault_exec secrets list 2>&1 | grep "^transit/" \
+    || vault_exec secrets enable transit
+  vault_exec auth list 2>&1 | grep "^jwt/" \
+    || vault_exec auth enable jwt
+  vault_exec read auth/jwt/config >/dev/null 2>&1 \
+    || vault_exec write auth/jwt/config \
+      oidc_discovery_url=http://spire-oidc.spire:8082 \
+      default_role="spire"
+  vault_exec policy read spire-transit >/dev/null 2>&1 \
+    || vault_exec policy write spire-transit - <<EOF
+path "transit/*" {
+  capabilities = ["read"]
+}
+path "transit/sign/e2e" {
+  capabilities = ["create", "read", "update"]
+}
+path "transit/sign/e2e/*" {
+  capabilities = ["read", "update"]
+}
+path "transit/verify/e2e" {
+  capabilities = ["create", "read", "update"]
+}
+path "transit/verify/e2e/*" {
+  capabilities = ["read", "update"]
+}
+EOF
+  vault_exec read auth/jwt/role/spire-chains-controller >/dev/null 2>&1 \
+    || vault_exec write auth/jwt/role/spire-chains-controller \
+      role_type=jwt \
+      user_claim=sub \
+      bound_audiences=e2e \
+      bound_subject=spiffe://example.org/ns/tekton-chains/sa/tekton-chains-controller \
+      token_ttl=15m \
+      token_policies=spire-transit
+  vault_exec read transit/keys/e2e >/dev/null 2>&1 \
+    || vault_exec write transit/keys/e2e type=ecdsa-p521
+  vault_exec read -format=json transit/keys/e2e \
+    | jq -r .data.keys.\"1\".public_key >"$(dirname $0)/testdata/vault.pub"
+}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -37,6 +37,8 @@ install_spire
 
 install_vault
 
+chains_patch_spire
+
 failed=0
 
 # Run the integration tests

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -33,6 +33,10 @@ install_pipeline_crd
 
 install_chains
 
+install_spire
+
+install_vault
+
 failed=0
 
 # Run the integration tests

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -593,8 +593,8 @@ func TestVaultKMSSpire(t *testing.T) {
 		"artifacts.taskrun.signer":        "kms",
 		"signers.kms.kmsref":              "hashivault://e2e",
 		"signers.kms.auth.address":        "http://vault.vault:8200",
-		"signers.kms.auth.path":           "jwt",
-		"signers.kms.auth.role":           "spire-chains-controller",
+		"signers.kms.auth.oidc.path":      "jwt",
+		"signers.kms.auth.oidc.role":      "spire-chains-controller",
 		"signers.kms.auth.spire.sock":     "unix:///tmp/spire-agent/public/api.sock",
 		"signers.kms.auth.spire.audience": "e2e",
 	})

--- a/test/testdata/.gitignore
+++ b/test/testdata/.gitignore
@@ -1,0 +1,1 @@
+vault.pub

--- a/test/testdata/chains-patch-spire.json
+++ b/test/testdata/chains-patch-spire.json
@@ -1,0 +1,55 @@
+{
+  "spec": {
+    "template": {
+      "spec": {
+        "$setElementOrder/containers": [
+          {
+            "name": "tekton-chains-controller"
+          }
+        ],
+        "$setElementOrder/volumes": [
+          {
+            "name": "signing-secrets"
+          },
+          {
+            "name": "oidc-info"
+          },
+          {
+            "name": "spire-agent-socket"
+          }
+        ],
+        "containers": [
+          {
+            "$setElementOrder/volumeMounts": [
+              {
+                "mountPath": "/etc/signing-secrets"
+              },
+              {
+                "mountPath": "/var/run/sigstore/cosign"
+              },
+              {
+                "mountPath": "/tmp/spire-agent/public"
+              }
+            ],
+            "name": "tekton-chains-controller",
+            "volumeMounts": [
+              {
+                "mountPath": "/tmp/spire-agent/public",
+                "name": "spire-agent-socket"
+              }
+            ]
+          }
+        ],
+        "volumes": [
+          {
+            "hostPath": {
+              "path": "/run/spire/sockets",
+              "type": "DirectoryOrCreate"
+            },
+            "name": "spire-agent-socket"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/testdata/spire.yaml
+++ b/test/testdata/spire.yaml
@@ -1,0 +1,541 @@
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spire-agent
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spire-server
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-agent
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+data:
+  agent.conf: |
+    agent {
+      data_dir = "/run/spire"
+      log_level = "DEBUG"
+      server_address = "spire-server"
+      server_port = "8081"
+      # socket_path = "/run/spire/sockets/agent.sock"
+      trust_bundle_path = "/run/spire/bundle/bundle.crt"
+      trust_domain = "example.org"
+    }
+
+    plugins {
+      NodeAttestor "k8s_psat" {
+        plugin_data {
+          cluster = "example"
+        }
+      }
+
+      KeyManager "memory" {
+        plugin_data {
+        }
+      }
+
+      WorkloadAttestor "k8s" {
+        plugin_data {
+          # Defaults to the secure kubelet port by default.
+          # Minikube does not have a cert in the cluster CA bundle that
+          # can authenticate the kubelet cert, so skip validation.
+          skip_kubelet_verification = true
+        }
+      }
+
+      # WorkloadAttestor "unix" {
+      #     plugin_data {
+      #     }
+      # }
+    }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-bundle
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+
+---
+
+# OIDC Discovery Provider: <https://github.com/spiffe/spire/blob/main/support/oidc-discovery-provider/README.md>
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-oidc-dp
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+data:
+  oidc-discovery-provider.conf: |
+    log_level = "INFO"
+    allow_insecure_scheme = "true"
+    domains = [ "spire-oidc.spire" ]
+    insecure_addr = ":8082"
+    # listen_socket_path = "/tmp/spire-server/private/oidc.sock"
+    server_api {
+      address = "unix:///tmp/spire-server/private/api.sock"
+    }
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-server
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+data:
+  server.conf: |
+    server {
+      bind_address = "0.0.0.0"
+      bind_port = "8081"
+      # socket_path = "/run/spire/sockets/server.sock"
+      trust_domain = "example.org"
+      data_dir = "/run/spire/data"
+      log_level = "DEBUG"
+      #AWS requires the use of RSA.  EC cryptography is not supported
+      # ca_key_type = "rsa-2048"
+      jwt_issuer = "spire-oidc.spire"
+
+      default_svid_ttl = "1h"
+      ca_subject = {
+        country = ["US"],
+        organization = ["SPIFFE"],
+        common_name = "",
+      }
+    }
+
+    plugins {
+      DataStore "sql" {
+        plugin_data {
+          database_type = "sqlite3"
+          connection_string = "/run/spire/data/datastore.sqlite3"
+        }
+      }
+
+      NodeAttestor "k8s_psat" {
+        plugin_data {
+          clusters = {
+            "example" = {
+              # use_token_review_api_validation = true
+              service_account_allow_list = ["spire:spire-agent"]
+            }
+          }
+        }
+      }
+
+      KeyManager "disk" {
+        plugin_data {
+          keys_path = "/run/spire/data/keys.json"
+        }
+      }
+
+      Notifier "k8sbundle" {
+        plugin_data {
+          # This plugin updates the bundle.crt value in the spire:spire-bundle
+          # ConfigMap by default, so no additional configuration is necessary.
+        }
+      }
+    }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
+---
+
+# Required cluster role to allow spire-agent to query k8s API server
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-agent-cluster-role
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+rules:
+- apiGroups: [""]
+  resources: ["pods","nodes","nodes/proxy"]
+  verbs: ["get"]
+---
+
+# ClusterRole to allow spire-server node attestor to query Token Review API
+# and to be able to push certificate bundles to a configmap
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-server-cluster-role
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+# - apiGroups: [""]
+#   resources: ["configmaps"]
+#   verbs: ["patch", "get", "list"]
+---
+
+# Binds above cluster role to spire-agent service account
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-agent-cluster-role-binding
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+subjects:
+- kind: ServiceAccount
+  name: spire-agent
+  namespace: spire
+roleRef:
+  kind: ClusterRole
+  name: spire-agent-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
+
+# Binds above cluster role to spire-server service account
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-server-cluster-role-binding
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+subjects:
+- kind: ServiceAccount
+  name: spire-server
+  namespace: spire
+roleRef:
+  kind: ClusterRole
+  name: spire-server-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+# Role for the SPIRE server
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: spire
+  name: spire-server-role
+rules:
+  # allow "get" access to pods (to resolve selectors for PSAT attestation)
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+  # allow access to "get" and "patch" the spire-bundle ConfigMap (for SPIRE
+  # agent bootstrapping, see the spire-bundle ConfigMap below)
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["spire-bundle"]
+  verbs: ["get", "patch"]
+
+---
+
+# RoleBinding granting the spire-server-role to the SPIRE server
+# service account.
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-server-role-binding
+  namespace: spire
+subjects:
+- kind: ServiceAccount
+  name: spire-server
+  namespace: spire
+roleRef:
+  kind: Role
+  name: spire-server-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+# Service definition for the admission webhook
+apiVersion: v1
+kind: Service
+metadata:
+  name: spire-oidc
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8082
+      targetPort: oidc
+      protocol: TCP
+      name: oidc
+  selector:
+    app: spire-server
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: spire-server
+  labels:
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8081
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    app: spire-server
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: spire-agent
+  labels:
+    app: spire-agent
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+spec:
+  selector:
+    matchLabels:
+      app: spire-agent
+      app.kubernetes.io/name: spire
+      app.kubernetes.io/instance: spire
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: spire-agent
+        app.kubernetes.io/name: spire
+        app.kubernetes.io/instance: spire
+    spec:
+      hostPID: true
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: spire-agent
+      securityContext:
+        {}
+      initContainers:
+        - name: init
+          securityContext:
+            {}
+          # This is a small image with wait-for-it, choose whatever image
+          # you prefer that waits for a service to be up. This image is built
+          # from https://github.com/lqhl/wait-for-it
+          image: gcr.io/spiffe-io/wait-for-it
+          imagePullPolicy: IfNotPresent
+          args: ["-t", "30", "spire-server:8081"]
+      containers:
+        - name: spire-agent
+          securityContext:
+            {}
+          image: gcr.io/spiffe-io/spire-agent:1.0.2
+          imagePullPolicy: IfNotPresent
+          args: ["-config", "/run/spire/config/agent.conf"]
+          volumeMounts:
+            - name: spire-config
+              mountPath: /run/spire/config
+              readOnly: true
+            - name: spire-bundle
+              mountPath: /run/spire/bundle
+              readOnly: true
+            - name: spire-agent-socket
+              mountPath: /tmp/spire-agent/public
+              readOnly: false
+            - name: spire-token
+              mountPath: /var/run/secrets/tokens
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8080
+            failureThreshold: 2
+            initialDelaySeconds: 15
+            periodSeconds: 60
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {}
+      volumes:
+        - name: spire-config
+          configMap:
+            name: spire-agent
+        - name: spire-bundle
+          configMap:
+            name: spire-bundle
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: DirectoryOrCreate
+        - name: spire-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: spire-agent
+                expirationSeconds: 7200
+                audience: spire-server
+
+---
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: spire-server
+  labels:
+    app: spire-server
+    app.kubernetes.io/name: spire
+    app.kubernetes.io/instance: spire
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spire-server
+      app.kubernetes.io/name: spire
+      app.kubernetes.io/instance: spire
+  serviceName: spire-server
+  template:
+    metadata:
+      labels:
+        app: spire-server
+        app.kubernetes.io/name: spire
+        app.kubernetes.io/instance: spire
+    spec:
+      serviceAccountName: spire-server
+      securityContext:
+        {}
+      containers:
+        - name: spire-server
+          securityContext:
+            {}
+          image: gcr.io/spiffe-io/spire-server:1.0.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - -config
+            - /run/spire/config/server.conf
+          ports:
+            - name: grpc
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: spire-config
+              mountPath: /run/spire/config
+              readOnly: true
+            # Spire is not configured with persistent data for CI tests
+            # - name: spire-data
+            #   mountPath: /run/spire/data
+            #   readOnly: false
+            - name: spire-server-socket
+              mountPath: /tmp/spire-server/private
+              readOnly: false
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8080
+            failureThreshold: 2
+            initialDelaySeconds: 15
+            periodSeconds: 60
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {}
+        - name: spire-oidc
+          image: gcr.io/spiffe-io/oidc-discovery-provider:1.0.2
+          imagePullPolicy: IfNotPresent
+          args:
+          - -config
+          - /run/spire/oidc/config/oidc-discovery-provider.conf
+          ports:
+          - name: oidc
+            containerPort: 8082
+            protocol: TCP
+          volumeMounts:
+          - name: spire-server-socket
+            mountPath: /tmp/spire-server/private
+            readOnly: false
+          - name: spire-oidc-config
+            mountPath: /run/spire/oidc/config/
+            readOnly: true
+          # - name: spire-data
+          #   mountPath: /run/spire/data
+          #   readOnly: false
+          readinessProbe:
+            exec:
+              command: ["/bin/ps", "aux", " ||", "grep", "oidc-discovery-provider -config /run/spire/oidc/config/oidc-discovery-provider.conf"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {}
+      volumes:
+        - name: spire-config
+          configMap:
+            name: spire-server
+        - name: spire-server-socket
+          emptyDir: {}
+        - name: spire-oidc-config
+          configMap:
+            name: spire-oidc-dp
+  # volumeClaimTemplates:
+  #   - metadata:
+  #       name: spire-data
+  #       labels:
+  #         app.kubernetes.io/name: spire
+  #         app.kubernetes.io/instance: spire
+  #     spec:
+  #       accessModes:
+  #         - ReadWriteOnce
+  #       resources:
+  #         requests:
+  #           storage: 1Gi

--- a/test/testdata/spire.yaml
+++ b/test/testdata/spire.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 
 apiVersion: v1

--- a/test/testdata/vault.yaml
+++ b/test/testdata/vault.yaml
@@ -1,0 +1,227 @@
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault
+  labels:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-server-binding
+  labels:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: vault
+  namespace: vault
+
+---
+
+# Service for Vault cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault-internal
+  labels:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+  annotations:
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: "http"
+      port: 8200
+      targetPort: 8200
+    - name: https-internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+    component: server
+
+---
+
+# Service for Vault cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  labels:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+  annotations:
+spec:
+  # We want the servers to become available even if they're not ready
+  # since this DNS is also used for join operations.
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: 8200
+      targetPort: 8200
+    - name: https-internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+    component: server
+
+---
+
+# StatefulSet to run the actual vault server cluster.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: vault
+  labels:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+spec:
+  serviceName: vault-internal
+  podManagementPolicy: Parallel
+  replicas: 1
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vault
+      app.kubernetes.io/instance: vault
+      component: server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vault
+        app.kubernetes.io/instance: vault
+        component: server
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: vault
+                  app.kubernetes.io/instance: "vault"
+                  component: server
+              topologyKey: kubernetes.io/hostname
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: vault
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 100
+        fsGroup: 1000
+      containers:
+        - name: vault
+          image: hashicorp/vault:1.9.2
+          imagePullPolicy: IfNotPresent
+          command:
+          - "/bin/sh"
+          - "-ec"
+          args:
+          - |
+            /usr/local/bin/docker-entrypoint.sh server -dev
+          securityContext:
+            allowPrivilegeEscalation: false
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VAULT_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: VAULT_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: VAULT_ADDR
+              value: "http://127.0.0.1:8200"
+            - name: VAULT_API_ADDR
+              value: "http://$(POD_IP):8200"
+            - name: SKIP_CHOWN
+              value: "true"
+            - name: SKIP_SETCAP
+              value: "true"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: VAULT_CLUSTER_ADDR
+              value: "https://$(HOSTNAME).vault-internal:8201"
+            - name: HOME
+              value: "/home/vault"
+            - name: VAULT_DEV_ROOT_TOKEN_ID
+              value: "token12345"
+            - name: VAULT_DEV_LISTEN_ADDR
+              value: "[::]:8200"
+          volumeMounts:
+            # Persistent data is not used for CI tests
+            # - name: data
+            #   mountPath: /vault/data
+            - name: home
+              mountPath: /home/vault
+          ports:
+            - containerPort: 8200
+              name: http
+            - containerPort: 8201
+              name: https-internal
+            - containerPort: 8202
+              name: http-rep
+          readinessProbe:
+            # Check status; unsealed vault servers return 0
+            # The exit code reflects the seal status:
+            #   0 - unsealed
+            #   1 - error
+            #   2 - sealed
+            exec:
+              command: ["/bin/sh", "-ec", "vault status -tls-skip-verify"]
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          lifecycle:
+            # Vault container doesn't receive SIGTERM from Kubernetes
+            # and after the grace period ends, Kube sends SIGKILL.  This
+            # causes issues with graceful shutdowns such as deregistering itself
+            # from Consul (zombie services).
+            preStop:
+              exec:
+                command: [
+                  "/bin/sh", "-c",
+                  # Adding a sleep here to give the pod eviction a
+                  # chance to propagate, so requests will not be made
+                  # to this pod while it's terminating
+                  "sleep 5 && kill -SIGTERM $(pidof vault)",
+                ]
+      volumes:
+        - name: home
+          emptyDir: {}
+  # volumeClaimTemplates:
+  #   - metadata:
+  #       name: data
+  #     spec:
+  #       accessModes:
+  #         - ReadWriteOnce
+  #       resources:
+  #         requests:
+  #           storage: 10Gi
+

--- a/test/testdata/vault.yaml
+++ b/test/testdata/vault.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 
 apiVersion: v1


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

This adds the following new configuration options:

```
	kmsAuthAddress       = "signers.kms.auth.address"
	kmsAuthPath          = "signers.kms.auth.path"
	kmsAuthRole          = "signers.kms.auth.role"
	kmsAuthSpireSock     = "signers.kms.auth.spire.sock"
	kmsAuthSpireAudience = "signers.kms.auth.spire.audience"
```

The changes are rebased on the latest sigstore to pull in [this PR](https://github.com/sigstore/sigstore/pull/249) which allows us to perform a vault login using OIDC instead of a static token. And this allows the OIDC credential to be generated from Spire so that only trusted workloads are allowed to login to vault. Also from the change, we're able to pass the vault address as a configuration rather than injecting as an environment variable.

In practice, we're applying the following patch to the chains config:

```
data:
  artifacts.oci.signer: kms
  artifacts.taskrun.signer: kms
  signers.kms.kmsref: "hashivault://ssf"
  signers.kms.auth.address: "http://vault.vault:8200"
  signers.kms.auth.path: jwt
  signers.kms.auth.role: "spire-chains-controller"
  signers.kms.auth.spire.sock: "unix:///run/spire/sockets/agent.sock"
  signers.kms.auth.spire.audience: TESTING
```

Let me know if this should go through it's own TEP, or if there's coordination needed with the other Spire integration work. 