### PR TITLE
Disable unit test that requires GCP credentials

### DIFF
--- a/pkg/chains/storage/storage_test.go
+++ b/pkg/chains/storage/storage_test.go
@@ -42,11 +42,12 @@ func TestInitializeBackends(t *testing.T) {
 			want: []string{"tekton"},
 			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("tekton")}}},
 		},
-		{
-			name: "gcs",
-			want: []string{"gcs"},
-			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("gcs")}}},
-		},
+		// TODO: Re-enable this test when it doesn't rely on ambient GCP credentials.
+		//{
+		//	name: "gcs",
+		//	want: []string{"gcs"},
+		//	cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("gcs")}}},
+		//},
 		{
 			name: "oci",
 			want: []string{"oci"},
@@ -59,8 +60,8 @@ func TestInitializeBackends(t *testing.T) {
 		},
 		{
 			name: "multi",
-			want: []string{"gcs", "grafeas", "oci", "tekton"},
-			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("gcs", "grafeas", "oci", "tekton", "not-exist")}}},
+			want: []string{"grafeas", "oci", "tekton"},
+			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("grafeas", "oci", "tekton", "not-exist")}}},
 		},
 		{
 			name: "pubsub",


### PR DESCRIPTION
This causes tests to fail in environments where credentials aren't set up.

https://github.com/tektoncd/chains/issues/426#issuecomment-1115516150

Unit tests shouldn't rely on being able to reach out to external services.

cc @dprotaso 