### PR TITLE
Full access to image url and digest in StorageOpts

### DIFF
--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -217,7 +217,8 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 			for _, backend := range signableType.StorageBackend(cfg).List() {
 				b := o.Backends[backend]
 				storageOpts := config.StorageOpts{
-					Key:           signableType.Key(obj),
+					ShortKey:      signableType.ShortKey(obj),
+					FullKey:       signableType.FullKey(obj),
 					Cert:          signer.Cert(),
 					Chain:         signer.Chain(),
 					PayloadFormat: payloadFormat,

--- a/pkg/chains/storage/docdb/docdb.go
+++ b/pkg/chains/storage/docdb/docdb.go
@@ -72,7 +72,7 @@ func (b *Backend) StorePayload(ctx context.Context, _ objects.TektonObject, rawP
 		Signed:    rawPayload,
 		Signature: base64.StdEncoding.EncodeToString([]byte(signature)),
 		Object:    obj,
-		Name:      opts.Key,
+		Name:      opts.ShortKey,
 		Cert:      opts.Cert,
 		Chain:     opts.Chain,
 	}
@@ -122,7 +122,7 @@ func (b *Backend) RetrievePayloads(ctx context.Context, _ objects.TektonObject, 
 }
 
 func (b *Backend) retrieveDocuments(ctx context.Context, opts config.StorageOpts) ([]SignedDocument, error) {
-	d := SignedDocument{Name: opts.Key}
+	d := SignedDocument{Name: opts.ShortKey}
 	if err := b.coll.Get(ctx, &d); err != nil {
 		return []SignedDocument{}, err
 	}

--- a/pkg/chains/storage/docdb/docdb_test.go
+++ b/pkg/chains/storage/docdb/docdb_test.go
@@ -78,7 +78,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			}
 
 			// Store the document.
-			opts := config.StorageOpts{Key: tt.args.key}
+			opts := config.StorageOpts{ShortKey: tt.args.key}
 			trObj := objects.NewTaskRunObject(tt.args.tr)
 			if err := b.StorePayload(ctx, trObj, sb, tt.args.signature, opts); (err != nil) != tt.wantErr {
 				t.Fatalf("Backend.StorePayload() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/chains/storage/gcs/gcs.go
+++ b/pkg/chains/storage/gcs/gcs.go
@@ -187,17 +187,17 @@ func (b *Backend) retrieveObject(ctx context.Context, object string) (string, er
 }
 
 func sigName(tr *v1beta1.TaskRun, opts config.StorageOpts) string {
-	return fmt.Sprintf(SignatureNameFormat, tr.Namespace, tr.Name, opts.Key)
+	return fmt.Sprintf(SignatureNameFormat, tr.Namespace, tr.Name, opts.ShortKey)
 }
 
 func payloadName(tr *v1beta1.TaskRun, opts config.StorageOpts) string {
-	return fmt.Sprintf(PayloadNameFormat, tr.Namespace, tr.Name, opts.Key)
+	return fmt.Sprintf(PayloadNameFormat, tr.Namespace, tr.Name, opts.ShortKey)
 }
 
 func certName(tr *v1beta1.TaskRun, opts config.StorageOpts) string {
-	return fmt.Sprintf(CertNameFormat, tr.Namespace, tr.Name, opts.Key)
+	return fmt.Sprintf(CertNameFormat, tr.Namespace, tr.Name, opts.ShortKey)
 }
 
 func chainName(tr *v1beta1.TaskRun, opts config.StorageOpts) string {
-	return fmt.Sprintf(ChainNameFormat, tr.Namespace, tr.Name, opts.Key)
+	return fmt.Sprintf(ChainNameFormat, tr.Namespace, tr.Name, opts.ShortKey)
 }

--- a/pkg/chains/storage/gcs/gcs_test.go
+++ b/pkg/chains/storage/gcs/gcs_test.go
@@ -56,7 +56,7 @@ func TestBackend_StorePayload(t *testing.T) {
 				},
 				signed:    []byte("signed"),
 				signature: "signature",
-				opts:      config.StorageOpts{Key: "foo.uuid", PayloadFormat: formats.PayloadTypeInTotoIte6},
+				opts:      config.StorageOpts{ShortKey: "foo.uuid", PayloadFormat: formats.PayloadTypeInTotoIte6},
 			},
 		},
 		{
@@ -71,7 +71,7 @@ func TestBackend_StorePayload(t *testing.T) {
 				},
 				signed:    []byte("signed"),
 				signature: "signature",
-				opts:      config.StorageOpts{Key: "foo.uuid", PayloadFormat: formats.PayloadTypeTekton},
+				opts:      config.StorageOpts{ShortKey: "foo.uuid", PayloadFormat: formats.PayloadTypeTekton},
 			},
 		},
 	}

