### PR TITLE
Issue 642: Add sidecar, step and remote tasks to pipelinerun materials

### DIFF
--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -178,6 +178,21 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 				Reproducible: false,
 			},
 			Materials: []slsa.ProvenanceMaterial{
+				{
+					URI:    "docker-pullable://gcr.io/test1/test1",
+					Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+				},
+				{URI: "github.com/catalog", Digest: slsa.DigestSet{"sha1": "x123"}},
+				{
+					URI:    "docker-pullable://gcr.io/test2/test2",
+					Digest: slsa.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+				},
+				{
+					URI:    "docker-pullable://gcr.io/test3/test3",
+					Digest: slsa.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+				},
+				{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "ab123"}},
+				{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "28b123"}},
 				{URI: "abc", Digest: slsa.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
 				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "abcd"}},
 			},
@@ -339,7 +354,8 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
-	if diff := cmp.Diff(expected, got); diff != "" {
+	// Sort Materials since their order can vary and result in flakes
+	if diff := cmp.Diff(expected, got, test.OptSortMaterial); diff != "" {
 		t.Errorf("InTotoIte6.CreatePayload(): -want +got: %s", diff)
 	}
 }
@@ -381,6 +397,20 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 			},
 			Materials: []slsa.ProvenanceMaterial{
 				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "abcd"}},
+				{
+					URI:    "docker-pullable://gcr.io/test3/test3",
+					Digest: slsa.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+				},
+				{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "ab123"}},
+				{
+					URI:    "docker-pullable://gcr.io/test1/test1",
+					Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+				},
+				{URI: "github.com/catalog", Digest: slsa.DigestSet{"sha1": "x123"}},
+				{
+					URI:    "docker-pullable://gcr.io/test2/test2",
+					Digest: slsa.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+				},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{},
@@ -535,7 +565,8 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
-	if diff := cmp.Diff(expected, got); diff != "" {
+	// Sort Materials since their order can vary and result in flakes
+	if diff := cmp.Diff(expected, got, test.OptSortMaterial); diff != "" {
 		t.Errorf("InTotoIte6.CreatePayload(): -want +got: %s", diff)
 	}
 }

--- a/pkg/chains/formats/intotoite6/pipelinerun/provenance_test.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/provenance_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats/intotoite6/extract"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/internal/objectloader"
+	"github.com/tektoncd/chains/test"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/selection"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -451,17 +452,50 @@ func TestMetadataInTimeZone(t *testing.T) {
 
 func TestMaterials(t *testing.T) {
 	expected := []slsa.ProvenanceMaterial{
+		{
+			URI:    "docker-pullable://gcr.io/test1/test1",
+			Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+		},
+		{URI: "github.com/catalog", Digest: slsa.DigestSet{"sha1": "x123"}},
+		{
+			URI:    "docker-pullable://gcr.io/test2/test2",
+			Digest: slsa.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+		},
+		{
+			URI:    "docker-pullable://gcr.io/test3/test3",
+			Digest: slsa.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+		},
+		{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "28b123"}},
+		{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "ab123"}},
 		{URI: "abc", Digest: slsa.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
 		{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "abcd"}},
 	}
-	got := materials(pro, logtesting.TestLogger(t))
-	if diff := cmp.Diff(expected, got); diff != "" {
-		t.Errorf("materials(): -want +got: %s", diff)
+	got, err := materials(pro, logtesting.TestLogger(t))
+	if err != nil {
+		t.Error(err)
+	}
+	if diff := cmp.Diff(expected, got, test.OptSortMaterial); diff != "" {
+		t.Errorf("Materials(): -want +got: %s", diff)
 	}
 }
 
 func TestStructuredResultMaterials(t *testing.T) {
 	want := []slsa.ProvenanceMaterial{
+		{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "28b123"}},
+		{
+			URI:    "docker-pullable://gcr.io/test1/test1",
+			Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+		},
+		{URI: "github.com/catalog", Digest: slsa.DigestSet{"sha1": "x123"}},
+		{
+			URI:    "docker-pullable://gcr.io/test2/test2",
+			Digest: slsa.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+		},
+		{
+			URI:    "docker-pullable://gcr.io/test3/test3",
+			Digest: slsa.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+		},
+		{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "ab123"}},
 		{
 			URI: "abcd",
 			Digest: slsa.DigestSet{
@@ -469,8 +503,11 @@ func TestStructuredResultMaterials(t *testing.T) {
 			},
 		},
 	}
-	got := materials(proStructuredResults, logtesting.TestLogger(t))
-	if diff := cmp.Diff(want, got); diff != "" {
+	got, err := materials(proStructuredResults, logtesting.TestLogger(t))
+	if err != nil {
+		t.Errorf("error while extracting materials: %v", err)
+	}
+	if diff := cmp.Diff(want, got, test.OptSortMaterial); diff != "" {
 		t.Errorf("materials(): -want +got: %s", diff)
 	}
 }

--- a/pkg/chains/formats/intotoite6/taskrun/material.go
+++ b/pkg/chains/formats/intotoite6/taskrun/material.go
@@ -35,28 +35,28 @@ const (
 	digestSeparator = ":"
 )
 
