### PR TITLE
Bump e2e tests to Pipelines 0.41, add k8s 1.25.

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -17,12 +17,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.22.x
         - v1.23.x
         - v1.24.x
-        # Can not test with v.25.x yet due to PSP
-        # resource mapping not found for name: "tekton-pipelines" namespace: "" from "https://storage.googleapis.com/tekton-releases-nightly/pipeline/latest/release.yaml": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
-        #- v1.25.x
+        - v1.25.x
 
     env:
       GOPATH: ${{ github.workspace }}
@@ -31,7 +28,7 @@ jobs:
       KO_DOCKER_REPO: registry.local:5000/knative
       KOCACHE: ~/ko
       SIGSTORE_SCAFFOLDING_RELEASE_VERSION: "v0.4.8"
-      TEKTON_PIPELINES_RELEASE: "https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.40.0/release.yaml"
+      TEKTON_PIPELINES_RELEASE: "https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.41.0/release.yaml"
 
     steps:
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,7 +28,7 @@ header "Setting up environment"
 # Test against nightly instead of latest.
 install_tkn
 
-export RELEASE_YAML="https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.40.0/release.yaml"
+export RELEASE_YAML="https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.41.0/release.yaml"
 install_pipeline_crd
 
 install_chains


### PR DESCRIPTION


<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

We previously were not able to run 1.25 due to a bug in Pipelines not supporting new PodSecurity admission. This was fixed in 0.41.

Removes 1.22 since it is EOL as of 2022-10-28 - https://kubernetes.io/releases/#release-v1-22

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
