### PR TITLE
Fix nightly builds

### DIFF
--- a/release/kustomization.yaml
+++ b/release/kustomization.yaml
@@ -1,0 +1,19 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - publish.yaml
+  - release-pipeline.yaml


### PR DESCRIPTION
The plubming project has a reference to the 'release' directory of the
chains project. This is a kustomize remote resource reference. In order
to satisfy 'kustomize build', add a new kustomization.yaml file under
the 'release' directory.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>