### PR TITLE
Record `invocation.configSource` section in slsa provenance

### DIFF
--- a/pkg/chains/formats/intotoite6/attest/attest.go
+++ b/pkg/chains/formats/intotoite6/attest/attest.go
@@ -55,8 +55,10 @@ func Step(step *v1beta1.Step, stepState *v1beta1.StepState) StepAttestation {
 	return attestation
 }
 
-func Invocation(params []v1beta1.Param, paramSpecs []v1beta1.ParamSpec) slsa.ProvenanceInvocation {
-	i := slsa.ProvenanceInvocation{}
+func Invocation(source *v1beta1.ConfigSource, params []v1beta1.Param, paramSpecs []v1beta1.ParamSpec) slsa.ProvenanceInvocation {
+	i := slsa.ProvenanceInvocation{
+		ConfigSource: convertConfigSource(source),
+	}
 	iParams := make(map[string]v1beta1.ArrayOrString)
 
 	// get implicit parameters from defaults
@@ -73,6 +75,17 @@ func Invocation(params []v1beta1.Param, paramSpecs []v1beta1.ParamSpec) slsa.Pro
 
 	i.Parameters = iParams
 	return i
+}
+
+func convertConfigSource(source *v1beta1.ConfigSource) slsa.ConfigSource {
+	if source == nil {
+		return slsa.ConfigSource{}
+	}
+	return slsa.ConfigSource{
+		URI:        source.URI,
+		Digest:     source.Digest,
+		EntryPoint: source.EntryPoint,
+	}
 }
 
 // supports the SPDX format which is recommended by in-toto

--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -71,6 +71,11 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "sha:taskrun"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
+				ConfigSource: slsa.ConfigSource{
+					URI:        "github.com/test",
+					Digest:     map[string]string{"sha1": "ab123"},
+					EntryPoint: "build.yaml",
+				},
 				Parameters: map[string]v1beta1.ArrayOrString{
 					"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
 					"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
@@ -160,7 +165,11 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "abcd"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
-				ConfigSource: slsa.ConfigSource{},
+				ConfigSource: slsa.ConfigSource{
+					URI:        "github.com/test",
+					Digest:     map[string]string{"sha1": "28b123"},
+					EntryPoint: "pipeline.yaml",
+				},
 				Parameters: map[string]v1beta1.ArrayOrString{
 					"IMAGE": {Type: "string", StringVal: "test.io/test/image"},
 				},
@@ -193,7 +202,11 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 							},
 						},
 						Invocation: slsa.ProvenanceInvocation{
-							ConfigSource: slsa.ConfigSource{},
+							ConfigSource: slsa.ConfigSource{
+								URI:        "github.com/catalog",
+								Digest:     slsa.DigestSet{"sha1": "x123"},
+								EntryPoint: "git-clone.yaml",
+							},
 							Parameters: map[string]v1beta1.ArrayOrString{
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
@@ -258,7 +271,11 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 							},
 						},
 						Invocation: slsa.ProvenanceInvocation{
-							ConfigSource: slsa.ConfigSource{},
+							ConfigSource: slsa.ConfigSource{
+								URI:        "github.com/test",
+								Digest:     map[string]string{"sha1": "ab123"},
+								EntryPoint: "build.yaml",
+							},
 							Parameters: map[string]v1beta1.ArrayOrString{
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
@@ -381,7 +398,11 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 							},
 						},
 						Invocation: slsa.ProvenanceInvocation{
-							ConfigSource: slsa.ConfigSource{},
+							ConfigSource: slsa.ConfigSource{
+								URI:        "github.com/catalog",
+								Digest:     slsa.DigestSet{"sha1": "x123"},
+								EntryPoint: "git-clone.yaml",
+							},
 							Parameters: map[string]v1beta1.ArrayOrString{
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
@@ -446,7 +467,11 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 							},
 						},
 						Invocation: slsa.ProvenanceInvocation{
-							ConfigSource: slsa.ConfigSource{},
+							ConfigSource: slsa.ConfigSource{
+								URI:        "github.com/test",
+								Digest:     map[string]string{"sha1": "ab123"},
+								EntryPoint: "build.yaml",
+							},
 							Parameters: map[string]v1beta1.ArrayOrString{
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
@@ -526,6 +551,11 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "sha:taskdefault"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
+				ConfigSource: slsa.ConfigSource{
+					URI:        "github.com/catalog",
+					Digest:     slsa.DigestSet{"sha1": "x123"},
+					EntryPoint: "git-clone.yaml",
+				},
 				Parameters: map[string]v1beta1.ArrayOrString{
 					"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
 					"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
@@ -555,31 +585,6 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
 	if diff := cmp.Diff(expected, got); diff != "" {
-		t.Errorf("InTotoIte6.CreatePayload(): -want +got: %s", diff)
-	}
-}
-
-func TestCreatePayloadNilTaskRef(t *testing.T) {
-	tr, err := objectloader.TaskRunFromFile("testdata/taskrun1.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tr.Spec.TaskRef = nil
-	cfg := config.Config{
-		Builder: config.BuilderConfig{
-			ID: "testid",
-		},
-	}
-	f, _ := NewFormatter(cfg, logtesting.TestLogger(t))
-
-	p, err := f.CreatePayload(objects.NewTaskRunObject(tr))
-	if err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
-	}
-
-	ps := p.(in_toto.ProvenanceStatement)
-	if diff := cmp.Diff("", ps.Predicate.Invocation.ConfigSource.EntryPoint); diff != "" {
 		t.Errorf("InTotoIte6.CreatePayload(): -want +got: %s", diff)
 	}
 }

--- a/pkg/chains/formats/intotoite6/pipelinerun/provenance_test.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/provenance_test.go
@@ -62,6 +62,11 @@ func createPro() *objects.PipelineRunObject {
 
 func TestInvocation(t *testing.T) {
 	expected := slsa.ProvenanceInvocation{
+		ConfigSource: slsa.ConfigSource{
+			URI:        "github.com/test",
+			Digest:     map[string]string{"sha1": "28b123"},
+			EntryPoint: "pipeline.yaml",
+		},
 		Parameters: map[string]v1beta1.ArrayOrString{
 			"IMAGE": {Type: "string", StringVal: "test.io/test/image"},
 		},
@@ -97,7 +102,11 @@ func TestBuildConfig(t *testing.T) {
 					},
 				},
 				Invocation: slsa.ProvenanceInvocation{
-					ConfigSource: slsa.ConfigSource{},
+					ConfigSource: slsa.ConfigSource{
+						URI:        "github.com/catalog",
+						Digest:     slsa.DigestSet{"sha1": "x123"},
+						EntryPoint: "git-clone.yaml",
+					},
 					Parameters: map[string]v1beta1.ArrayOrString{
 						"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
 						"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
@@ -162,7 +171,11 @@ func TestBuildConfig(t *testing.T) {
 					},
 				},
 				Invocation: slsa.ProvenanceInvocation{
-					ConfigSource: slsa.ConfigSource{},
+					ConfigSource: slsa.ConfigSource{
+						URI:        "github.com/test",
+						Digest:     map[string]string{"sha1": "ab123"},
+						EntryPoint: "build.yaml",
+					},
 					Parameters: map[string]v1beta1.ArrayOrString{
 						"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 						"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
@@ -273,7 +286,11 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 							},
 						},
 						Invocation: slsa.ProvenanceInvocation{
-							ConfigSource: slsa.ConfigSource{},
+							ConfigSource: slsa.ConfigSource{
+								URI:        "github.com/catalog",
+								Digest:     slsa.DigestSet{"sha1": "x123"},
+								EntryPoint: "git-clone.yaml",
+							},
 							Parameters: map[string]v1beta1.ArrayOrString{
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
@@ -338,7 +355,11 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 							},
 						},
 						Invocation: slsa.ProvenanceInvocation{
-							ConfigSource: slsa.ConfigSource{},
+							ConfigSource: slsa.ConfigSource{
+								URI:        "github.com/test",
+								Digest:     map[string]string{"sha1": "ab123"},
+								EntryPoint: "build.yaml",
+							},
 							Parameters: map[string]v1beta1.ArrayOrString{
 								// TODO: Is this right?
 								// "CHAINS-GIT_COMMIT": {Type: "string", StringVal: "abcd"},

--- a/pkg/chains/formats/intotoite6/taskrun/taskrun.go
+++ b/pkg/chains/formats/intotoite6/taskrun/taskrun.go
@@ -56,7 +56,11 @@ func invocation(tro *objects.TaskRunObject) slsa.ProvenanceInvocation {
 	if ts := tro.Status.TaskSpec; ts != nil {
 		paramSpecs = ts.Params
 	}
-	return attest.Invocation(tro.Spec.Params, paramSpecs)
+	var source *v1beta1.ConfigSource
+	if p := tro.Status.Provenance; p != nil {
+		source = p.ConfigSource
+	}
+	return attest.Invocation(source, tro.Spec.Params, paramSpecs)
 }
 
 func metadata(tro *objects.TaskRunObject) *slsa.ProvenanceMetadata {

--- a/pkg/chains/formats/intotoite6/testdata/pipelinerun1.json
+++ b/pkg/chains/formats/intotoite6/testdata/pipelinerun1.json
@@ -292,6 +292,15 @@
                     }
                 }
             }
+        },
+        "provenance": {
+          "configSource": {
+            "uri": "github.com/test",
+            "digest": {
+              "sha1": "28b123"
+            },
+            "entryPoint": "pipeline.yaml"
+          }
         }
     }
 }

--- a/pkg/chains/formats/intotoite6/testdata/taskrun1.json
+++ b/pkg/chains/formats/intotoite6/testdata/taskrun1.json
@@ -122,6 +122,15 @@
                     "description": "Digest of the file just built."
                 }
             ]
