### PR TITLE
Revert default fulcio URL to fulcio.sigstore.dev

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -152,7 +152,7 @@ func defaultConfig() *Config {
 		},
 		Signers: SignerConfigs{
 			X509: X509Signer{
-				FulcioAddr: "https://v1.fulcio.sigstore.dev",
+				FulcioAddr: "https://fulcio.sigstore.dev",
 			},
 		},
 		Builder: BuilderConfig{

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -86,7 +86,7 @@ func TestNewConfigStore(t *testing.T) {
 
 var defaultSigners = SignerConfigs{
 	X509: X509Signer{
-		FulcioAddr: "https://v1.fulcio.sigstore.dev",
+		FulcioAddr: "https://fulcio.sigstore.dev",
 	},
 }
 
@@ -429,7 +429,7 @@ func TestParse(t *testing.T) {
 				},
 				Signers: SignerConfigs{
 					X509: X509Signer{
-						FulcioAddr: "https://v1.fulcio.sigstore.dev",
+						FulcioAddr: "https://fulcio.sigstore.dev",
 					},
 				},
 				Transparency: TransparencyConfig{
@@ -462,7 +462,7 @@ func TestParse(t *testing.T) {
 				},
 				Signers: SignerConfigs{
 					X509: X509Signer{
-						FulcioAddr: "https://v1.fulcio.sigstore.dev",
+						FulcioAddr: "https://fulcio.sigstore.dev",
 					},
 				},
 				Transparency: TransparencyConfig{


### PR DESCRIPTION
now, fulcio.sigstore.dev and v1.fulcio.sigstore.dev point to the same service, so we can switch back.

cc @tcnghia who originally found this bug