### PR TITLE
Remove `predicate.buildConfig.tasks[i].ref` field

### DIFF
--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -172,12 +172,8 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 			BuildConfig: pipelinerun.BuildConfig{
 				Tasks: []pipelinerun.TaskAttestation{
 					{
-						Name:  "git-clone",
-						After: nil,
-						Ref: v1beta1.TaskRef{
-							Name: "git-clone",
-							Kind: "ClusterTask",
-						},
+						Name:       "git-clone",
+						After:      nil,
 						StartedOn:  e1BuildStart,
 						FinishedOn: e1BuildFinished,
 						Status:     "Succeeded",
@@ -219,12 +215,8 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 						},
 					},
 					{
-						Name:  "build",
-						After: []string{"git-clone"},
-						Ref: v1beta1.TaskRef{
-							Name: "build",
-							Kind: "ClusterTask",
-						},
+						Name:       "build",
+						After:      []string{"git-clone"},
 						StartedOn:  e1BuildStart,
 						FinishedOn: e1BuildFinished,
 						Status:     "Succeeded",
@@ -360,12 +352,8 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 			BuildConfig: pipelinerun.BuildConfig{
 				Tasks: []pipelinerun.TaskAttestation{
 					{
-						Name:  "git-clone",
-						After: nil,
-						Ref: v1beta1.TaskRef{
-							Name: "git-clone",
-							Kind: "ClusterTask",
-						},
+						Name:       "git-clone",
+						After:      nil,
 						StartedOn:  e1BuildStart,
 						FinishedOn: e1BuildFinished,
 						Status:     "Succeeded",
@@ -407,12 +395,8 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 						},
 					},
 					{
-						Name:  "build",
-						After: []string{"git-clone"},
-						Ref: v1beta1.TaskRef{
-							Name: "build",
-							Kind: "ClusterTask",
-						},
+						Name:       "build",
+						After:      []string{"git-clone"},
 						StartedOn:  e1BuildStart,
 						FinishedOn: e1BuildFinished,
 						Status:     "Succeeded",

--- a/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
@@ -140,10 +140,6 @@ func buildConfig(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) Buil
 			Results:    tr.Status.TaskRunResults,
 		}
 
-		if t.TaskRef != nil {
-			task.Ref = *t.TaskRef
-		}
-
 		tasks = append(tasks, task)
 		if i < len(pSpec.Tasks) {
 			last = task.Name

--- a/pkg/chains/formats/intotoite6/pipelinerun/provenance_test.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/provenance_test.go
@@ -76,12 +76,8 @@ func TestBuildConfig(t *testing.T) {
 	expected := BuildConfig{
 		Tasks: []TaskAttestation{
 			{
-				Name:  "git-clone",
-				After: nil,
-				Ref: v1beta1.TaskRef{
-					Name: "git-clone",
-					Kind: "ClusterTask",
-				},
+				Name:       "git-clone",
+				After:      nil,
 				StartedOn:  e1BuildStart,
 				FinishedOn: e1BuildFinished,
 				Status:     "Succeeded",
@@ -123,12 +119,8 @@ func TestBuildConfig(t *testing.T) {
 				},
 			},
 			{
-				Name:  "build",
-				After: []string{"git-clone"},
-				Ref: v1beta1.TaskRef{
-					Name: "build",
-					Kind: "ClusterTask",
-				},
+				Name:       "build",
+				After:      []string{"git-clone"},
 				StartedOn:  e1BuildStart,
 				FinishedOn: e1BuildFinished,
 				Status:     "Succeeded",
@@ -252,12 +244,8 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 			expected := BuildConfig{
 				Tasks: []TaskAttestation{
 					{
-						Name:  "git-clone",
-						After: nil,
-						Ref: v1beta1.TaskRef{
-							Name: "git-clone",
-							Kind: "ClusterTask",
-						},
+						Name:       "git-clone",
+						After:      nil,
 						StartedOn:  e1BuildStart,
 						FinishedOn: e1BuildFinished,
 						Status:     "Succeeded",
@@ -299,12 +287,8 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 						},
 					},
 					{
-						Name:  "build",
-						After: []string{"git-clone"},
-						Ref: v1beta1.TaskRef{
-							Name: "build",
-							Kind: "ClusterTask",
-						},
+						Name:       "build",
+						After:      []string{"git-clone"},
 						StartedOn:  e1BuildStart,
 						FinishedOn: e1BuildFinished,
 						Status:     "Succeeded",


### PR DESCRIPTION


<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Related to https://github.com/tektoncd/chains/pull/436#discussion_r973143588.

Prior, pipeline level provenance had a `ref` field in the `predicate.buildConfig.tasks[i]` section.

In this commit, we remove this `ref` field from buildConfig in favor of `buildConfig.tasks[i].invocation.configSource` https://github.com/tektoncd/chains/pull/554 because configsource should be enough to record the source information that we need to track the origin of the remote definitions.

Since `predicate.buildConfig` is pretty much free text, this deletion shouldn't introduce backward incompatible changes.

Signed-off-by: Chuang Wang <chuangw@google.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Remove the `ref` field from free text field `predicate.buildConfig.tasks[i]` in the Pipeline level provenance
```
