### PR TITLE
Convert times to UTC

### DIFF
--- a/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
@@ -132,8 +132,8 @@ func buildConfig(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) Buil
 		task := TaskAttestation{
 			Name:       t.Name,
 			After:      after,
-			StartedOn:  tr.Status.StartTime.Time,
-			FinishedOn: tr.Status.CompletionTime.Time,
+			StartedOn:  tr.Status.StartTime.Time.UTC(),
+			FinishedOn: tr.Status.CompletionTime.Time.UTC(),
 			Status:     getStatus(tr.Status.Conditions),
 			Steps:      steps,
 			Invocation: attest.Invocation(params, paramSpecs),
@@ -155,10 +155,12 @@ func buildConfig(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) Buil
 func metadata(pro *objects.PipelineRunObject) *slsa.ProvenanceMetadata {
 	m := &slsa.ProvenanceMetadata{}
 	if pro.Status.StartTime != nil {
-		m.BuildStartedOn = &pro.Status.StartTime.Time
+		utc := pro.Status.StartTime.Time.UTC()
+		m.BuildStartedOn = &utc
 	}
 	if pro.Status.CompletionTime != nil {
-		m.BuildFinishedOn = &pro.Status.CompletionTime.Time
+		utc := pro.Status.CompletionTime.Time.UTC()
+		m.BuildFinishedOn = &utc
 	}
 	for label, value := range pro.Labels {
 		if label == attest.ChainsReproducibleAnnotation && value == "true" {

--- a/pkg/chains/formats/intotoite6/pipelinerun/provenance_test.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/provenance_test.go
@@ -404,6 +404,28 @@ func TestMetadata(t *testing.T) {
 	}
 }
 
+func TestMetadataInTimeZone(t *testing.T) {
+	expected := &slsa.ProvenanceMetadata{
+		BuildStartedOn:  &e1BuildStart,
+		BuildFinishedOn: &e1BuildFinished,
+		Completeness: slsa.ProvenanceComplete{
+			Parameters:  false,
+			Environment: false,
+			Materials:   false,
+		},
+		Reproducible: false,
+	}
+
+	zoned := objects.NewPipelineRunObject(pro.DeepCopy())
+	tz := time.FixedZone("Test Time", int((12 * time.Hour).Seconds()))
+	zoned.Status.StartTime.Time = zoned.Status.StartTime.Time.In(tz)
+	zoned.Status.CompletionTime.Time = zoned.Status.CompletionTime.Time.In(tz)
+	got := metadata(zoned)
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("metadata(): -want +got: %s", diff)
+	}
+}
+
 func TestMaterials(t *testing.T) {
 	expected := []slsa.ProvenanceMaterial{
 		{URI: "abc", Digest: slsa.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},

--- a/pkg/chains/formats/intotoite6/taskrun/taskrun.go
+++ b/pkg/chains/formats/intotoite6/taskrun/taskrun.go
@@ -62,10 +62,12 @@ func invocation(tro *objects.TaskRunObject) slsa.ProvenanceInvocation {
 func metadata(tro *objects.TaskRunObject) *slsa.ProvenanceMetadata {
 	m := &slsa.ProvenanceMetadata{}
 	if tro.Status.StartTime != nil {
-		m.BuildStartedOn = &tro.Status.StartTime.Time
+		utc := tro.Status.StartTime.Time.UTC()
+		m.BuildStartedOn = &utc
 	}
 	if tro.Status.CompletionTime != nil {
-		m.BuildFinishedOn = &tro.Status.CompletionTime.Time
+		utc := tro.Status.CompletionTime.Time.UTC()
+		m.BuildFinishedOn = &utc
 	}
 	for label, value := range tro.Labels {
 		if label == attest.ChainsReproducibleAnnotation && value == "true" {


### PR DESCRIPTION
# Changes

The SLSA provenance prescribes that the Timestamp data types must be in UTC time zone. It can happen that the environment where Chains controller is running is not set to the UTC time zone, and in that case the `predicate.metadata.buildStartedOn` and
`predicate.metadata.buildFinishedOn` will be set with the local time zone. This is due to apimachinery converting `time.Time` values into local timezone on JSON unmarshall.

This forces all dates to the UTC time zone.

Fixes #630

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Makes sure all dates in SLSA provenance attestations are in UTC time zone
```
