### PR TITLE
Fix error msg in case no image produced

### DIFF
--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -105,7 +105,9 @@ func (b *Backend) StorePayload(ctx context.Context, tr *v1beta1.TaskRun, rawPayl
 		return b.uploadAttestation(attestation, signature, storageOpts, auth)
 	}
 
-	return errors.New("OCI storage backend is only supported for OCI images and in-toto attestations")
+	// Fallback in case unsupported payload format is used or the deprecated "tekton" format
+	b.logger.Info("Skipping upload to OCI registry, OCI storage backend is only supported for OCI images and in-toto attestations")
+	return nil
 }
 
 func (b *Backend) uploadSignature(format simple.SimpleContainerImage, rawPayload []byte, signature string, storageOpts config.StorageOpts, remoteOpts ...remote.Option) error {

--- a/pkg/chains/storage/oci/oci_test.go
+++ b/pkg/chains/storage/oci/oci_test.go
@@ -140,6 +140,34 @@ func TestBackend_StorePayload(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "in-toto-and-simple-payload",
+			fields: fields{
+				tr: tr,
+			},
+			args: args{
+				payload:   simple,
+				signature: "",
+				storageOpts: config.StorageOpts{
+					PayloadFormat: "in-toto",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "tekton-and-simple-payload",
+			fields: fields{
+				tr: tr,
+			},
+			args: args{
+				payload:   simple,
+				signature: "",
+				storageOpts: config.StorageOpts{
+					PayloadFormat: "tekton",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "no subject",
 			fields: fields{
 				tr: tr,


### PR DESCRIPTION
Fix #458 - Change fallback error message for non OCI images/results

In case task run does not produce an image, like git-clone, produce currently the oci logic an error message, which results in a wrong annotation `chains.tekton.dev/signed: failed`

This PR fix the error handling.