--- a/pkg/chains/storage/grafeas/grafeas.go
+++ b/pkg/chains/storage/grafeas/grafeas.go
@@ -245,8 +245,7 @@ func (b *Backend) createOccurrence(ctx context.Context, tr *v1beta1.TaskRun, pay
 
 	// create Occurrence_Attestation for OCI
 	if opts.PayloadFormat == formats.PayloadTypeSimpleSigning {
-		uri := b.retrieveSingleOCIURI(tr, opts)
-		occ, err := b.createAttestationOccurrence(ctx, tr, payload, signature, uri)
+		occ, err := b.createAttestationOccurrence(ctx, tr, payload, signature, opts.FullKey)
 		if err != nil {
 			return nil, err
 		}
@@ -393,23 +392,6 @@ func (b *Backend) findOccurrencesForCriteria(ctx context.Context, projectPath st
 		return nil, err
 	}
 	return occurences.GetOccurrences(), nil
-}
-
-// get resource uri for a single oci image in the format of `IMAGE_URL@IMAGE_DIGEST`
-func (b *Backend) retrieveSingleOCIURI(tr *v1beta1.TaskRun, opts config.StorageOpts) string {
-	imgs := b.retrieveAllArtifactIdentifiers(tr)
-	for _, img := range imgs {
-		// get digest part of the image representation
-		digest := strings.Split(img, "sha256:")[1]
-
-		// for oci image, the key in StorageOpts will be the first 12 chars of digest
-		// so we want to compare
-		digestKey := digest[:12]
-		if digestKey == opts.Key {
-			return img
-		}
-	}
-	return ""
 }
 
 // retrieve the uri of all images generated from a specific taskrun in the format of `IMAGE_URL@IMAGE_DIGEST`

--- a/pkg/chains/storage/grafeas/grafeas_test.go
+++ b/pkg/chains/storage/grafeas/grafeas_test.go
@@ -147,7 +147,7 @@ func TestGrafeasBackend_StoreAndRetrieve(t *testing.T) {
 				},
 				payload:   []byte("{}"),
 				signature: "taskrun signature",
-				opts:      config.StorageOpts{Key: "taskrun.uuid", PayloadFormat: formats.PayloadTypeInTotoIte6},
+				opts:      config.StorageOpts{FullKey: "tekton.dev-v1beta1-taskrun-uuid", PayloadFormat: formats.PayloadTypeInTotoIte6},
 			},
 			wantErr: false,
 		},
@@ -174,12 +174,7 @@ func TestGrafeasBackend_StoreAndRetrieve(t *testing.T) {
 				},
 				payload:   []byte("oci payload"),
 				signature: "oci signature",
-				// The Key field must be the same as the first 12 chars of the image digest.
-				// Reason:
-				// Inside chains.Sign function, we set the key field for both artifacts.
-				// For OCI artifact, it is implemented as the first 12 chars of the image digest.
-				// https://github.com/tektoncd/chains/blob/v0.8.0/pkg/artifacts/signable.go#L200
-				opts: config.StorageOpts{Key: "cfe4f0bf41c8", PayloadFormat: formats.PayloadTypeSimpleSigning},
+				opts:      config.StorageOpts{FullKey: "gcr.io/test/kaniko-chains1@sha256:cfe4f0bf41c80609214f9b8ec0408b1afb28b3ced343b944aaa05d47caba3e00", PayloadFormat: formats.PayloadTypeSimpleSigning},
 			},
 			wantErr: false,
 		},
@@ -193,7 +188,7 @@ func TestGrafeasBackend_StoreAndRetrieve(t *testing.T) {
 						UID:       types.UID("uid3"),
 					},
 				},
-				opts: config.StorageOpts{Key: "taskrun2.uuid", PayloadFormat: formats.PayloadTypeTekton},
+				opts: config.StorageOpts{FullKey: "tekton.dev-v1beta1-taskrun2-uuid", PayloadFormat: formats.PayloadTypeTekton},
 			},
 			wantErr: true,
 		},
