### PR TITLE
Adding Go linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,47 @@
+name: lint
+on:
+  # only check PRs for new issues until preexisting issues are cleaned
+  # push:
+  #   branches:
+  #     - main
+  pull_request:
+    branches: [ main ]
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+
+      - uses: actions/checkout@v2
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          args: --timeout 10m0s
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true
+
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/pkg/chains/formats/intotoite6/intotoite6.go
+++ b/pkg/chains/formats/intotoite6/intotoite6.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/in-toto/in-toto-golang/in_toto"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
@@ -130,7 +129,7 @@ func invocation(tr *v1beta1.TaskRun) slsa.ProvenanceInvocation {
 				if v == "" {
 					v = fmt.Sprintf("%v", p.Default.ArrayVal)
 				}
-				params[p.Name] = fmt.Sprintf("%s", v)
+				params[p.Name] = v
 			}
 		}
 	}
@@ -179,7 +178,7 @@ func GetSubjectDigests(tr *v1beta1.TaskRun, logger *zap.SugaredLogger) []intoto.
 					}
 				}
 			}
-			subjects = append(subjects, in_toto.Subject{
+			subjects = append(subjects, intoto.Subject{
 				Name: url,
 				Digest: slsa.DigestSet{
 					"sha256": strings.TrimPrefix(digest, "sha256:"),

--- a/pkg/chains/signing/wrap.go
+++ b/pkg/chains/signing/wrap.go
@@ -94,15 +94,15 @@ type sslSigner struct {
 	chain   string
 }
 
-func (s *sslSigner) Type() string {
-	return s.typ
+func (w *sslSigner) Type() string {
+	return w.typ
 }
-func (s *sslSigner) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
-	return s.pub, nil
+func (w *sslSigner) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+	return w.pub, nil
 }
 
-func (s *sslSigner) Sign(ctx context.Context, payload []byte) ([]byte, []byte, error) {
-	env, err := s.wrapper.SignPayload(in_toto.PayloadType, payload)
+func (w *sslSigner) Sign(ctx context.Context, payload []byte) ([]byte, []byte, error) {
+	env, err := w.wrapper.SignPayload(in_toto.PayloadType, payload)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -113,12 +113,12 @@ func (s *sslSigner) Sign(ctx context.Context, payload []byte) ([]byte, []byte, e
 	return b, []byte(env.Payload), nil
 }
 
-func (s *sslSigner) SignMessage(payload io.Reader, opts ...signature.SignOption) ([]byte, error) {
+func (w *sslSigner) SignMessage(payload io.Reader, opts ...signature.SignOption) ([]byte, error) {
 	m, err := ioutil.ReadAll(payload)
 	if err != nil {
 		return nil, err
 	}
-	env, err := s.wrapper.SignPayload(in_toto.PayloadType, m)
+	env, err := w.wrapper.SignPayload(in_toto.PayloadType, m)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chains/signing/x509/x509_test.go
+++ b/pkg/chains/signing/x509/x509_test.go
@@ -90,8 +90,8 @@ func TestSigner_SignECDSA(t *testing.T) {
 }
 
 func TestSigner_SignED25519(t *testing.T) {
-	ctx := context.Background()
 	t.Skip("skip test until ed25519 signing is implemented")
+	ctx := context.Background()
 	logger := logtesting.TestLogger(t)
 	d := t.TempDir()
 	p := filepath.Join(d, "x509.pem")

--- a/pkg/chains/storage/docdb/docdb_test.go
+++ b/pkg/chains/storage/docdb/docdb_test.go
@@ -58,8 +58,8 @@ func TestBackend_StorePayload(t *testing.T) {
 		},
 	}
 
-	memUrl := "mem://chains/name"
-	coll, err := docstore.OpenCollection(ctx, memUrl)
+	memURL := "mem://chains/name"
+	coll, err := docstore.OpenCollection(ctx, memURL)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chains/storage/gcs/gcs_test.go
+++ b/pkg/chains/storage/gcs/gcs_test.go
@@ -98,13 +98,13 @@ func TestBackend_StorePayload(t *testing.T) {
 			if got[objectSig][0] != tt.args.signature {
 				t.Errorf("wrong signature, expected %q, got %q", tt.args.signature, got[objectSig][0])
 			}
-			var got_payload map[string]string
-			got_payload, err = b.RetrievePayloads(ctx, tt.args.opts)
+			var gotPayload map[string]string
+			gotPayload, err = b.RetrievePayloads(ctx, tt.args.opts)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got_payload[objectPayload] != string(tt.args.signed) {
-				t.Errorf("wrong signature, expected %s, got %s", tt.args.signed, got_payload[objectPayload])
+			if gotPayload[objectPayload] != string(tt.args.signed) {
+				t.Errorf("wrong signature, expected %s, got %s", tt.args.signed, gotPayload[objectPayload])
 			}
 		})
 	}

--- a/pkg/chains/storage/grafeas/grafeas.go
+++ b/pkg/chains/storage/grafeas/grafeas.go
@@ -125,7 +125,7 @@ func (b *Backend) StorePayload(ctx context.Context, rawPayload []byte, signature
 	return nil
 }
 
-// Retrieve payloads from grafeas server and store it in a map
+// RetrievePayloads retrieves payloads from grafeas server and store it in a map
 func (b *Backend) RetrievePayloads(ctx context.Context, opts config.StorageOpts) (map[string]string, error) {
 	// initialize an empty map for result
 	result := make(map[string]string)
@@ -148,7 +148,7 @@ func (b *Backend) RetrievePayloads(ctx context.Context, opts config.StorageOpts)
 	return result, nil
 }
 
-// Retrieve signatures from grafeas server and store it in a map
+// RetrieveSignatures retrieves signatures from grafeas server and store it in a map
 func (b *Backend) RetrieveSignatures(ctx context.Context, opts config.StorageOpts) (map[string][]string, error) {
 	// initialize an empty map for result
 	result := make(map[string][]string)

--- a/pkg/chains/storage/tekton/tekton.go
+++ b/pkg/chains/storage/tekton/tekton.go
@@ -110,7 +110,7 @@ func (b *Backend) retrieveAnnotationValue(ctx context.Context, annotationKey str
 	return annotationValue, nil
 }
 
-// RetrieveSignature retrieve the signature stored in the taskrun.
+// RetrieveSignatures retrieves the signature stored in the taskrun.
 func (b *Backend) RetrieveSignatures(ctx context.Context, opts config.StorageOpts) (map[string][]string, error) {
 	b.logger.Infof("Retrieving signature on TaskRun %s/%s", b.tr.Namespace, b.tr.Name)
 	signatureAnnotation := sigName(opts)
@@ -129,7 +129,7 @@ func (b *Backend) RetrieveSignatures(ctx context.Context, opts config.StorageOpt
 	return m, nil
 }
 
-// RetrievePayload retrieve the payload stored in the taskrun.
+// RetrievePayloads retrieves the payload stored in the taskrun.
 func (b *Backend) RetrievePayloads(ctx context.Context, opts config.StorageOpts) (map[string]string, error) {
 	b.logger.Infof("Retrieving payload on TaskRun %s/%s", b.tr.Namespace, b.tr.Name)
 	payloadAnnotation := payloadName(opts)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	Transparency TransparencyConfig
 }
 
-// ArtifactConfig contains the configuration for how to sign/store/format the signatures for each artifact type
+// ArtifactConfigs contains the configuration for how to sign/store/format the signatures for each artifact type
 type ArtifactConfigs struct {
 	TaskRuns Artifact
 	OCI      Artifact
@@ -47,7 +47,7 @@ type Artifact struct {
 	Signer         string
 }
 
-// StorageConfig contains the configuration to instantiate different storage providers
+// StorageConfigs contains the configuration to instantiate different storage providers
 type StorageConfigs struct {
 	GCS     GCSStorageConfig
 	OCI     OCIStorageConfig
@@ -56,7 +56,7 @@ type StorageConfigs struct {
 	Grafeas GrafeasConfig
 }
 
-// SigningConfig contains the configuration to instantiate different signers
+// SignerConfigs contains the configuration to instantiate different signers
 type SignerConfigs struct {
 	X509 X509Signer
 	KMS  KMSSigner
@@ -127,7 +127,6 @@ const (
 	kmsSignerKMSRef = "signers.kms.kmsref"
 	// Fulcio
 	x509SignerFulcioEnabled = "signers.x509.fulcio.enabled"
-	x509SignerFulcioAuth    = "signers.x509.fulcio.auth"
 	x509SignerFulcioAddr    = "signers.x509.fulcio.address"
 
 	// Builder config

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -25,6 +25,7 @@ import (
 
 type cfgKey struct{}
 
+// ConfigStore is the configuration from a ConfigMap
 // +k8s:deepcopy-gen=false
 type ConfigStore struct {
 	*configmap.UntypedStore


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

This adds a linter and cleans up a bunch of the easy linting warnings I was seeing. The linter should be configured to only pickup on new issues, but this is the first time I'm setting this one up, so extra eyes on the GHA are welcome.

The following I held off fixing since they may point to bigger changes or deleting code that may have future uses:

```
pkg/chains/formats/intotoite6/intotoite6.go:41:2: `ociDigestResult` is unused (deadcode)
        ociDigestResult              = "IMAGE_DIGEST"
        ^
pkg/chains/formats/intotoite6/intotoite6.go:42:2: `chainsDigestSuffix` is unused (deadcode)
        chainsDigestSuffix           = "_DIGEST"
        ^
pkg/chains/storage/tekton/tekton.go:159:6: `certName` is unused (deadcode)
func certName(opts config.StorageOpts) string {
     ^
pkg/chains/storage/tekton/tekton.go:163:6: `chainName` is unused (deadcode)
func chainName(opts config.StorageOpts) string {
     ^
pkg/chains/rekor.go:38:2: `timeout` is unused (deadcode)
        timeout = 30 * time.Second
        ^
pkg/chains/storage/grafeas/grafeas_test.go:351:15: Error return value of `serv.Serve` is not checked (errcheck)
        go serv.Serve(lis)
                     ^
```