### PR TITLE
Allow TaskRun payloads other than IMAGE_URL

### DIFF
--- a/pkg/chains/storage/tekton/tekton.go
+++ b/pkg/chains/storage/tekton/tekton.go
@@ -17,8 +17,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"strings"
-
 	"github.com/tektoncd/chains/pkg/config"
 
 	"github.com/tektoncd/chains/pkg/patch"
@@ -118,12 +116,7 @@ func (b *Backend) RetrieveSignatures(ctx context.Context, tr *v1beta1.TaskRun, o
 	}
 
 	m := make(map[string][]string)
-	for _, res := range tr.Status.TaskRunResults {
-		if strings.HasSuffix(res.Name, "IMAGE_URL") {
-			m[signatureAnnotation] = []string{signature}
-			break
-		}
-	}
+	m[signatureAnnotation] = []string{signature}
 	return m, nil
 }
 
@@ -136,13 +129,7 @@ func (b *Backend) RetrievePayloads(ctx context.Context, tr *v1beta1.TaskRun, opt
 		return nil, err
 	}
 	m := make(map[string]string)
-	for _, res := range tr.Status.TaskRunResults {
-		if strings.HasSuffix(res.Name, "IMAGE_URL") {
-			m[payloadAnnotation] = payload
-			break
-		}
-	}
-
+	m[payloadAnnotation] = payload
 	return m, nil
 }
 


### PR DESCRIPTION
Prior to this commit, in the `tekton` backend, a payload or a signature
was considered valid only if the TaskRun status had `IMAGE_URL` in the
results. This is incorrect since Chains considers both, `IMAGE_URL` and
`IMAGE_DIGEST` as results of interest. Moreover, Chains considers
PipelineResources to indicate an output of interest as well.

This commit removes checking for `IMAGE_URL` in the TaskRun status to
validate payloads, instead relies solely on the presence of a payload
annotation on the TaskRun given that it's only added when Chains has
signed something (after validation anyway).