### PR TITLE
Upgrade PipelineResourceTypeGit and PipelineResourceTypeImage to v1beta1 types

### DIFF
--- a/pkg/chains/formats/intotoite6/intotoite6.go
+++ b/pkg/chains/formats/intotoite6/intotoite6.go
@@ -28,7 +28,6 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"go.uber.org/zap"
 )
 
@@ -174,7 +173,7 @@ func GetSubjectDigests(tr *v1beta1.TaskRun, logger *zap.SugaredLogger) []intoto.
 			continue
 		}
 		// similarly, we could do this for other pipeline resources or whatever thing replaces them
-		if output.PipelineResourceBinding.ResourceSpec.Type == v1alpha1.PipelineResourceTypeImage {
+		if output.PipelineResourceBinding.ResourceSpec.Type == v1beta1.PipelineResourceTypeImage {
 			// get the url and digest, and save as a subject
 			var url, digest string
 			for _, s := range tr.Status.ResourcesResult {
@@ -221,7 +220,7 @@ func materials(tr *v1beta1.TaskRun) []slsa.ProvenanceMaterial {
 
 	// check for a Git PipelineResource
 	for _, input := range tr.Spec.Resources.Inputs {
-		if input.ResourceSpec == nil || input.ResourceSpec.Type != v1alpha1.PipelineResourceTypeGit {
+		if input.ResourceSpec == nil || input.ResourceSpec.Type != v1beta1.PipelineResourceTypeGit {
 			continue
 		}
 

--- a/pkg/chains/formats/intotoite6/provenance_test.go
+++ b/pkg/chains/formats/intotoite6/provenance_test.go
@@ -275,7 +275,7 @@ func TestGetSubjectDigests(t *testing.T) {
 						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
 							Name: "built-image",
 							ResourceSpec: &v1alpha1.PipelineResourceSpec{
-								Type: v1alpha1.PipelineResourceTypeImage,
+								Type: v1beta1.PipelineResourceTypeImage,
 							},
 						},
 					},


### PR DESCRIPTION
Upgrade PipelineResourceTypeGit and PipelineResourceTypeImage to v1beta1 types

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes
Upgrade PipelineResourceTypeGit and PipelineResourceTypeImage to v1beta1 Pipeline types
``` release-note
NONE
```
