### PR TITLE
Fix the default value for `builder.id` in the config doc

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -93,7 +93,7 @@ Tekton Chains supports the following docstore services:
 
 | Key | Description | Supported Values | Default |
 | :--- | :--- | :--- | :--- |
-| `builder.id` | The builder ID to set for in-toto attestations | | `tekton-chains`|
+| `builder.id` | The builder ID to set for in-toto attestations | | `https://tekton.dev/chains/v2`|
 
 ### Experimental Features Configuration
 


### PR DESCRIPTION
Prior to this commit, the config doc says the default value for
the `builder.id` field is tekton-chains. However, the default value defined in ` pkg/config/config.go` is
`https://tekton.dev/chains/v2`.