### PR TITLE
Cleanup: replaced deprecated `ioutil` package use.

### DIFF
--- a/pkg/chains/signing/wrap.go
+++ b/pkg/chains/signing/wrap.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
@@ -114,7 +113,7 @@ func (w *sslSigner) Sign(ctx context.Context, payload []byte) ([]byte, []byte, e
 }
 
 func (w *sslSigner) SignMessage(payload io.Reader, opts ...signature.SignOption) ([]byte, error) {
-	m, err := ioutil.ReadAll(payload)
+	m, err := io.ReadAll(payload)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chains/signing/x509/x509.go
+++ b/pkg/chains/signing/x509/x509.go
@@ -20,7 +20,7 @@ import (
 	cx509 "crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -54,9 +54,9 @@ func NewSigner(ctx context.Context, secretPath string, cfg config.Config, logger
 
 	if cfg.Signers.X509.FulcioEnabled {
 		return fulcioSigner(ctx, cfg.Signers.X509, logger)
-	} else if contents, err := ioutil.ReadFile(x509PrivateKeyPath); err == nil {
+	} else if contents, err := os.ReadFile(x509PrivateKeyPath); err == nil {
 		return x509Signer(contents, logger)
-	} else if contents, err := ioutil.ReadFile(cosignPrivateKeypath); err == nil {
+	} else if contents, err := os.ReadFile(cosignPrivateKeypath); err == nil {
 		return cosignSigner(secretPath, contents, logger)
 	}
 	return nil, errors.New("no valid private key found, looked for: [x509.pem, cosign.key]")
@@ -124,7 +124,7 @@ func x509Signer(privateKey []byte, logger *zap.SugaredLogger) (*Signer, error) {
 func cosignSigner(secretPath string, privateKey []byte, logger *zap.SugaredLogger) (*Signer, error) {
 	logger.Info("Found cosign key...")
 	cosignPasswordPath := filepath.Join(secretPath, "cosign.password")
-	password, err := ioutil.ReadFile(cosignPasswordPath)
+	password, err := os.ReadFile(cosignPasswordPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading cosign.password file")
 	}

--- a/pkg/chains/signing/x509/x509_test.go
+++ b/pkg/chains/signing/x509/x509_test.go
@@ -20,7 +20,7 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -53,7 +53,7 @@ func TestSigner_SignECDSA(t *testing.T) {
 	logger := logtesting.TestLogger(t)
 	d := t.TempDir()
 	p := filepath.Join(d, "x509.pem")
-	if err := ioutil.WriteFile(p, []byte(ecdsaPriv), 0644); err != nil {
+	if err := os.WriteFile(p, []byte(ecdsaPriv), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -95,7 +95,7 @@ func TestSigner_SignED25519(t *testing.T) {
 	logger := logtesting.TestLogger(t)
 	d := t.TempDir()
 	p := filepath.Join(d, "x509.pem")
-	if err := ioutil.WriteFile(p, []byte(ed25519Priv), 0644); err != nil {
+	if err := os.WriteFile(p, []byte(ed25519Priv), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/chains/storage/gcs/gcs.go
+++ b/pkg/chains/storage/gcs/gcs.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"cloud.google.com/go/storage"
 
@@ -179,7 +178,7 @@ func (b *Backend) retrieveObject(ctx context.Context, object string) (string, er
 	}
 
 	defer reader.Close()
-	payload, err := ioutil.ReadAll(reader)
+	payload, err := io.ReadAll(reader)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
# Changes

`ioutil` functionality is replaced with the `io` or `os` package as of Go 1.16.

There are no expected functional changes in this PR.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
