### PR TITLE
Stop reconciliation on unrecoverable error

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -241,6 +241,35 @@ func TestReconciler_handlePipelineRun(t *testing.T) {
 			shouldSign: false,
 			wantErr:    true,
 		},
+		{
+			name: "missing taskrun",
+			pr: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "pipelinerun",
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1beta1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					},
+					PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+						TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+							"taskrun1": {
+								PipelineTaskName: "task1",
+								Status: &v1beta1.TaskRunStatus{
+									TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+										CompletionTime: &metav1.Time{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldSign: false,
+			wantErr:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes: #602

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

When reconciling a PipelineRun, if one of the TaskRuns is not found, do not retry reconciling the resource later.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
