### PR TITLE
Update PipelineRun attestation buildType

### DIFF
--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -167,7 +167,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 			Builder: slsa.ProvenanceBuilder{
 				ID: "test_builder-1",
 			},
-			BuildType: "https://tekton.dev/attestations/chains/pipelinerun@v2",
+			BuildType: "tekton.dev/v1beta1/PipelineRun",
 			BuildConfig: pipelinerun.BuildConfig{
 				Tasks: []pipelinerun.TaskAttestation{
 					{
@@ -355,7 +355,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 			Builder: slsa.ProvenanceBuilder{
 				ID: "test_builder-1",
 			},
-			BuildType: "https://tekton.dev/attestations/chains/pipelinerun@v2",
+			BuildType: "tekton.dev/v1beta1/PipelineRun",
 			BuildConfig: pipelinerun.BuildConfig{
 				Tasks: []pipelinerun.TaskAttestation{
 					{

--- a/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
@@ -14,6 +14,7 @@ limitations under the License.
 package pipelinerun
 
 import (
+	"fmt"
 	"time"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
@@ -25,10 +26,6 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
-)
-
-const (
-	TektonPipelineRunID = "https://tekton.dev/attestations/chains/pipelinerun@v2"
 )
 
 type BuildConfig struct {
@@ -60,7 +57,7 @@ func GenerateAttestation(builderID string, pro *objects.PipelineRunObject, logge
 			Builder: slsa.ProvenanceBuilder{
 				ID: builderID,
 			},
-			BuildType:   TektonPipelineRunID,
+			BuildType:   fmt.Sprintf("%s/%s", pro.GetGroupVersionKind().GroupVersion().String(), pro.GetGroupVersionKind().Kind),
 			Invocation:  invocation(pro),
 			BuildConfig: buildConfig(pro, logger),
 			Metadata:    metadata(pro),

--- a/pkg/chains/formats/intotoite6/taskrun/taskrun.go
+++ b/pkg/chains/formats/intotoite6/taskrun/taskrun.go
@@ -26,10 +26,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	TektonID = "https://tekton.dev/attestations/chains@v2"
-)
-
 func GenerateAttestation(builderID string, tro *objects.TaskRunObject, logger *zap.SugaredLogger) (interface{}, error) {
 	subjects := extract.SubjectDigests(tro, logger)
 


### PR DESCRIPTION
# Changes

To match the structure of the buildType of TaskRun attestation, change
the buildType of PipelineRun attestations from:
    https://tekton.dev/attestations/chains/pipelinerun@v2
to:
    tekton.dev/v1beta1/PipelineRun

Also, remove unused TektonID const. This is leftover from when this value was used for the buildType value of TaskRun attestations.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
