### PR TITLE
Promote Sigstore features out of experimental.

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -11,75 +11,7 @@ This doc covers experimental features in Tekton Chains.
 
 Currently, experimental features include:
 
-- [Transparency Log Support](#Transparency-Log-Support)
-- [Keyless Signing Mode](#Keyless-Signing-Mode)
-
-## Transparency Log Support
-
-Chains supports automatic binary uploads to a transparency log and defaults to
-using Rekor. If enabled, all signatures and attestations will be logged. The
-entry ID will be appended as an annotation on a `TaskRun` or a `PipelineRun`
-once Chains has uploaded it:
-
-```yaml
-chains.tekton.dev/transparency: https://rekor.sigstore.dev/7599
-```
-
-### Enabling Transparency Log Support
-
-To enable, run:
-
-```shell
-kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"transparency.enabled": "true"}}'
-```
-
-Right now, Chains default to storing entries in Rekor
-(<https://rekor.sigstore.dev>). To customize where entries are stored, run:
-
-```shell
-kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"transparency.url": "<YOUR URL>"}}'
-```
-
-## Keyless Signing Mode
-
-Chains also supports a keyless signing mode with
-[Fulcio](https://github.com/sigstore/fulcio), sigstore's free root certificate
-authority.
-
-In this mode, instead of setting up a signing key, Chains would request an
-identity token from the cluster it is running in. This identity token will be
-used to authorize a Fulcio certificate for a Tekton artifact (OCI image,
-`TaskRun`, or `PipelineRun`). Currently, this experimental feature only works
-on a GKE cluster with
-[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
-configured (Workload Identity is required for Chains to be able to request an
-identity token).
-
-Once Chains has successfully requested a certificate, it will store the cert as
-a base64 encoded annotation on the `TaskRun` or `PipelineRun` , along with the
-payload and signature.
-
-This can look like:
-
-```yaml
-Annotations:  chains.tekton.dev/cert-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
-              chains.tekton.dev/chain-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
-              chains.tekton.dev/payload-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
-                eyJfdHlwZSI6ImJ1aWxkLWNoYWlucy01dnhycyIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3Rla3Rvbi5kZXYvY2hhaW5zL3Byb3ZlbmFuY2UiLCJzdWJqZWN0IjpbeyJuYW1lIj...
-              chains.tekton.dev/signature-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
-                eyJwYXlsb2FkVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5pbi10b3RvK2pzb24iLCJwYXlsb2FkIjoiZXlKZmRIbHdaU0k2SW1KMWFXeGtMV05vWVdsdWN5MDFkbmh5Y3lJc0luQnlaV1...
-              chains.tekton.dev/signed: true
-              chains.tekton.dev/transparency: https://rekor.sigstore.dev/7599
-              pipeline.tekton.dev/release: v0.25.0
-```
-
-### Enabling Keyless Signing Mode
-
-To enable singing with Fulcio, run:
-
-```shell
-kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"signers.x509.fulcio.enabled": "true"}}'
-```
+- [PubSub Storage Backend Support](#Pubsub-Storage-Backend-Support)
 
 ## PubSub Storage Backend Support
 

--- a/docs/sigstore.md
+++ b/docs/sigstore.md
@@ -1,0 +1,78 @@
+<!--
+
+---
+linkTitle: "Sigstore"
+weight: 50
+---
+
+-->
+
+# Sigstore
+
+## Transparency Log Support
+
+Chains supports automatic binary uploads to a transparency log and defaults to
+using [Rekor](https://github.com/sigstore/rekor). If enabled, all signatures and
+attestations will be logged. The entry ID will be appended as an annotation on a
+`TaskRun` or a `PipelineRun` once Chains has uploaded it:
+
+```yaml
+chains.tekton.dev/transparency: https://rekor.sigstore.dev/7599
+```
+
+### Enabling Transparency Log Support
+
+To enable, run:
+
+```shell
+kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"transparency.enabled": "true"}}'
+```
+
+Right now, Chains default to storing entries in the public Rekor instance
+(<https://rekor.sigstore.dev>). To customize where entries are stored, run:
+
+```shell
+kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"transparency.url": "<YOUR URL>"}}'
+```
+
+## Keyless Signing Mode
+
+Chains also supports a keyless signing mode with
+[Fulcio](https://github.com/sigstore/fulcio), Sigstore's free root certificate
+authority.
+
+In this mode, instead of setting up a signing key, Chains would request an
+identity token from the cluster it is running in. This identity token will be
+used to authorize a Fulcio certificate for a Tekton artifact (OCI image,
+`TaskRun`, or `PipelineRun`). This feature has been tested on GKE,
+[EKS](https://www.chainguard.dev/unchained/keyless-signing-with-tekton-on-amazon-eks-2),
+and
+[AKS](https://www.chainguard.dev/unchained/keyless-signing-with-tekton-on-aks),
+but should work on any environment that supports
+[Cosign OIDC signing](https://docs.sigstore.dev/cosign/openid_signing).
+
+Once Chains has successfully requested a certificate, it will store the cert as
+a base64 encoded annotation on the `TaskRun` or `PipelineRun` , along with the
+payload and signature.
+
+This can look like:
+
+```yaml
+Annotations:  chains.tekton.dev/cert-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
+              chains.tekton.dev/chain-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
+              chains.tekton.dev/payload-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
+                eyJfdHlwZSI6ImJ1aWxkLWNoYWlucy01dnhycyIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3Rla3Rvbi5kZXYvY2hhaW5zL3Byb3ZlbmFuY2UiLCJzdWJqZWN0IjpbeyJuYW1lIj...
+              chains.tekton.dev/signature-taskrun-57e7ef8e-13fb-4d27-af6e-dc4d68f73cc4:
+                eyJwYXlsb2FkVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5pbi10b3RvK2pzb24iLCJwYXlsb2FkIjoiZXlKZmRIbHdaU0k2SW1KMWFXeGtMV05vWVdsdWN5MDFkbmh5Y3lJc0luQnlaV1...
+              chains.tekton.dev/signed: true
+              chains.tekton.dev/transparency: https://rekor.sigstore.dev/7599
+              pipeline.tekton.dev/release: v0.25.0
+```
+
+### Enabling Keyless Signing Mode
+
+To enable singing with Fulcio, run:
+
+```shell
+kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"signers.x509.fulcio.enabled": "true"}}'
+```


### PR DESCRIPTION


<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Keyless signing has already been a part of our [e2e tests](https://github.com/tektoncd/chains/blob/b5efd5868630a3b2914f6eeb8e5399fe1b1c1d8b/.github/workflows/kind-e2e.yaml#L97) for quite some time, and with Sigstore GA (https://blog.sigstore.dev/sigstore-ga-ddd6ba67894d), these features are stable enough that we can move them out of experimental.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Sigstore integration promoted out of experimental.
```
