### PR TITLE
Remove Tekton Pipelines v1alpha1 type dependencies

### DIFF
--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -88,13 +88,6 @@ type StructuredSignable struct {
 
 func (oa *OCIArtifact) ExtractObjects(tr *v1beta1.TaskRun) []interface{} {
 	imageResourceNames := map[string]*image{}
-	if tr.Status.TaskSpec != nil && tr.Status.TaskSpec.Resources != nil {
-		for _, output := range tr.Status.TaskSpec.Resources.Outputs {
-			if output.Type == v1beta1.PipelineResourceTypeImage {
-				imageResourceNames[output.Name] = &image{}
-			}
-		}
-	}
 
 	for _, rr := range tr.Status.ResourcesResult {
 		img, ok := imageResourceNames[rr.ResourceName]

--- a/pkg/chains/formats/intotoite6/provenance_test.go
+++ b/pkg/chains/formats/intotoite6/provenance_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logtesting "knative.dev/pkg/logging/testing"
 )
@@ -271,13 +270,6 @@ func TestGetSubjectDigests(t *testing.T) {
 						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
 							Name: "nil-check",
 						},
-					}, {
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: "built-image",
-							ResourceSpec: &v1alpha1.PipelineResourceSpec{
-								Type: v1alpha1.PipelineResourceTypeImage,
-							},
-						},
 					},
 				},
 			},
@@ -320,17 +312,6 @@ func TestGetSubjectDigests(t *testing.T) {
 					{
 						Name:  "invalid_ARTIFACT_DIGEST",
 						Value: *v1beta1.NewArrayOrString(digest5),
-					},
-				},
-				ResourcesResult: []v1beta1.PipelineResourceResult{
-					{
-						ResourceName: "built-image",
-						Key:          "url",
-						Value:        "registry/resource-image",
-					}, {
-						ResourceName: "built-image",
-						Key:          "digest",
-						Value:        digest2,
 					},
 				},
 			},


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Remove Tekton Pipelines v1alpha1 type dependencies since v0.38 is removing some v1alpha1 types.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Remove Tekton Pipelines v1alpha1 type dependencies.
```
