### PR TITLE
Add more supported GCP KMS key ref formats in config doc

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -67,7 +67,7 @@ Supported keys include:
 
 | Key | Description | Supported Values | Default |
 | :--- | :--- | :--- | :--- |
-| `signers.kms.kmsref` | The URI reference to a KMS service to use in `KMS` signers. | `gcpkms://projects/[PROJECT]/locations/[LOCATION]>/keyRings/[KEYRING]/cryptoKeys/[KEY]`| |
+| `signers.kms.kmsref` | The URI reference to a KMS service to use in `KMS` signers. | One of the three formats: <br/>`gcpkms://projects/[PROJECT]/locations/[LOCATION]>/keyRings/[KEYRING]/cryptoKeys/[KEY]` <br/> `gcpkms://projects/[PROJECT]/locations/[LOCATION]>/keyRings/[KEYRING]/cryptoKeys/[KEY]/cryptoKeyVersions/[KEY_VERSION]` <br/> `gcpkms://projects/[PROJECT]/locations/[LOCATION]>/keyRings/[KEYRING]/cryptoKeys/[KEY]/versions/[KEY_VERSION]`| |
 
 ### Storage Configuration
 


### PR DESCRIPTION
Prior to this commit, the config doc only mentions that the key ref
without version specified is supported. However, the key refs with
version specified are also specified. And there are two ways to specify
the version `../cryptoKeyVersions/..` (new) or `../versions/..` (old).

In this commit, we mention all support formats explicitly in the doc.