### PR TITLE
Cleaned up `golangci-lint` and added additional linters.

### DIFF
--- a/.golang-ci.yaml
+++ b/.golang-ci.yaml
@@ -1,28 +1,43 @@
+# Documentation: https://golangci-lint.run/usage/configuration/
 linters-settings:
-  linters:
-    disable-all: true
-    enable:
+linters:
+  disable-all: true
+  enable:
+  - bodyclose
+  - decorder
+  - depguard
+  - dupword
+  - errcheck
+  - gocritic
+  - gofmt
+  - goimports
+  - gomodguard
+  - gosec
+  - gosimple
+  - govet
+  - misspell
+  - revive
+  - thelper
+  - typecheck
+  - unconvert
+  - unused
+  - usestdlibvars
+  - whitespace
+output:
+  uniq-by-line: false
+issues:
+  exclude-rules:
+  - path: _test\.go
+    linters:
     - errcheck
-    - gofmt
-    - goimports
     - gosec
-    - gocritic
-    - revive
-  output:
-    uniq-by-line: false
-  issues:
-    exclude-rules:
-    - path: _test\.go
-      linters:
-      - errcheck
-      - gosec
-    max-issues-per-linter: 0
-    max-same-issues: 0
-  run:
-    issues-exit-code: 1
-    build-tags:
-    - e2e
-    skip-dirs:
-    - vendor
-    timeout: 10m
-    modules-download-mode: vendor
+  max-issues-per-linter: 0
+  max-same-issues: 0
+run:
+  issues-exit-code: 1
+  build-tags:
+  - e2e
+  skip-dirs:
+  - vendor
+  timeout: 10m
+  modules-download-mode: vendor


### PR DESCRIPTION
# Changes

Cleaned up `golangci-lint` and added additional linters.

- Cleaned up configuration, which previously violated whitespace conventions for `yaml`
- Added link to documentation
- Enabled additional linters

There are no expected functional changes in this PR.

Larger context: https://github.com/tektoncd/pipeline/issues/5899 -- we should also be upleveling our conformance with Go style here in Chains!

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
