### PR TITLE
Generalize format loading.

### DIFF
--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/opencontainers/go-digest"
-	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -38,7 +37,7 @@ type Signable interface {
 	ExtractObjects(obj objects.TektonObject) []interface{}
 	StorageBackend(cfg config.Config) sets.String
 	Signer(cfg config.Config) string
-	PayloadFormat(cfg config.Config) formats.PayloadType
+	PayloadFormat(cfg config.Config) config.PayloadType
 	// FullKey returns the full identifier for a signable artifact.
 	// - For OCI artifact, it is the full representation in the format of `<NAME>@sha256:<DIGEST>`.
 	// - For TaskRun/PipelineRun artifact, it is `<GROUP>-<VERSION>-<KIND>-<UID>`
@@ -80,8 +79,8 @@ func (ta *TaskRunArtifact) StorageBackend(cfg config.Config) sets.String {
 	return cfg.Artifacts.TaskRuns.StorageBackend
 }
 
-func (ta *TaskRunArtifact) PayloadFormat(cfg config.Config) formats.PayloadType {
-	return formats.PayloadType(cfg.Artifacts.TaskRuns.Format)
+func (ta *TaskRunArtifact) PayloadFormat(cfg config.Config) config.PayloadType {
+	return config.PayloadType(cfg.Artifacts.TaskRuns.Format)
 }
 
 func (ta *TaskRunArtifact) Signer(cfg config.Config) string {
@@ -122,8 +121,8 @@ func (pa *PipelineRunArtifact) StorageBackend(cfg config.Config) sets.String {
 	return cfg.Artifacts.PipelineRuns.StorageBackend
 }
 
-func (pa *PipelineRunArtifact) PayloadFormat(cfg config.Config) formats.PayloadType {
-	return formats.PayloadType(cfg.Artifacts.PipelineRuns.Format)
+func (pa *PipelineRunArtifact) PayloadFormat(cfg config.Config) config.PayloadType {
+	return config.PayloadType(cfg.Artifacts.PipelineRuns.Format)
 }
 
 func (pa *PipelineRunArtifact) Signer(cfg config.Config) string {
@@ -392,8 +391,8 @@ func (oa *OCIArtifact) StorageBackend(cfg config.Config) sets.String {
 	return cfg.Artifacts.OCI.StorageBackend
 }
 
-func (oa *OCIArtifact) PayloadFormat(cfg config.Config) formats.PayloadType {
-	return formats.PayloadType(cfg.Artifacts.OCI.Format)
+func (oa *OCIArtifact) PayloadFormat(cfg config.Config) config.PayloadType {
+	return config.PayloadType(cfg.Artifacts.OCI.Format)
 }
 
 func (oa *OCIArtifact) Signer(cfg config.Config) string {

--- a/pkg/chains/formats/all/all.go
+++ b/pkg/chains/formats/all/all.go
@@ -1,0 +1,21 @@
+// Copyright 2022 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package all
+
+import (
+	_ "github.com/tektoncd/chains/pkg/chains/formats/intotoite6"
+	_ "github.com/tektoncd/chains/pkg/chains/formats/simple"
+	_ "github.com/tektoncd/chains/pkg/chains/formats/tekton"
+)

--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -39,6 +39,8 @@ var e1BuildStart = time.Unix(1617011400, 0)
 var e1BuildFinished = time.Unix(1617011415, 0)
 
 func TestTaskRunCreatePayload1(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+
 	tr, err := objectloader.TaskRunFromFile("testdata/taskrun1.json")
 	if err != nil {
 		t.Fatal(err)
@@ -113,9 +115,9 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 			},
 		},
 	}
-	i, _ := NewFormatter(cfg, logtesting.TestLogger(t))
+	i, _ := NewFormatter(cfg)
 
-	got, err := i.CreatePayload(objects.NewTaskRunObject(tr))
+	got, err := i.CreatePayload(ctx, objects.NewTaskRunObject(tr))
 
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
@@ -126,6 +128,7 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 }
 
 func TestPipelineRunCreatePayload(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
 	pr, err := objectloader.PipelineRunFromFile("testdata/pipelinerun1.json")
 	if err != nil {
 		t.Fatal(err)
@@ -316,9 +319,9 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 	pro.AppendTaskRun(tr1)
 	pro.AppendTaskRun(tr2)
 
-	i, _ := NewFormatter(cfg, logtesting.TestLogger(t))
+	i, _ := NewFormatter(cfg)
 
-	got, err := i.CreatePayload(pro)
+	got, err := i.CreatePayload(ctx, pro)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
@@ -327,6 +330,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 	}
 }
 func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
 	pr, err := objectloader.PipelineRunFromFile("testdata/pipelinerun-childrefs.json")
 	if err != nil {
 		t.Fatal(err)
@@ -512,8 +516,8 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 	pro.AppendTaskRun(tr1)
 	pro.AppendTaskRun(tr2)
 
-	i, _ := NewFormatter(cfg, logtesting.TestLogger(t))
-	got, err := i.CreatePayload(pro)
+	i, _ := NewFormatter(cfg)
+	got, err := i.CreatePayload(ctx, pro)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
@@ -523,6 +527,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 }
 
 func TestTaskRunCreatePayload2(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
 	tr, err := objectloader.TaskRunFromFile("testdata/taskrun2.json")
 	if err != nil {
 		t.Fatal(err)
@@ -578,8 +583,8 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 			},
 		},
 	}
-	i, _ := NewFormatter(cfg, logtesting.TestLogger(t))
-	got, err := i.CreatePayload(objects.NewTaskRunObject(tr))
+	i, _ := NewFormatter(cfg)
+	got, err := i.CreatePayload(ctx, objects.NewTaskRunObject(tr))
 
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
@@ -590,6 +595,8 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 }
 
 func TestMultipleSubjects(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+
 	tr, err := objectloader.TaskRunFromFile("testdata/taskrun-multiple-subjects.json")
 	if err != nil {
 		t.Fatal(err)
@@ -641,8 +648,8 @@ func TestMultipleSubjects(t *testing.T) {
 		},
 	}
 
-	i, _ := NewFormatter(cfg, logtesting.TestLogger(t))
-	got, err := i.CreatePayload(objects.NewTaskRunObject(tr))
+	i, _ := NewFormatter(cfg)
+	got, err := i.CreatePayload(ctx, objects.NewTaskRunObject(tr))
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
@@ -658,7 +665,7 @@ func TestNewFormatter(t *testing.T) {
 				ID: "testid",
 			},
 		}
-		f, err := NewFormatter(cfg, logtesting.TestLogger(t))
+		f, err := NewFormatter(cfg)
 		if f == nil {
 			t.Error("Failed to create formatter")
 		}
@@ -669,15 +676,17 @@ func TestNewFormatter(t *testing.T) {
 }
 
 func TestCreatePayloadError(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+
 	cfg := config.Config{
 		Builder: config.BuilderConfig{
 			ID: "testid",
 		},
 	}
-	f, _ := NewFormatter(cfg, logtesting.TestLogger(t))
+	f, _ := NewFormatter(cfg)
 
 	t.Run("Invalid type", func(t *testing.T) {
-		p, err := f.CreatePayload("not a task ref")
+		p, err := f.CreatePayload(ctx, "not a task ref")
 
 		if p != nil {
 			t.Errorf("Unexpected payload")

--- a/pkg/chains/formats/simple/simple.go
+++ b/pkg/chains/formats/simple/simple.go
@@ -14,23 +14,32 @@ limitations under the License.
 package simple
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/config"
 
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
+const (
+	PayloadTypeSimpleSigning = formats.PayloadTypeSimpleSigning
+)
+
+func init() {
+	formats.RegisterPayloader(PayloadTypeSimpleSigning, NewFormatter)
+}
+
 // SimpleSigning is a formatter that uses the RedHat simple signing format
 // https://www.redhat.com/en/blog/container-image-signing
-type SimpleSigning struct {
-}
+type SimpleSigning struct{}
 
 type SimpleContainerImage payload.SimpleContainerImage
 
 // CreatePayload implements the Payloader interface.
-func (i *SimpleSigning) CreatePayload(obj interface{}) (interface{}, error) {
+func (i *SimpleSigning) CreatePayload(ctx context.Context, obj interface{}) (interface{}, error) {
 	switch v := obj.(type) {
 	case name.Digest:
 		format := NewSimpleStruct(v)
@@ -44,7 +53,7 @@ func (i *SimpleSigning) Wrap() bool {
 	return false
 }
 
-func NewFormatter() (formats.Payloader, error) {
+func NewFormatter(config.Config) (formats.Payloader, error) {
 	return &SimpleSigning{}, nil
 }
 
@@ -57,6 +66,6 @@ func (i SimpleContainerImage) ImageName() string {
 	return fmt.Sprintf("%s@%s", i.Critical.Identity.DockerReference, i.Critical.Image.DockerManifestDigest)
 }
 
-func (i *SimpleSigning) Type() formats.PayloadType {
+func (i *SimpleSigning) Type() config.PayloadType {
 	return formats.PayloadTypeSimpleSigning
 }

--- a/pkg/chains/formats/simple/simple_test.go
+++ b/pkg/chains/formats/simple/simple_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package simple
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -61,7 +62,7 @@ func TestSimpleSigning_CreatePayload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &SimpleSigning{}
-			got, err := i.CreatePayload(tt.obj)
+			got, err := i.CreatePayload(context.Background(), tt.obj)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SimpleSigning.CreatePayload() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -81,7 +82,7 @@ func TestImageName(t *testing.T) {
 	obj := makeDigest(t, img)
 
 	i := &SimpleSigning{}
-	format, err := i.CreatePayload(obj)
+	format, err := i.CreatePayload(context.Background(), obj)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chains/formats/tekton/tekton.go
+++ b/pkg/chains/formats/tekton/tekton.go
@@ -14,22 +14,32 @@ limitations under the License.
 package tekton
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/chains/pkg/config"
 )
+
+const (
+	PayloadTypeTekton = formats.PayloadTypeTekton
+)
+
+func init() {
+	formats.RegisterPayloader(PayloadTypeTekton, NewFormatter)
+}
 
 // Tekton is a formatter that just captures the TaskRun Status with no modifications.
 type Tekton struct {
 }
 
-func NewFormatter() (formats.Payloader, error) {
+func NewFormatter(config.Config) (formats.Payloader, error) {
 	return &Tekton{}, nil
 }
 
 // CreatePayload implements the Payloader interface.
-func (i *Tekton) CreatePayload(obj interface{}) (interface{}, error) {
+func (i *Tekton) CreatePayload(ctx context.Context, obj interface{}) (interface{}, error) {
 	switch v := obj.(type) {
 	case *objects.TaskRunObject:
 		return v.Status, nil
@@ -40,7 +50,7 @@ func (i *Tekton) CreatePayload(obj interface{}) (interface{}, error) {
 	}
 }
 
-func (i *Tekton) Type() formats.PayloadType {
+func (i *Tekton) Type() config.PayloadType {
 	return formats.PayloadTypeTekton
 }
 

--- a/pkg/chains/formats/tekton/tekton_test.go
+++ b/pkg/chains/formats/tekton/tekton_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package tekton
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestTekton_CreatePayload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &Tekton{}
-			got, err := i.CreatePayload(objects.NewTaskRunObject(tt.tr))
+			got, err := i.CreatePayload(context.Background(), objects.NewTaskRunObject(tt.tr))
 			if err != nil {
 				t.Errorf("Tekton.CreatePayload() error = %v", err)
 				return

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/logging"
 	rtesting "knative.dev/pkg/reconciler/testing"
+
+	_ "github.com/tektoncd/chains/pkg/chains/formats/all"
 )
 
 func TestSigner_Sign(t *testing.T) {
@@ -144,9 +146,7 @@ func TestSigner_Sign(t *testing.T) {
 
 			ctx = config.ToContext(ctx, tt.config.DeepCopy())
 
-			logger := logging.FromContext(ctx)
 			ts := &ObjectSigner{
-				Formatters:        AllFormatters(*tt.config, logger),
 				Backends:          fakeAllBackends(tt.backends),
 				SecretPath:        "./signing/x509/testdata/",
 				Pipelineclientset: ps,
@@ -302,9 +302,7 @@ func TestSigner_Transparency(t *testing.T) {
 
 			ctx = config.ToContext(ctx, tt.cfg.DeepCopy())
 
-			logger := logging.FromContext(ctx)
 			os := &ObjectSigner{
-				Formatters:        AllFormatters(*tt.cfg, logger),
 				Backends:          fakeAllBackends(backends),
 				SecretPath:        "./signing/x509/testdata/",
 				Pipelineclientset: ps,

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package config
 
-import "github.com/tektoncd/chains/pkg/chains/formats"
+// PayloadType specifies the format to store payload in.
+// - For OCI artifact, Chains only supports `simplesigning` format. https://www.redhat.com/en/blog/container-image-signing
+// - For Tekton artifacts, Chains supports `tekton` and `in-toto` format. https://slsa.dev/provenance/v0.2
+type PayloadType string
 
 // StorageOpts contains additional information required when storing signatures
 type StorageOpts struct {
@@ -43,7 +46,5 @@ type StorageOpts struct {
 	Chain string
 
 	// PayloadFormat is the format to store payload in.
-	// - For OCI artifact, Chains only supports `simplesigning` format. https://www.redhat.com/en/blog/container-image-signing
-	// - For TaskRun artifact, Chains supports `tekton` and `in-toto` format. https://slsa.dev/provenance/v0.2
-	PayloadFormat formats.PayloadType
+	PayloadFormat PayloadType
 }

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -54,9 +54,6 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 			// get updated config
 			cfg := *value.(*config.Config)
 
-			// get all formatters for formatting payload
-			psSigner.Formatters = chains.AllFormatters(cfg, logger)
-
 			// get all backends for storing provenance
 			backends, err := storage.InitializeBackends(ctx, pipelineClient, kubeClient, logger, cfg)
 			if err != nil {

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -29,6 +29,8 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+
+	_ "github.com/tektoncd/chains/pkg/chains/formats/all"
 )
 
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -26,6 +26,8 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+
+	_ "github.com/tektoncd/chains/pkg/chains/formats/all"
 )
 
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -48,9 +48,6 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 			// get updated config
 			cfg := *value.(*config.Config)
 
-			// get all formatters for formatting payload
-			tsSigner.Formatters = chains.AllFormatters(cfg, logger)
-
 			// get all backends for storing provenance
 			backends, err := storage.InitializeBackends(ctx, pipelineClient, kubeClient, logger, cfg)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Billy Lynch <billy@chainguard.dev>

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

This refactors how formatters are initialized and configured to be more uniform. This allows for formatter providers to be more easily slotted in / configured without needing to make modifications for downstream signers. The ultimate goal for this change is to allow for "type aliasing" of formatters, where the same formatter may be referenced by different names to allow for supporting new formats in a backwards compatible way (i.e. letting slsa be an alias for intoto or slsa0.2, etc.)

This follows a similar pattern to sigstore KMS providers - https://github.com/sigstore/sigstore/tree/main/pkg/signature/kms

As part of this change, the way to initialize a formatter is standardized. To support this, the intoto logger that was previously configured during initialization is now taken from the context.

Part of #597 

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
BREAKING CHANGES: (client library only)
- formats.PayloadType is now defined in config rather than formats. The semantics behind this value are still the same.
- CreatePayload now takes in a context.
- InTotoIte6.NewFormatter no longer takes in a logger.
- formats.AllFormatters is removed. Use formats.GetPayloader instead.
```
