### PR TITLE
chore: upgrade setup-ko to its latest version

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -53,7 +53,7 @@ jobs:
       with:
         go-version: 1.18.x
 
-    - uses: imjasonh/setup-ko@v0.5
+    - uses: imjasonh/setup-ko@v0.6
       with:
         version: tip
 


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

I upgraded the _setup-ko_ GitHub Action to the latest version because ko has been moving its organization recently.

> https://github.com/imjasonh/setup-ko#github-action-to-install-and-setup-ko

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
e2e tests are now using the latest of the version of _setup-ko_ GitHub action because ko has been moving its organization recently.
```

/cc @imjasonh 