### PR TITLE
Change SCC from anyuid to nonroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ for more information.
 
    ```bash
    oc new-project tekton-chains
-   oc adm policy add-scc-to-user anyuid -z tekton-chains-controller
+   oc adm policy add-scc-to-user nonroot -z tekton-chains-controller
    ```
 
 1. Install Tekton Chains:


### PR DESCRIPTION
This commit changes the SCC required to run Chains on OpenShift to
nonroot, since anyuid is no longer required.

Fix #366 