### PR TITLE
fix: pubusub to pubsub in storage backend support of experimental features

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -90,7 +90,7 @@ provider implementation is Kafka, and more may follow in the future.
 To enable the Kafka backend run:
 
 ```shell
-kubectl patch configmap chains-config -n tekton-chains -p='{"data": {storage.pubsub.provider": "kafka","storage.pubusub.topic": "chains", "storage.pubsub.kafka.bootstrap.servers":"kafka-0.kafka-headless.default.svc.cluster.local:9092"}}'
+kubectl patch configmap chains-config -n tekton-chains -p='{"data": {storage.pubsub.provider": "kafka","storage.pubsub.topic": "chains", "storage.pubsub.kafka.bootstrap.servers":"kafka-0.kafka-headless.default.svc.cluster.local:9092"}}'
 ```
 
 Note that the `storage.pubsub.kafka.bootstrap.servers` value needs to be


### PR DESCRIPTION


Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

This PR will fix the typo on the _Experimental Features_ page of the _Supply Chain Security_ category.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
fix: pubusub to pubsub in storage backend support of experimental features
```