+        },
+      "provenance": {
+          "configSource": {
+            "uri": "github.com/test",
+            "digest": {
+              "sha1": "ab123"
+            },
+            "entryPoint": "build.yaml"
+          }
         }
     }
 }

--- a/pkg/chains/formats/intotoite6/testdata/taskrun2.json
+++ b/pkg/chains/formats/intotoite6/testdata/taskrun2.json
@@ -91,6 +91,15 @@
                     "description": "some calculated uri"
                 }
             ]
+        },
+        "provenance": {
+          "configSource": {
+            "uri": "github.com/catalog",
+            "digest": {
+              "sha1": "x123"
+            },
+            "entryPoint": "git-clone.yaml"
+          }
         }
     }
 }


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Related to https://github.com/tektoncd/chains/issues/521.

Prior to this PR, the SLSA provenance that Chains produces did not record
the source information of remote resources.

In this change, we want to record the source information in the provenance
to track where the remote pipeline/task definition came from i.e. git repo,
tekton bundles etc. The source information is available in
PipelineRun/TaskRun `Status.Provenance` field.

If a remote pipeline definition references remote task definitions from other remote places,
`predicate.invocation.configSource` will record the source information of
the remote pipeline definition only, and `predicate.buildConfig.tasks[x].invocation.configSource`
will record the source information for the corresponding remote task definition.

Signed-off-by: Chuang Wang <chuangw@google.com>


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
SLSA provenance records the source information of remote task/pipeline definition.
```
