### PR TITLE
allow reading the pull secret from the podTemplate

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -16,7 +16,9 @@ This doc will cover how to set this up!
 
 ## Authenticating to an OCI Registry
 
-The Chains controller will use the same service account your Task runs under as credentials for pushing signatures to an OCI registry. This section will cover how to set up a service account that has the necessary credentials.
+To push to an OCI registry, the Chains controller will look for credentials in two places. The first place is in the pod executing your Task and the second place is in the service account configured to run your Task. 
+
+### First we'll cover creating the credentials.
 
 Set the namespace and name of the Kubernetes service account:
 
@@ -72,7 +74,28 @@ kubectl create secret docker-registry registry-credentials \
 
 More details around creating this secret can be found [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line).
 
-### Grant access to the service account
+### Setup credentials using the pod
+Tekton supports specifying a Pod template to customize the Pod running your Task. You must supply the Pod template when starting your Task with the cli or embeddng it into your TaskRun.
+
+An example TaskRun configured with the `registry-credentials` secret.
+```yaml
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: mytaskrun
+  namespace: default
+spec:
+  taskRef:
+    name: mytask
+  podTemplate:
+    imagePullSecrets:
+    - name: registry-credentials
+```
+
+More details on how to modify the podTemplate for a taskRun can be found [here](https://github.com/tektoncd/pipeline/blob/main/docs/taskruns.md#specifying-a-pod-template).
+
+### Setup credentials using the service account
 
 Finally, give the service account access to the secret above:
 

--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -16,6 +16,7 @@ package objects
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,6 +55,7 @@ type TektonObject interface {
 	Patch(ctx context.Context, clientSet versioned.Interface, patchBytes []byte) error
 	GetResults() []Result
 	GetServiceAccountName() string
+	GetPullSecrets() []string
 }
 
 // TaskRunObject extends v1beta1.TaskRun with additional functions.
@@ -105,6 +107,11 @@ func (tro *TaskRunObject) GetResults() []Result {
 // Get the ServiceAccount declared in the TaskRun
 func (tro *TaskRunObject) GetServiceAccountName() string {
 	return tro.Spec.ServiceAccountName
+}
+
+// Get the imgPullSecrets from the pod template
+func (tro *TaskRunObject) GetPullSecrets() []string {
+	return getPodPullSecrets(tro.Spec.PodTemplate)
 }
 
 // PipelineRunObject extends v1beta1.PipelineRun with additional functions.
@@ -178,4 +185,23 @@ func (pro *PipelineRunObject) GetTaskRunFromTask(taskName string) *v1beta1.TaskR
 		}
 	}
 	return nil
+}
+
+// Get the imgPullSecrets from the pod template
+func (pro *PipelineRunObject) GetPullSecrets() []string {
+	return getPodPullSecrets(pro.Spec.PodTemplate)
+}
+
+// Get the imgPullSecrets from a pod template, if they exist
+func getPodPullSecrets(podTemplate *pod.Template) []string {
+	imgPullSecrets := []string{}
+	if podTemplate != nil {
+		pullSecrets := podTemplate.ImagePullSecrets
+		if pullSecrets != nil {
+			for _, secret := range pullSecrets {
+				imgPullSecrets = append(imgPullSecrets, secret.Name)
+			}
+		}
+	}
+	return imgPullSecrets
 }

