### PR TITLE
Adding pipelinerun attestations to e2e tests

### DIFF
--- a/examples/pipelineruns/pipeline-output-image.yaml
+++ b/examples/pipelineruns/pipeline-output-image.yaml
@@ -1,0 +1,54 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: image-pipelinerun
+spec:
+  params:
+  - name: CHAINS-GIT_COMMIT
+    value: my-git-commit
+  - name: CHAINS-GIT_URL
+    value: https://my-git-url
+  pipelineSpec:
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.buildimage.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.buildimage.results.IMAGE_DIGEST)
+    tasks:
+    - name: buildimage
+      taskSpec:
+        results:
+        - name: IMAGE_URL
+          type: string
+        - name: IMAGE_DIGEST
+          type: string
+        steps:
+        - image: docker.io/library/bash:latest
+          name: create-dockerfile
+          resources: {}
+          script: |-
+            #!/usr/bin/env bash
+            echo 'gcr.io/foo/bar' | tee $(results.IMAGE_URL.path)
+            echo 'sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5' | tee $(results.IMAGE_DIGEST.path)
+          volumeMounts:
+          - mountPath: /dockerfile
+            name: dockerfile
+        volumes:
+        - emptyDir: {}
+          name: dockerfile

--- a/pkg/chains/annotations_test.go
+++ b/pkg/chains/annotations_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/tektoncd/chains/pkg/chains/objects"
-	"github.com/tektoncd/chains/pkg/internal/tekton"
+	"github.com/tektoncd/chains/pkg/test/tekton"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -119,9 +119,7 @@ func TestMarkSigned(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			c := fakepipelineclient.Get(ctx)
 
-			if err := tekton.CreateObject(t, ctx, c, tt.object); err != nil {
-				t.Fatal(err)
-			}
+			tekton.CreateObject(t, ctx, c, tt.object)
 
 			// Now mark it as signed.
 			if err := MarkSigned(ctx, tt.object, c, nil); err != nil {
@@ -202,9 +200,7 @@ func TestMarkFailed(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			// Create a TR for testing
 			c := fakepipelineclient.Get(ctx)
-			if err := tekton.CreateObject(t, ctx, c, tt.object); err != nil {
-				t.Fatal(err)
-			}
+			tekton.CreateObject(t, ctx, c, tt.object)
 
 			// Test HandleRetry, should mark it as failed
 			if err := HandleRetry(ctx, tt.object, c, nil); err != nil {
@@ -302,9 +298,7 @@ func TestAddRetry(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			c := fakepipelineclient.Get(ctx)
 
-			if err := tekton.CreateObject(t, ctx, c, tt.object); err != nil {
-				t.Fatal(err)
-			}
+			tekton.CreateObject(t, ctx, c, tt.object)
 
 			// run it through AddRetry, make sure annotation is added
 			if err := AddRetry(ctx, tt.object, c, nil); err != nil {

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/signing"
 	"github.com/tektoncd/chains/pkg/chains/storage"
 	"github.com/tektoncd/chains/pkg/config"
-	"github.com/tektoncd/chains/pkg/internal/tekton"
+	"github.com/tektoncd/chains/pkg/test/tekton"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	"go.uber.org/zap"
@@ -152,9 +152,8 @@ func TestSigner_Sign(t *testing.T) {
 				Pipelineclientset: ps,
 			}
 
-			if err := tekton.CreateObject(t, ctx, ps, tt.object); err != nil {
-				t.Errorf("error creating fake object: %v", err)
-			}
+			tekton.CreateObject(t, ctx, ps, tt.object)
+
 			if err := ts.Sign(ctx, tt.object); (err != nil) != tt.wantErr {
 				t.Errorf("Signer.Sign() error = %v", err)
 			}
@@ -312,9 +311,9 @@ func TestSigner_Transparency(t *testing.T) {
 			}
 
 			obj := tt.getNewObject("foo")
-			if err := tekton.CreateObject(t, ctx, ps, obj); err != nil {
-				t.Errorf("error creating fake object: %v", err)
-			}
+
+			tekton.CreateObject(t, ctx, ps, obj)
+
 			if err := os.Sign(ctx, obj); err != nil {
 				t.Errorf("Signer.Sign() error = %v", err)
 			}
@@ -328,9 +327,9 @@ func TestSigner_Transparency(t *testing.T) {
 			ctx = config.ToContext(ctx, tt.cfg.DeepCopy())
 
 			obj = tt.getNewObject("foobar")
-			if err := tekton.CreateObject(t, ctx, ps, obj); err != nil {
-				t.Errorf("error creating fake object: %v", err)
-			}
+
+			tekton.CreateObject(t, ctx, ps, obj)
+
 			if err := os.Sign(ctx, obj); err != nil {
 				t.Errorf("Signer.Sign() error = %v", err)
 			}
@@ -344,9 +343,9 @@ func TestSigner_Transparency(t *testing.T) {
 			ctx = config.ToContext(ctx, tt.cfg.DeepCopy())
 
 			obj = tt.getNewObject("mytektonobject")
-			if err := tekton.CreateObject(t, ctx, ps, obj); err != nil {
-				t.Errorf("error creating fake object: %v", err)
-			}
+
+			tekton.CreateObject(t, ctx, ps, obj)
+
 			if err := os.Sign(ctx, obj); err != nil {
 				t.Errorf("Signer.Sign() error = %v", err)
 			}

--- a/pkg/chains/storage/tekton/tekton_test.go
+++ b/pkg/chains/storage/tekton/tekton_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
-	"github.com/tektoncd/chains/pkg/internal/tekton"
+	"github.com/tektoncd/chains/pkg/test/tekton"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,9 +83,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			c := fakepipelineclient.Get(ctx)
 
-			if err := tekton.CreateObject(t, ctx, c, tt.object); err != nil {
-				t.Errorf("error setting up fake taskrun: %v", err)
-			}
+			tekton.CreateObject(t, ctx, c, tt.object)
 
 			b := &Backend{
 				pipelineclientset: c,

--- a/test/testdata/intoto/pipeline-output-image.json
+++ b/test/testdata/intoto/pipeline-output-image.json
@@ -1,0 +1,81 @@
+{
+    "_type": "https://in-toto.io/Statement/v0.1",
+    "predicateType": "https://slsa.dev/provenance/v0.2",
+    "subject": [
+        {
+            "name": "gcr.io/foo/bar",
+            "digest": {
+                "sha256": "05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"
+            }
+        }
+    ],
+    "predicate": {
+        "builder": {
+            "id": "https://tekton.dev/chains/v2"
+        },
+        "buildType": "tekton.dev/v1beta1/PipelineRun",
+        "invocation": {
+            "configSource": {},
+            "parameters": {
+                "CHAINS-GIT_COMMIT": "my-git-commit",
+                "CHAINS-GIT_URL": "https://my-git-url"
+            }
+        },
+        "buildConfig": {
+            "tasks": [
+                {
+                    "name": "buildimage",
+                    "ref": {},
+                    "startedOn": "{{index .BuildStartTimes 0}}",
+                    "finishedOn": "{{index .BuildFinishedTimes 0}}",
+                    "status": "Succeeded",
+                    "steps": [
+                        {
+                            "entryPoint": "#!/usr/bin/env bash\necho 'gcr.io/foo/bar' | tee /tekton/results/IMAGE_URL\necho 'sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5' | tee /tekton/results/IMAGE_DIGEST",
+                            "arguments": null,
+                            "environment": {
+                                "container": "create-dockerfile",
+                                "image": "docker-pullable://bash@sha256:0ba55510cdffa76de0d3d8149a3fa7cb62d9725d1a606fc234d18778e7807ac3"
+                            },
+                            "annotations": null
+                        }
+                    ],
+                    "invocation": {
+                        "configSource": {},
+                        "parameters": {}
+                    },
+                    "results": [
+                        {
+                            "name": "IMAGE_DIGEST",
+                            "type": "string",
+                            "value": "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5\n"
+                        },
+                        {
+                            "name": "IMAGE_URL",
+                            "type": "string",
+                            "value": "gcr.io/foo/bar\n"
+                        }
+                    ]
+                }
+            ]
+        },
+        "metadata": {
+            "buildStartedOn": "{{.PipelineStartedOn}}",
+            "buildFinishedOn": "{{.PipelineFinishedOn}}",
+            "completeness": {
+                "parameters": false,
+                "environment": false,
+                "materials": false
+            },
+            "reproducible": false
+        },
+        "materials": [
+            {
+                "uri": "git+https://my-git-url.git",
+                "digest": {
+                    "sha1": "my-git-commit"
+                }
+            }
+        ]
+    }
+}

--- a/test/testdata/intoto/task-output-image.json
+++ b/test/testdata/intoto/task-output-image.json
@@ -68,8 +68,8 @@
             ]
         },
         "metadata": {
-            "buildStartedOn": "{{.BuildStartedOn}}",
-            "buildFinishedOn": "{{.BuildFinishedOn}}",
+            "buildStartedOn": "{{index .BuildStartTimes 0}}",
+            "buildFinishedOn": "{{index .BuildFinishedTimes 0}}",
             "completeness": {
                 "parameters": false,
                 "environment": false,


### PR DESCRIPTION
# Changes

Making the following changes:
- Refactor e2e tests to use the generic Tekton Objects
- Add test cases for `PipelineRun`'s in e2e tests

Fixes #562

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

Support for `PipelineRun` attestations in the e2e tests.
