### PR TITLE
Remove unused funcs/vars reported by golangci-lint

### DIFF
--- a/pkg/chains/formats/intotoite6/intotoite6.go
+++ b/pkg/chains/formats/intotoite6/intotoite6.go
@@ -38,8 +38,6 @@ const (
 	tektonID                     = "https://tekton.dev/attestations/chains@v2"
 	commitParam                  = "CHAINS-GIT_COMMIT"
 	urlParam                     = "CHAINS-GIT_URL"
-	ociDigestResult              = "IMAGE_DIGEST"
-	chainsDigestSuffix           = "_DIGEST"
 	ChainsReproducibleAnnotation = "chains.tekton.dev/reproducible"
 )
 

--- a/pkg/chains/rekor.go
+++ b/pkg/chains/rekor.go
@@ -15,7 +15,6 @@ package chains
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/pkg/cosign"
@@ -31,11 +30,6 @@ import (
 
 const (
 	RekorAnnotation = "chains.tekton.dev/transparency-upload"
-)
-
-var (
-	// using cosign default
-	timeout = 30 * time.Second
 )
 
 type rekor struct {

--- a/pkg/chains/storage/tekton/tekton.go
+++ b/pkg/chains/storage/tekton/tekton.go
@@ -155,11 +155,3 @@ func sigName(opts config.StorageOpts) string {
 func payloadName(opts config.StorageOpts) string {
 	return fmt.Sprintf(PayloadAnnotationFormat, opts.Key)
 }
-
-func certName(opts config.StorageOpts) string {
-	return fmt.Sprintf(CertAnnotationsFormat, opts.Key)
-}
-
-func chainName(opts config.StorageOpts) string {
-	return fmt.Sprintf(ChainAnnotationFormat, opts.Key)
-}


### PR DESCRIPTION
This PR removed unused variables and functions that are complaint by `golangci-lint run`. 