### PR TITLE
Remove usage of context.TODO

### DIFF
--- a/pkg/chains/annotations_test.go
+++ b/pkg/chains/annotations_test.go
@@ -121,7 +121,7 @@ func TestAddRetry(t *testing.T) {
 	}
 
 	// run it through AddRetry, make sure annotation is added
-	if err := AddRetry(tr, c, nil); err != nil {
+	if err := AddRetry(ctx, tr, c, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -135,7 +135,7 @@ func TestAddRetry(t *testing.T) {
 	}
 
 	// run it again, make sure we see an increase
-	if err := AddRetry(signed, c, nil); err != nil {
+	if err := AddRetry(ctx, signed, c, nil); err != nil {
 		t.Fatal(err)
 	}
 	signed, err = c.TektonV1beta1().TaskRuns(tr.Namespace).Get(ctx, tr.Name, metav1.GetOptions{})

--- a/pkg/chains/signing/kms/kms.go
+++ b/pkg/chains/signing/kms/kms.go
@@ -37,8 +37,8 @@ type Signer struct {
 }
 
 // NewSigner returns a configured Signer
-func NewSigner(cfg config.KMSSigner, logger *zap.SugaredLogger) (*Signer, error) {
-	k, err := kms.Get(context.Background(), cfg.KMSRef, crypto.SHA256)
+func NewSigner(ctx context.Context, cfg config.KMSSigner, logger *zap.SugaredLogger) (*Signer, error) {
+	k, err := kms.Get(ctx, cfg.KMSRef, crypto.SHA256)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chains/signing/x509/x509.go
+++ b/pkg/chains/signing/x509/x509.go
@@ -48,12 +48,12 @@ type Signer struct {
 }
 
 // NewSigner returns a configured Signer
-func NewSigner(secretPath string, cfg config.Config, logger *zap.SugaredLogger) (*Signer, error) {
+func NewSigner(ctx context.Context, secretPath string, cfg config.Config, logger *zap.SugaredLogger) (*Signer, error) {
 	x509PrivateKeyPath := filepath.Join(secretPath, "x509.pem")
 	cosignPrivateKeypath := filepath.Join(secretPath, "cosign.key")
 
 	if cfg.Signers.X509.FulcioEnabled {
-		return fulcioSigner(cfg.Signers.X509.FulcioAddr, logger)
+		return fulcioSigner(ctx, cfg.Signers.X509.FulcioAddr, logger)
 	} else if contents, err := ioutil.ReadFile(x509PrivateKeyPath); err == nil {
 		return x509Signer(contents, logger)
 	} else if contents, err := ioutil.ReadFile(cosignPrivateKeypath); err == nil {
@@ -62,9 +62,7 @@ func NewSigner(secretPath string, cfg config.Config, logger *zap.SugaredLogger) 
 	return nil, errors.New("no valid private key found, looked for: [x509.pem, cosign.key]")
 }
 
-func fulcioSigner(addr string, logger *zap.SugaredLogger) (*Signer, error) {
-	ctx := context.Background()
-
+func fulcioSigner(ctx context.Context, addr string, logger *zap.SugaredLogger) (*Signer, error) {
 	if !providers.Enabled(ctx) {
 		return nil, fmt.Errorf("no auth provider for fulcio is enabled")
 	}

--- a/pkg/chains/signing/x509/x509_test.go
+++ b/pkg/chains/signing/x509/x509_test.go
@@ -15,6 +15,7 @@ package x509
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/sha256"
@@ -48,6 +49,7 @@ MC4CAQAwBQYDK2VwBCIEIGQn0bJwshjwuVdnd/FylMk3Gvb89aGgH49bQpgzCY0n
 -----END PRIVATE KEY-----`
 
 func TestSigner_SignECDSA(t *testing.T) {
+	ctx := context.Background()
 	logger := logtesting.TestLogger(t)
 	d := t.TempDir()
 	p := filepath.Join(d, "x509.pem")
@@ -56,7 +58,7 @@ func TestSigner_SignECDSA(t *testing.T) {
 	}
 
 	// create a signer
-	signer, err := NewSigner(d, config.Config{}, logger)
+	signer, err := NewSigner(ctx, d, config.Config{}, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,6 +90,7 @@ func TestSigner_SignECDSA(t *testing.T) {
 }
 
 func TestSigner_SignED25519(t *testing.T) {
+	ctx := context.Background()
 	t.Skip("skip test until ed25519 signing is implemented")
 	logger := logtesting.TestLogger(t)
 	d := t.TempDir()
@@ -97,7 +100,7 @@ func TestSigner_SignED25519(t *testing.T) {
 	}
 
 	// create a signer
-	signer, err := NewSigner(d, config.Config{}, logger)
+	signer, err := NewSigner(ctx, d, config.Config{}, logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -52,7 +52,7 @@ func TestMarkSigned(t *testing.T) {
 	}
 
 	// Now mark it as signed.
-	if err := MarkSigned(tr, c, nil); err != nil {
+	if err := MarkSigned(ctx, tr, c, nil); err != nil {
 		t.Errorf("MarkSigned() error = %v", err)
 	}
 
@@ -71,7 +71,7 @@ func TestMarkSigned(t *testing.T) {
 	extra := map[string]string{
 		"foo": "bar",
 	}
-	if err := MarkSigned(tr, c, extra); err != nil {
+	if err := MarkSigned(ctx, tr, c, extra); err != nil {
 		t.Errorf("MarkSigned() error = %v", err)
 	}
 
@@ -108,7 +108,7 @@ func TestMarkFailed(t *testing.T) {
 	}
 
 	// Test HandleRetry, should mark it as failed
-	if err := HandleRetry(tr, c, nil); err != nil {
+	if err := HandleRetry(ctx, tr, c, nil); err != nil {
 		t.Errorf("HandleRetry() error = %v", err)
 	}
 
@@ -321,7 +321,7 @@ func TestTaskRunSigner_Transparency(t *testing.T) {
 
 func setupMocks(backends []*mockBackend, rekor *mockRekor) func() {
 	oldGet := getBackends
-	getBackends = func(ps versioned.Interface, _ kubernetes.Interface, logger *zap.SugaredLogger, _ *v1beta1.TaskRun, _ config.Config) (map[string]storage.Backend, error) {
+	getBackends = func(ctx context.Context, ps versioned.Interface, _ kubernetes.Interface, logger *zap.SugaredLogger, _ *v1beta1.TaskRun, _ config.Config) (map[string]storage.Backend, error) {
 		newBackends := map[string]storage.Backend{}
 		for _, m := range backends {
 			newBackends[m.backendType] = m
@@ -359,7 +359,7 @@ type mockBackend struct {
 }
 
 // StorePayload implements the Payloader interface.
-func (b *mockBackend) StorePayload(signed []byte, signature string, opts config.StorageOpts) error {
+func (b *mockBackend) StorePayload(ctx context.Context, signed []byte, signature string, opts config.StorageOpts) error {
 	if b.shouldErr {
 		return errors.New("mock error storing")
 	}
@@ -371,10 +371,10 @@ func (b *mockBackend) Type() string {
 	return b.backendType
 }
 
-func (b *mockBackend) RetrievePayloads(opts config.StorageOpts) (map[string]string, error) {
+func (b *mockBackend) RetrievePayloads(ctx context.Context, opts config.StorageOpts) (map[string]string, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (b *mockBackend) RetrieveSignatures(opts config.StorageOpts) (map[string][]string, error) {
+func (b *mockBackend) RetrieveSignatures(ctx context.Context, opts config.StorageOpts) (map[string][]string, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/pkg/chains/storage/docdb/docdb_test.go
+++ b/pkg/chains/storage/docdb/docdb_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestBackend_StorePayload(t *testing.T) {
+	ctx := context.Background()
 
 	type args struct {
 		tr        *v1beta1.TaskRun
@@ -58,7 +59,7 @@ func TestBackend_StorePayload(t *testing.T) {
 	}
 
 	memUrl := "mem://chains/name"
-	coll, err := docstore.OpenCollection(context.Background(), memUrl)
+	coll, err := docstore.OpenCollection(ctx, memUrl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +68,6 @@ func TestBackend_StorePayload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Prepare the document.
-			ctx := context.Background()
 			b := &Backend{
 				logger: logtesting.TestLogger(t),
 				tr:     tt.args.tr,
@@ -80,7 +80,7 @@ func TestBackend_StorePayload(t *testing.T) {
 
 			// Store the document.
 			opts := config.StorageOpts{Key: tt.args.key}
-			if err := b.StorePayload(sb, tt.args.signature, opts); (err != nil) != tt.wantErr {
+			if err := b.StorePayload(ctx, sb, tt.args.signature, opts); (err != nil) != tt.wantErr {
 				t.Fatalf("Backend.StorePayload() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			obj := SignedDocument{
@@ -91,7 +91,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			}
 
 			// Check the signature.
-			signatures, err := b.RetrieveSignatures(opts)
+			signatures, err := b.RetrieveSignatures(ctx, opts)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -104,7 +104,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			}
 
 			// Check the payload.
-			payloads, err := b.RetrievePayloads(opts)
+			payloads, err := b.RetrievePayloads(ctx, opts)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/chains/storage/gcs/gcs.go
+++ b/pkg/chains/storage/gcs/gcs.go
@@ -46,8 +46,7 @@ type Backend struct {
 }
 
 // NewStorageBackend returns a new Tekton StorageBackend that stores signatures on a TaskRun
-func NewStorageBackend(logger *zap.SugaredLogger, tr *v1beta1.TaskRun, cfg config.Config) (*Backend, error) {
-	ctx := context.Background()
+func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, tr *v1beta1.TaskRun, cfg config.Config) (*Backend, error) {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return nil, err
@@ -63,7 +62,7 @@ func NewStorageBackend(logger *zap.SugaredLogger, tr *v1beta1.TaskRun, cfg confi
 }
 
 // StorePayload implements the storage.Backend interface.
-func (b *Backend) StorePayload(rawPayload []byte, signature string, opts config.StorageOpts) error {
+func (b *Backend) StorePayload(ctx context.Context, rawPayload []byte, signature string, opts config.StorageOpts) error {
 	// We need multiple objects: the signature and the payload. We want to make these unique to the UID, but easy to find based on the
 	// name/namespace as well.
 	// $bucket/taskrun-$namespace-$name/$key.signature
@@ -71,7 +70,7 @@ func (b *Backend) StorePayload(rawPayload []byte, signature string, opts config.
 	sigName := b.sigName(opts)
 	b.logger.Infof("Storing signature at %s", sigName)
 
-	sigObj := b.writer.GetWriter(sigName)
+	sigObj := b.writer.GetWriter(ctx, sigName)
 	if _, err := sigObj.Write([]byte(signature)); err != nil {
 		return err
 	}
@@ -79,7 +78,7 @@ func (b *Backend) StorePayload(rawPayload []byte, signature string, opts config.
 		return err
 	}
 
-	payloadObj := b.writer.GetWriter(b.payloadName(opts))
+	payloadObj := b.writer.GetWriter(ctx, b.payloadName(opts))
 	defer payloadObj.Close()
 	if _, err := payloadObj.Write(rawPayload); err != nil {
 		return err
@@ -92,7 +91,7 @@ func (b *Backend) StorePayload(rawPayload []byte, signature string, opts config.
 		return nil
 	}
 	certName := b.certName(opts)
-	certObj := b.writer.GetWriter(certName)
+	certObj := b.writer.GetWriter(ctx, certName)
 	defer certObj.Close()
 	if _, err := certObj.Write([]byte(opts.Cert)); err != nil {
 		return err
@@ -102,7 +101,7 @@ func (b *Backend) StorePayload(rawPayload []byte, signature string, opts config.
 	}
 
 	chainName := b.chainName(opts)
-	chainObj := b.writer.GetWriter(chainName)
+	chainObj := b.writer.GetWriter(ctx, chainName)
 	defer chainObj.Close()
 	if _, err := chainObj.Write([]byte(opts.Chain)); err != nil {
 		return err
@@ -119,7 +118,7 @@ func (b *Backend) Type() string {
 }
 
 type gcsWriter interface {
-	GetWriter(object string) io.WriteCloser
+	GetWriter(ctx context.Context, object string) io.WriteCloser
 }
 
 type writer struct {
@@ -128,7 +127,7 @@ type writer struct {
 }
 
 type gcsReader interface {
-	GetReader(object string) (io.ReadCloser, error)
+	GetReader(ctx context.Context, object string) (io.ReadCloser, error)
 }
 
 type reader struct {
@@ -136,19 +135,17 @@ type reader struct {
 	bucket string
 }
 
-func (r *writer) GetWriter(object string) io.WriteCloser {
-	ctx := context.Background()
+func (r *writer) GetWriter(ctx context.Context, object string) io.WriteCloser {
 	return r.client.Bucket(r.bucket).Object(object).NewWriter(ctx)
 }
 
-func (r *reader) GetReader(object string) (io.ReadCloser, error) {
-	ctx := context.Background()
+func (r *reader) GetReader(ctx context.Context, object string) (io.ReadCloser, error) {
 	return r.client.Bucket(r.bucket).Object(object).NewReader(ctx)
 }
 
-func (b *Backend) RetrieveSignatures(opts config.StorageOpts) (map[string][]string, error) {
+func (b *Backend) RetrieveSignatures(ctx context.Context, opts config.StorageOpts) (map[string][]string, error) {
 	object := b.sigName(opts)
-	signature, err := b.retrieveObject(object)
+	signature, err := b.retrieveObject(ctx, object)
 	if err != nil {
 		return nil, err
 	}
@@ -158,10 +155,10 @@ func (b *Backend) RetrieveSignatures(opts config.StorageOpts) (map[string][]stri
 	return m, nil
 }
 
-func (b *Backend) RetrievePayloads(opts config.StorageOpts) (map[string]string, error) {
+func (b *Backend) RetrievePayloads(ctx context.Context, opts config.StorageOpts) (map[string]string, error) {
 	object := b.payloadName(opts)
 	m := make(map[string]string)
-	payload, err := b.retrieveObject(object)
+	payload, err := b.retrieveObject(ctx, object)
 	if err != nil {
 		return nil, err
 	}
@@ -170,8 +167,8 @@ func (b *Backend) RetrievePayloads(opts config.StorageOpts) (map[string]string, 
 	return m, nil
 }
 
-func (b *Backend) retrieveObject(object string) (string, error) {
-	reader, err := b.reader.GetReader(object)
+func (b *Backend) retrieveObject(ctx context.Context, object string) (string, error) {
+	reader, err := b.reader.GetReader(ctx, object)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/chains/storage/oci/oci_test.go
+++ b/pkg/chains/storage/oci/oci_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package oci
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -27,6 +28,7 @@ import (
 )
 
 func TestBackend_StorePayload(t *testing.T) {
+	ctx := context.Background()
 
 	// pretty much anything that has no Subject
 	sampleIntotoStatementBytes, _ := json.Marshal(in_toto.Statement{})
@@ -73,7 +75,7 @@ func TestBackend_StorePayload(t *testing.T) {
 				kc:     tt.fields.kc,
 				auth:   tt.fields.auth,
 			}
-			if err := b.StorePayload(tt.args.rawPayload, tt.args.signature, tt.args.storageOpts); (err != nil) != tt.wantErr {
+			if err := b.StorePayload(ctx, tt.args.rawPayload, tt.args.signature, tt.args.storageOpts); (err != nil) != tt.wantErr {
 				t.Errorf("Backend.StorePayload() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/chains/storage/storage_test.go
+++ b/pkg/chains/storage/storage_test.go
@@ -51,7 +51,7 @@ func TestInitializeBackends(t *testing.T) {
 	tr := &v1beta1.TaskRun{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := InitializeBackends(ps, kc, logger, tr, tt.cfg)
+			got, err := InitializeBackends(ctx, ps, kc, logger, tr, tt.cfg)
 			if err != nil {
 				t.Errorf("InitializeBackends() error = %v", err)
 				return

--- a/pkg/chains/storage/tekton/tekton_test.go
+++ b/pkg/chains/storage/tekton/tekton_test.go
@@ -74,7 +74,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			}
 			opts := config.StorageOpts{Key: "mockpayload"}
 			mockSignature := "mocksignature"
-			if err := b.StorePayload(payload, mockSignature, opts); (err != nil) != tt.wantErr {
+			if err := b.StorePayload(ctx, payload, mockSignature, opts); (err != nil) != tt.wantErr {
 				t.Errorf("Backend.StorePayload() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
@@ -83,8 +83,8 @@ func TestBackend_StorePayload(t *testing.T) {
 				return
 			}
 
-			payloadAnnotation := b.PayloadName(opts)
-			payloads, err := b.RetrievePayloads(opts)
+			payloadAnnotation := payloadName(opts)
+			payloads, err := b.RetrievePayloads(ctx, opts)
 			if err != nil {
 				t.Errorf("error base64 decoding: %v", err)
 			}
@@ -100,8 +100,8 @@ func TestBackend_StorePayload(t *testing.T) {
 			}
 
 			// Compare the signature.
-			signatureAnnotation := b.SigName(opts)
-			sigs, err := b.RetrieveSignatures(opts)
+			signatureAnnotation := sigName(opts)
+			sigs, err := b.RetrieveSignatures(ctx, opts)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/chains/verifier.go
+++ b/pkg/chains/verifier.go
@@ -48,11 +48,11 @@ func (tv *TaskRunVerifier) VerifyTaskRun(ctx context.Context, tr *v1beta1.TaskRu
 	}
 
 	// Storage
-	allBackends, err := getBackends(tv.Pipelineclientset, tv.KubeClient, logger, tr, cfg)
+	allBackends, err := getBackends(ctx, tv.Pipelineclientset, tv.KubeClient, logger, tr, cfg)
 	if err != nil {
 		return err
 	}
-	signers := allSigners(tv.SecretPath, cfg, logger)
+	signers := allSigners(ctx, tv.SecretPath, cfg, logger)
 
 	for _, signableType := range enabledSignableTypes {
 		if !signableType.Enabled(cfg) {
@@ -68,11 +68,11 @@ func (tv *TaskRunVerifier) VerifyTaskRun(ctx context.Context, tr *v1beta1.TaskRu
 
 		for _, backend := range signableType.StorageBackend(cfg).List() {
 			b := allBackends[backend]
-			signatures, err := b.RetrieveSignatures(config.StorageOpts{})
+			signatures, err := b.RetrieveSignatures(ctx, config.StorageOpts{})
 			if err != nil {
 				return err
 			}
-			payload, err := b.RetrievePayloads(config.StorageOpts{})
+			payload, err := b.RetrievePayloads(ctx, config.StorageOpts{})
 			if err != nil {
 				return err
 			}

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -239,7 +239,7 @@ func verifySignature(ctx context.Context, t *testing.T, c *clients, tr *v1beta1.
 	logger := logging.FromContext(ctx)
 
 	// Initialize the backend.
-	backends, err := chainsstrorage.InitializeBackends(c.PipelineClient, c.KubeClient, logger, tr, *cfg)
+	backends, err := chainsstrorage.InitializeBackends(ctx, c.PipelineClient, c.KubeClient, logger, tr, *cfg)
 	if err != nil {
 		t.Errorf("error initializing backends: %s", err)
 	}
@@ -253,11 +253,11 @@ func verifySignature(ctx context.Context, t *testing.T, c *clients, tr *v1beta1.
 		}
 
 		// Let's fetch the signature and body.
-		signatures, err := backend.RetrieveSignatures(opts)
+		signatures, err := backend.RetrieveSignatures(ctx, opts)
 		if err != nil {
 			t.Errorf("error retrieving the signature: %s", err)
 		}
-		payloads, err := backend.RetrievePayloads(opts)
+		payloads, err := backend.RetrievePayloads(ctx, opts)
 		if err != nil {
 			t.Errorf("error retrieving the payload: %s", err)
 		}


### PR DESCRIPTION
This PR removes usage of context.TODO/context.Background by plumbing
through a context through the respective functions.
This is a breaking library change, though hopefully one that is minimally
intrusive.

Also unexports a few methods in the Tekton storage backend that do not need to be exposed.