### PR TITLE
Fix param value ordering in materials

### DIFF
--- a/pkg/chains/formats/intotoite6/intotoite6.go
+++ b/pkg/chains/formats/intotoite6/intotoite6.go
@@ -267,16 +267,6 @@ func (i *InTotoIte6) Type() formats.PayloadType {
 // with specified names.
 func gitInfo(tr *v1beta1.TaskRun) (commit string, url string) {
 	// Scan for git params to use for materials
-	for _, p := range tr.Spec.Params {
-		if p.Name == commitParam {
-			commit = p.Value.StringVal
-			continue
-		}
-		if p.Name == urlParam {
-			url = p.Value.StringVal
-		}
-	}
-
 	if tr.Status.TaskSpec != nil {
 		for _, p := range tr.Status.TaskSpec.Params {
 			if p.Default == nil {
@@ -289,6 +279,16 @@ func gitInfo(tr *v1beta1.TaskRun) (commit string, url string) {
 			if p.Name == urlParam {
 				url = p.Default.StringVal
 			}
+		}
+	}
+
+	for _, p := range tr.Spec.Params {
+		if p.Name == commitParam {
+			commit = p.Value.StringVal
+			continue
+		}
+		if p.Name == urlParam {
+			url = p.Value.StringVal
 		}
 	}
 

--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -62,12 +62,12 @@ func TestCreatePayload1(t *testing.T) {
 				BuildFinishedOn: &e1BuildFinished,
 			},
 			Materials: []slsa.ProvenanceMaterial{
-				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "abcd"}},
+				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "sha:taskrun"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				Parameters: map[string]v1beta1.ArrayOrString{
 					"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
-					"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "abcd"},
+					"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 					"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 					"filename":          {Type: "string", StringVal: "/bin/ls"},
 				},
@@ -133,8 +133,14 @@ func TestCreatePayload2(t *testing.T) {
 			Builder: slsa.ProvenanceBuilder{
 				ID: "test_builder-2",
 			},
+			Materials: []slsa.ProvenanceMaterial{
+				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "sha:taskdefault"}},
+			},
 			Invocation: slsa.ProvenanceInvocation{
-				Parameters: map[string]v1beta1.ArrayOrString{},
+				Parameters: map[string]v1beta1.ArrayOrString{
+					"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
+					"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
+				},
 			},
 			BuildType: "https://tekton.dev/attestations/chains@v2",
 			BuildConfig: BuildConfig{

--- a/pkg/chains/formats/intotoite6/testdata/taskrun1.json
+++ b/pkg/chains/formats/intotoite6/testdata/taskrun1.json
@@ -7,7 +7,7 @@
             },
             {
                 "name": "CHAINS-GIT_COMMIT",
-                "value": "abcd"
+                "value": "sha:taskrun"
             },
             {
                 "name": "CHAINS-GIT_URL",
@@ -89,6 +89,14 @@
                 {
                     "name": "BUILDER_IMAGE",
                     "type": "string"
+                }, {
+                    "name": "CHAINS-GIT_COMMIT",
+                    "type": "string",
+                    "default": "sha:task"
+                }, {
+                    "name": "CHAINS-GIT_URL",
+                    "type": "string",
+                    "default": "https://defaultgit.test.com"
                 }
             ],
             "results": [

--- a/pkg/chains/formats/intotoite6/testdata/taskrun2.json
+++ b/pkg/chains/formats/intotoite6/testdata/taskrun2.json
@@ -36,7 +36,18 @@
             }
         ],
         "taskSpec": {
-            "params": [],
+            "params": [
+                {
+                    "name": "CHAINS-GIT_COMMIT",
+                    "type": "string",
+                    "default": "sha:taskdefault"
+                },
+                {
+                    "name": "CHAINS-GIT_URL",
+                    "type": "string",
+                    "default": "https://git.test.com"
+                }
+            ],
             "results": [
                 {
                     "name": "some-uri_DIGEST",


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Prior to the fix, when generating `materials` section of the intoto
attestation, Chains gets the param value from TaskRun spec first and then
default from Task spec. This overwriting will cause the problem that
the actual value used in run is from taskrun spec, but the value recorded
in `materials` is the value defined in task spec's `default`.

In this PR, we fix the issue by making sure that the default parameters are 
always overwritten by values from the taskrun spec.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