-// addStepImagesToMaterials adds step images to predicate.materials
-func addStepImagesToMaterials(steps []v1beta1.StepState, mats *[]slsa.ProvenanceMaterial) error {
+// AddStepImagesToMaterials adds step images to predicate.materials
+func AddStepImagesToMaterials(steps []v1beta1.StepState, mats *[]slsa.ProvenanceMaterial) error {
 	for _, stepState := range steps {
-		if err := addImageIDToMaterials(stepState.ImageID, mats); err != nil {
+		if err := AddImageIDToMaterials(stepState.ImageID, mats); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// addSidecarImagesToMaterials adds sidecar images to predicate.materials
-func addSidecarImagesToMaterials(sidecars []v1beta1.SidecarState, mats *[]slsa.ProvenanceMaterial) error {
+// AddSidecarImagesToMaterials adds sidecar images to predicate.materials
+func AddSidecarImagesToMaterials(sidecars []v1beta1.SidecarState, mats *[]slsa.ProvenanceMaterial) error {
 	for _, sidecarState := range sidecars {
-		if err := addImageIDToMaterials(sidecarState.ImageID, mats); err != nil {
+		if err := AddImageIDToMaterials(sidecarState.ImageID, mats); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// addImageIDToMaterials converts an imageId with format <uri>@sha256:<digest> and then adds it to a provenance materials.
-func addImageIDToMaterials(imageID string, mats *[]slsa.ProvenanceMaterial) error {
+// AddImageIDToMaterials converts an imageId with format <uri>@sha256:<digest> and then adds it to a provenance materials.
+func AddImageIDToMaterials(imageID string, mats *[]slsa.ProvenanceMaterial) error {
 	m := slsa.ProvenanceMaterial{
 		Digest: slsa.DigestSet{},
 	}
@@ -83,12 +83,12 @@ func materials(tro *objects.TaskRunObject, logger *zap.SugaredLogger) ([]slsa.Pr
 	var mats []slsa.ProvenanceMaterial
 
 	// add step images
-	if err := addStepImagesToMaterials(tro.Status.Steps, &mats); err != nil {
+	if err := AddStepImagesToMaterials(tro.Status.Steps, &mats); err != nil {
 		return mats, nil
 	}
 
 	// add sidecar images
-	if err := addSidecarImagesToMaterials(tro.Status.Sidecars, &mats); err != nil {
+	if err := AddSidecarImagesToMaterials(tro.Status.Sidecars, &mats); err != nil {
 		return mats, nil
 	}
 

--- a/pkg/chains/formats/intotoite6/taskrun/material_test.go
+++ b/pkg/chains/formats/intotoite6/taskrun/material_test.go
@@ -303,7 +303,7 @@ func TestAddStepImagesToMaterials(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		var mat []slsa.ProvenanceMaterial
-		if err := addStepImagesToMaterials(tc.steps, &mat); err != nil {
+		if err := AddStepImagesToMaterials(tc.steps, &mat); err != nil {
 			if err.Error() != tc.wantError.Error() {
 				t.Fatalf("Expected error %v but got %v", tc.wantError, err)
 			}
@@ -373,7 +373,7 @@ func TestAddSidecarImagesToMaterials(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		var mat []slsa.ProvenanceMaterial
-		if err := addSidecarImagesToMaterials(tc.sidecars, &mat); err != nil {
+		if err := AddSidecarImagesToMaterials(tc.sidecars, &mat); err != nil {
 			if err.Error() != tc.wantError.Error() {
 				t.Fatalf("Expected error %v but got %v", tc.wantError, err)
 			}
@@ -411,7 +411,7 @@ func TestAddImageIDToMaterials(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		mat := []slsa.ProvenanceMaterial{}
-		if err := addImageIDToMaterials(tc.imageID, &mat); err != nil {
+		if err := AddImageIDToMaterials(tc.imageID, &mat); err != nil {
 			if err.Error() != tc.wantError.Error() {
 				t.Fatalf("Expected error %v but got %v", tc.wantError, err)
 			}

--- a/test/sortoptions.go
+++ b/test/sortoptions.go
@@ -23,5 +23,16 @@ import (
 
 // OptSortMaterial provides compare options to sort a slice of materials by URI in the provenance
 var OptSortMaterial = cmpopts.SortSlices(func(i, j slsa.ProvenanceMaterial) bool {
+	if i.URI == j.URI {
+		i_DigestValue := ""
+		for _, v := range i.Digest {
+			i_DigestValue = v
+		}
+		j_DigestValue := ""
+		for _, v := range j.Digest {
+			j_DigestValue = v
+		}
+		return i_DigestValue < j_DigestValue
+	}
 	return i.URI < j.URI
 })

--- a/test/testdata/intoto/pipeline-output-image.json
+++ b/test/testdata/intoto/pipeline-output-image.json
@@ -70,6 +70,14 @@
             "reproducible": false
         },
         "materials": [
+	    {{range .URIDigest}}
+	    {
+		"uri": "{{.URI}}",
+		"digest": {
+		    "sha256": "{{.Digest}}"
+		}
+	    },
+	    {{end}}
             {
                 "uri": "git+https://my-git-url.git",
                 "digest": {


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->
This PR addresses issue https://github.com/tektoncd/chains/issues/642 by adding steps and sidecars image uri and digest information to predicate.materials for a PipelineRun.

Prior to reviewing this PR, review #649 
# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
predicate.materials includes image uri and digest information from all steps, sidecars and also config source information for remote tasks. 
```
/kind bug