### PR TITLE
Fix for issue #515, This PR ensures only those signers which are specified as signers for any artifact are initialized.

### DIFF
--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -56,7 +56,12 @@ type TaskRunSigner struct {
 
 func allSigners(ctx context.Context, sp string, cfg config.Config, l *zap.SugaredLogger) map[string]signing.Signer {
 	all := map[string]signing.Signer{}
+	neededSigners := map[string]struct{}{cfg.Artifacts.OCI.Signer: {}, cfg.Artifacts.TaskRuns.Signer: {}}
+
 	for _, s := range signing.AllSigners {
+		if _, ok := neededSigners[s]; !ok {
+			continue
+		}
 		switch s {
 		case signing.TypeX509:
 			signer, err := x509.NewSigner(ctx, sp, cfg, l)


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
Fixes #515
This PR ensures only those signers which are specified as signers for any artifact are initialized. 
This change ensures that we do not initialize unwanted signers for which we might not have all necessary configs, which was resulting in unwanted errors in logs.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