@@ -251,8 +246,7 @@ func testStoreAndRetrieve(ctx context.Context, t *testing.T, test testConfig, ba
 	// ----------------
 	expectSignature := map[string][]string{}
 	if test.args.opts.PayloadFormat == formats.PayloadTypeSimpleSigning {
-		uri := backend.retrieveSingleOCIURI(test.args.tr, test.args.opts)
-		expectSignature[uri] = []string{test.args.signature}
+		expectSignature[test.args.opts.FullKey] = []string{test.args.signature}
 	}
 	if test.args.opts.PayloadFormat == formats.PayloadTypeInTotoIte6 {
 		allURIs := backend.retrieveAllArtifactIdentifiers(test.args.tr)
@@ -274,8 +268,7 @@ func testStoreAndRetrieve(ctx context.Context, t *testing.T, test testConfig, ba
 	// --------------
 	expectPayload := map[string]string{}
 	if test.args.opts.PayloadFormat == formats.PayloadTypeSimpleSigning {
-		uri := backend.retrieveSingleOCIURI(test.args.tr, test.args.opts)
-		expectPayload[uri] = string(test.args.payload)
+		expectPayload[test.args.opts.FullKey] = string(test.args.payload)
 	}
 	if test.args.opts.PayloadFormat == formats.PayloadTypeInTotoIte6 {
 		allURIs := backend.retrieveAllArtifactIdentifiers(test.args.tr)

--- a/pkg/chains/storage/tekton/tekton.go
+++ b/pkg/chains/storage/tekton/tekton.go
@@ -56,10 +56,10 @@ func (b *Backend) StorePayload(ctx context.Context, obj objects.TektonObject, ra
 	// Use patch instead of update to prevent race conditions.
 	patchBytes, err := patch.GetAnnotationsPatch(map[string]string{
 		// Base64 encode both the signature and the payload
-		fmt.Sprintf(PayloadAnnotationFormat, opts.Key):   base64.StdEncoding.EncodeToString(rawPayload),
-		fmt.Sprintf(SignatureAnnotationFormat, opts.Key): base64.StdEncoding.EncodeToString([]byte(signature)),
-		fmt.Sprintf(CertAnnotationsFormat, opts.Key):     base64.StdEncoding.EncodeToString([]byte(opts.Cert)),
-		fmt.Sprintf(ChainAnnotationFormat, opts.Key):     base64.StdEncoding.EncodeToString([]byte(opts.Chain)),
+		fmt.Sprintf(PayloadAnnotationFormat, opts.ShortKey):   base64.StdEncoding.EncodeToString(rawPayload),
+		fmt.Sprintf(SignatureAnnotationFormat, opts.ShortKey): base64.StdEncoding.EncodeToString([]byte(signature)),
+		fmt.Sprintf(CertAnnotationsFormat, opts.ShortKey):     base64.StdEncoding.EncodeToString([]byte(opts.Cert)),
+		fmt.Sprintf(ChainAnnotationFormat, opts.ShortKey):     base64.StdEncoding.EncodeToString([]byte(opts.Chain)),
 	})
 	if err != nil {
 		return err
@@ -131,9 +131,9 @@ func (b *Backend) RetrievePayloads(ctx context.Context, obj objects.TektonObject
 }
 
 func sigName(opts config.StorageOpts) string {
-	return fmt.Sprintf(SignatureAnnotationFormat, opts.Key)
+	return fmt.Sprintf(SignatureAnnotationFormat, opts.ShortKey)
 }
 
 func payloadName(opts config.StorageOpts) string {
-	return fmt.Sprintf(PayloadAnnotationFormat, opts.Key)
+	return fmt.Sprintf(PayloadAnnotationFormat, opts.ShortKey)
 }

--- a/pkg/chains/storage/tekton/tekton_test.go
+++ b/pkg/chains/storage/tekton/tekton_test.go
@@ -95,7 +95,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			if err != nil {
 				t.Errorf("error marshaling json: %v", err)
 			}
-			opts := config.StorageOpts{Key: "mockpayload"}
+			opts := config.StorageOpts{ShortKey: "mockpayload"}
 			mockSignature := "mocksignature"
 			if err := b.StorePayload(ctx, tt.object, payload, mockSignature, opts); (err != nil) != tt.wantErr {
 				t.Errorf("Backend.StorePayload() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -20,10 +20,16 @@ import "github.com/tektoncd/chains/pkg/chains/formats"
 
 // StorageOpts contains additional information required when storing signatures
 type StorageOpts struct {
-	// Key stands for the identifier of an artifact.
+	// FullKey stands for the identifier of an artifact.
+	// - For OCI artifact, it is the full representation in the format of `<NAME>@sha256:<DIGEST>`.
+	// - For TaskRun/PipelineRun artifact, it is `<GROUP>-<VERSION>-<KIND>-<UID>`
+	FullKey string
+
+	// ShortKey is the short version of an artifact identifier. This is useful for annotation based storage
+	// because annotation key has limitations (https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set).
 	// - For OCI artifact, it is first 12 chars of the image digest.
-	// - For TaskRun artifact, it is `taskrun-<UID>`
-	Key string
+	// - For TaskRun/PipelineRun artifact, it is `<KIND>-<UID>`.
+	ShortKey string
 
 	// Cert is an OPTIONAL property that contains a PEM-encoded x509 certificate.
 	// If present, this certificate MUST embed the public key that can be used to verify the signature.

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -247,7 +247,7 @@ func verifySignature(ctx context.Context, t *testing.T, c *clients, tr *v1beta1.
 
 		// Initialize the storage options.
 		opts := config.StorageOpts{
-			Key: fmt.Sprintf("taskrun-%s", tr.UID),
+			ShortKey: fmt.Sprintf("taskrun-%s", tr.UID),
 		}
 
 		trObj := objects.NewTaskRunObject(tr)


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Related to https://github.com/tektoncd/chains/issues/476

Prior, the StorageOpts key for OCI artifact was the first 12 characters of the digest.

Now, we set it to be the full representation of the OCI artifact in the format of 
`IMAGE_URL@IMAGE_DIGEST` so that storage backends can have the full 
access to the identifier of the OCI artifact directly.

Signed-off-by: Chuang Wang <chuangw@google.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
StorageOpts have the full access to the image identifier.
```
