### PR TITLE
docs: fix verify-attestation cmd

### DIFF
--- a/docs/tutorials/signed-provenance-tutorial.md
+++ b/docs/tutorials/signed-provenance-tutorial.md
@@ -114,7 +114,7 @@ To verify the image and the attestation, we'll use `cosign` again:
 
 ```shell
 cosign verify --key cosign.pub $REGISTRY/kaniko-chains
-cosign verify-attestation --key cosign.pub $REGISTRY/kaniko-chains
+cosign verify-attestation --key cosign.pub --type slsaprovenance $REGISTRY/kaniko-chains
 ```
 
 You should see verification output for both!


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Based on the conversation on Slack #chains: _https://tektoncd.slack.com/archives/C015FAQV290/p1664801546556049_

According to the document,  at the verification part [here](https://tekton.dev/docs/chains/signed-provenance-tutorial/#verifying-the-image-and-attestation),  users need to specify which type of attestation that do they want to verify, which is a “slsaprovenance” in this case, if they follow up this documentation they will encounter an error like the following:

_Error: none of the attestations matched the predicate type: custom
main.go:62: error during command execution: none of the attestations matched the predicate type: custom_

Because cosign will try to verify attestation based on custom type if no type is specified

Cross-issue: https://github.com/buildsec/frsca/pull/322

Thanks @sudo-bmitch  

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
fix: correct the verify-attestation command by adding the --type flag to it
```