--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -196,11 +196,8 @@ func (pro *PipelineRunObject) GetPullSecrets() []string {
 func getPodPullSecrets(podTemplate *pod.Template) []string {
 	imgPullSecrets := []string{}
 	if podTemplate != nil {
-		pullSecrets := podTemplate.ImagePullSecrets
-		if pullSecrets != nil {
-			for _, secret := range pullSecrets {
-				imgPullSecrets = append(imgPullSecrets, secret.Name)
-			}
+		for _, secret := range podTemplate.ImagePullSecrets {
+			imgPullSecrets = append(imgPullSecrets, secret.Name)
 		}
 	}
 	return imgPullSecrets

--- a/pkg/chains/objects/objects_test.go
+++ b/pkg/chains/objects/objects_test.go
@@ -23,68 +23,70 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	namespace  = "objects-test"
-	pullSecret = "pull-secret"
-)
-
-var (
-	tr = &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: namespace,
-		},
-		Spec: v1beta1.TaskRunSpec{},
-	}
-	pr = &v1beta1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: namespace,
-		},
-		Spec: v1beta1.PipelineRunSpec{},
-	}
-	templatePullSecret = &pod.PodTemplate{
+func getPullSecretTemplate(pullSecret string) *pod.PodTemplate {
+	return &pod.PodTemplate{
 		ImagePullSecrets: []corev1.LocalObjectReference{
 			{
 				Name: pullSecret,
 			},
 		},
 	}
-	emptyTemplate = &pod.PodTemplate{}
-)
+}
+
+func getEmptyTemplate() *pod.PodTemplate {
+	return &pod.PodTemplate{}
+}
+
+func getTaskRun() *v1beta1.TaskRun {
+	return &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "objects-test",
+		},
+		Spec: v1beta1.TaskRunSpec{},
+	}
+}
+
+func getPipelineRun() *v1beta1.PipelineRun {
+	return &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "objects-test",
+		},
+		Spec: v1beta1.PipelineRunSpec{},
+	}
+}
 
 func TestTaskRun_ImagePullSecrets(t *testing.T) {
+	pullSecret := "pull-secret"
 
 	tests := []struct {
 		name     string
-		taskRun  *TaskRunObject
 		template *pod.PodTemplate
 		want     []string
 	}{
 		{
 			name:     "Test pull secret found",
-			taskRun:  NewTaskRunObject(tr),
-			template: templatePullSecret,
+			template: getPullSecretTemplate(pullSecret),
 			want:     []string{pullSecret},
 		},
 		{
 			name:     "Test pull secret missing",
-			taskRun:  NewTaskRunObject(tr),
 			template: nil,
 			want:     []string{},
 		},
 		{
 			name:     "Test podTemplate missing",
-			taskRun:  NewTaskRunObject(tr),
-			template: emptyTemplate,
+			template: getEmptyTemplate(),
 			want:     []string{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.taskRun.Spec.PodTemplate = tt.template
-			secret := tt.taskRun.GetPullSecrets()
+			tr := NewTaskRunObject(getTaskRun())
+			tr.Spec.PodTemplate = tt.template
+			secret := tr.GetPullSecrets()
 			assert.ElementsMatch(t, secret, tt.want)
 		})
 	}
@@ -92,38 +94,36 @@ func TestTaskRun_ImagePullSecrets(t *testing.T) {
 }
 
 func TestPipelineRun_ImagePullSecrets(t *testing.T) {
+	pullSecret := "pull-secret"
+
 	tests := []struct {
-		name        string
-		pipelineRun *PipelineRunObject
-		template    *pod.PodTemplate
-		want        []string
+		name     string
+		template *pod.PodTemplate
+		want     []string
 	}{
 		{
-			name:        "Test pull secret found",
-			pipelineRun: NewPipelineRunObject(pr),
-			template:    templatePullSecret,
-			want:        []string{pullSecret},
+			name:     "Test pull secret found",
+			template: getPullSecretTemplate(pullSecret),
+			want:     []string{pullSecret},
 		},
 		{
-			name:        "Test pull secret missing",
-			pipelineRun: NewPipelineRunObject(pr),
-			template:    nil,
-			want:        []string{},
+			name:     "Test pull secret missing",
+			template: nil,
+			want:     []string{},
 		},
 		{
-			name:        "Test podTemplate missing",
-			pipelineRun: NewPipelineRunObject(pr),
-			template:    emptyTemplate,
-			want:        []string{},
+			name:     "Test podTemplate missing",
+			template: getEmptyTemplate(),
+			want:     []string{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.pipelineRun.Spec.PodTemplate = tt.template
-			secret := tt.pipelineRun.GetPullSecrets()
+			pr := NewPipelineRunObject(getPipelineRun())
+			pr.Spec.PodTemplate = tt.template
+			secret := pr.GetPullSecrets()
 			assert.ElementsMatch(t, secret, tt.want)
 		})
 	}
-
 }

--- a/pkg/chains/objects/objects_test.go
+++ b/pkg/chains/objects/objects_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2022 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objects
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	namespace  = "objects-test"
+	pullSecret = "pull-secret"
+)
+
+var (
+	tr = &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: namespace,
+		},
+		Spec: v1beta1.TaskRunSpec{},
+	}
+	pr = &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: namespace,
+		},
+		Spec: v1beta1.PipelineRunSpec{},
+	}
+	templatePullSecret = &pod.PodTemplate{
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{
+				Name: pullSecret,
+			},
+		},
+	}
+	emptyTemplate = &pod.PodTemplate{}
+)
+
+func TestTaskRun_ImagePullSecrets(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		taskRun  *TaskRunObject
+		template *pod.PodTemplate
+		want     []string
+	}{
+		{
+			name:     "Test pull secret found",
+			taskRun:  NewTaskRunObject(tr),
+			template: templatePullSecret,
+			want:     []string{pullSecret},
+		},
+		{
+			name:     "Test pull secret missing",
+			taskRun:  NewTaskRunObject(tr),
+			template: nil,
+			want:     []string{},
+		},
+		{
+			name:     "Test podTemplate missing",
+			taskRun:  NewTaskRunObject(tr),
+			template: emptyTemplate,
+			want:     []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.taskRun.Spec.PodTemplate = tt.template
+			secret := tt.taskRun.GetPullSecrets()
+			assert.ElementsMatch(t, secret, tt.want)
+		})
+	}
+
+}
+
+func TestPipelineRun_ImagePullSecrets(t *testing.T) {
+	tests := []struct {
+		name        string
+		pipelineRun *PipelineRunObject
+		template    *pod.PodTemplate
+		want        []string
+	}{
+		{
+			name:        "Test pull secret found",
+			pipelineRun: NewPipelineRunObject(pr),
+			template:    templatePullSecret,
+			want:        []string{pullSecret},
+		},
+		{
+			name:        "Test pull secret missing",
+			pipelineRun: NewPipelineRunObject(pr),
+			template:    nil,
+			want:        []string{},
+		},
+		{
+			name:        "Test podTemplate missing",
+			pipelineRun: NewPipelineRunObject(pr),
+			template:    emptyTemplate,
+			want:        []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.pipelineRun.Spec.PodTemplate = tt.template
+			secret := tt.pipelineRun.GetPullSecrets()
+			assert.ElementsMatch(t, secret, tt.want)
+		})
+	}
+
+}

--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -60,7 +60,11 @@ func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, client ku
 		client: client,
 		getAuthenticator: func(ctx context.Context, obj objects.TektonObject, client kubernetes.Interface) (remote.Option, error) {
 			kc, err := k8schain.New(ctx, client,
-				k8schain.Options{Namespace: obj.GetNamespace(), ServiceAccountName: obj.GetServiceAccountName()})
+				k8schain.Options{
+					Namespace:          obj.GetNamespace(),
+					ServiceAccountName: obj.GetServiceAccountName(),
+					ImagePullSecrets:   obj.GetPullSecrets(),
+				})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
# Changes
This change is to allow chains to get the `imgPullSecret` from the pod template. This will allow users to configure repo auth on a per pipelineRun/taskRun basis and not modify the service account.


