### PR TITLE
Do not fail OCI upload when no subjects

### DIFF
--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -90,9 +90,13 @@ func (b *Backend) StorePayload(ctx context.Context, rawPayload []byte, signature
 		}
 
 		// This can happen if the Task/TaskRun does not adhere to specific naming conventions
-		// like *IMAGE_URL that would serve as hints.
+		// like *IMAGE_URL that would serve as hints. This may be intentional for a Task/TaskRun
+		// that is not intended to produce an image, e.g. git-clone.
 		if len(attestation.Subject) == 0 {
-			return errors.New("Did not find anything to attest")
+			b.logger.Infof(
+				"No image subject to attest for TaskRun %s/%s. Skipping upload to registry",
+				b.tr.Namespace, b.tr.Name)
+			return nil
 		}
 
 		return b.uploadAttestation(attestation, signature, storageOpts)

--- a/pkg/chains/storage/oci/oci_test.go
+++ b/pkg/chains/storage/oci/oci_test.go
@@ -63,7 +63,7 @@ func TestBackend_StorePayload(t *testing.T) {
 					PayloadFormat: "in-toto",
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Instead, log an INFO message and carry on. Many tasks in a given Tekton
Pipeline may not produce an image. For example, a Pipeline may contain
tasks to clone a git repository and run different kinds of tests.

Triggering an error means the TaskRun resource is re-added to the
operator reconcilliation loop, causing the same resource to be
re-processed multiple times. If other storage backends are also
configured, payloads are regenerated and re-uploaded to those backends.
This multiple upload behavior is also seen when rekor integration is
enabled.

Fixes #402

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>