### PR TITLE
Disable unit test for grafeas backend creation

### DIFF
--- a/pkg/chains/storage/storage_test.go
+++ b/pkg/chains/storage/storage_test.go
@@ -53,15 +53,16 @@ func TestInitializeBackends(t *testing.T) {
 			want: []string{"oci"},
 			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("oci")}}},
 		},
-		{
-			name: "grafeas",
-			want: []string{"grafeas"},
-			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("grafeas")}}},
-		},
+		// TODO: Re-enable this test when it doesn't rely on ambient GCP credentials.
+		// {
+		// 	name: "grafeas",
+		// 	want: []string{"grafeas"},
+		// 	cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("grafeas")}}},
+		// },
 		{
 			name: "multi",
-			want: []string{"grafeas", "oci", "tekton"},
-			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("grafeas", "oci", "tekton", "not-exist")}}},
+			want: []string{"oci", "tekton"},
+			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("oci", "tekton")}}},
 		},
 		{
 			name: "pubsub",


### PR DESCRIPTION
Prior to this commit, unit tests for creating grafeas backend storage
fail in environments where credentials aren't set up.

In this commit, those two unit tests are disabled.

related #438, https://github.com/tektoncd/chains/issues/426#issuecomment-1115516150

cc @imjasonh @dprotaso