### PR TITLE
Use cos_containerd image for e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.1.1
 	github.com/stretchr/testify v1.8.0
 	github.com/tektoncd/pipeline v0.40.1
-	github.com/tektoncd/plumbing v0.0.0-20220817140952-3da8ce01aeeb
+	github.com/tektoncd/plumbing v0.0.0-20221102182345-5dbcfda657d7
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399
 	go.uber.org/atomic v1.10.0
 	go.uber.org/zap v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -2159,8 +2159,8 @@ github.com/tdakkota/asciicheck v0.1.1 h1:PKzG7JUTUmVspQTDqtkX9eSiLGossXTybutHwTX
 github.com/tdakkota/asciicheck v0.1.1/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tektoncd/pipeline v0.40.1 h1:O8Y3pZLa5JLe4WpPZSQcLG+KTd1fTplNPVQDu7+5tOI=
 github.com/tektoncd/pipeline v0.40.1/go.mod h1:DqabXb6NBN/CMMZn20UXiGkdHEgMfRDvh2r6g/YEQ50=
-github.com/tektoncd/plumbing v0.0.0-20220817140952-3da8ce01aeeb h1:LUUCR8pLF+MzdQ7kOQQrMzDahIPZLdPCzfnNow1Um3Y=
-github.com/tektoncd/plumbing v0.0.0-20220817140952-3da8ce01aeeb/go.mod h1:uJBaI0AL/kjPThiMYZcWRujEz7D401v643d6s/21GAg=
+github.com/tektoncd/plumbing v0.0.0-20221102182345-5dbcfda657d7 h1:YsjQ83UBIIq4k/s2PzQ6pqe4tpPtm1hia3oyNBDDrDU=
+github.com/tektoncd/plumbing v0.0.0-20221102182345-5dbcfda657d7/go.mod h1:uJBaI0AL/kjPThiMYZcWRujEz7D401v643d6s/21GAg=
 github.com/tenntenn/modver v1.0.1 h1:2klLppGhDgzJrScMpkj9Ujy3rXPUspSjAcev9tSEBgA=
 github.com/tenntenn/modver v1.0.1/go.mod h1:bePIyQPb7UeioSRkw3Q0XeMhYZSMx9B8ePqg6SAMGH0=
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpRQGxTSkNYKJ51yaw6ChIqO+Je8UqsTKN/cDag=

--- a/test/testdata/intoto/pipeline-output-image.json
+++ b/test/testdata/intoto/pipeline-output-image.json
@@ -35,7 +35,7 @@
                             "arguments": null,
                             "environment": {
                                 "container": "create-dockerfile",
-                                "image": "docker-pullable://distroless.dev/busybox@sha256:186312fcf3f381b5fc1dd80b1afc0d316f3ed39fb4add8ff900d1f0c7c49a92c"
+                                "image": "distroless.dev/busybox@sha256:186312fcf3f381b5fc1dd80b1afc0d316f3ed39fb4add8ff900d1f0c7c49a92c"
                             },
                             "annotations": null
                         }

--- a/vendor/github.com/tektoncd/plumbing/.gitignore
+++ b/vendor/github.com/tektoncd/plumbing/.gitignore
@@ -10,3 +10,5 @@
 
 # Virtualenv files
 .venv
+
+**/.bin

--- a/vendor/github.com/tektoncd/plumbing/scripts/library.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/library.sh
@@ -20,7 +20,7 @@
 
 # Default GKE version to be used with Tekton Serving
 readonly SERVING_GKE_VERSION=gke-channel-regular
-readonly SERVING_GKE_IMAGE=cos
+readonly SERVING_GKE_IMAGE=cos_containerd
 
 # Conveniently set GOPATH if unset
 if [[ -z "${GOPATH:-}" ]]; then

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1751,7 +1751,7 @@ github.com/tektoncd/pipeline/pkg/resolution/common
 github.com/tektoncd/pipeline/pkg/resolution/resource
 github.com/tektoncd/pipeline/pkg/substitution
 github.com/tektoncd/pipeline/test
-# github.com/tektoncd/plumbing v0.0.0-20220817140952-3da8ce01aeeb
+# github.com/tektoncd/plumbing v0.0.0-20221102182345-5dbcfda657d7
 ## explicit; go 1.13
 github.com/tektoncd/plumbing
 github.com/tektoncd/plumbing/scripts


### PR DESCRIPTION


Signed-off-by: Luiz Carvalho <lucarval@redhat.com>

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Use cos_containerd image for e2e tests.
The cos image is no longer supported:
https://cloud.google.com/kubernetes-engine/docs/concepts/node-images

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
