### PR TITLE
Cleanup: use idiomatic Go.

### DIFF
--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -41,9 +41,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const (
-	StorageBackendOCI = "oci"
-)
+const StorageBackendOCI = "oci"
 
 type Backend struct {
 	logger           *zap.SugaredLogger

--- a/pkg/chains/storage/oci/oci_test.go
+++ b/pkg/chains/storage/oci/oci_test.go
@@ -39,9 +39,7 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 )
 
-const (
-	namespace = "oci-test"
-)
+const namespace = "oci-test"
 
 var (
 	tr = &v1beta1.TaskRun{
@@ -116,126 +114,117 @@ func TestBackend_StorePayload(t *testing.T) {
 		fields  fields
 		args    args
 		wantErr bool
-	}{
-		{
-			name: "simplesigning payload",
-			fields: fields{
-				object: objects.NewTaskRunObject(tr),
-			},
-			args: args{
-				payload:   simple,
-				signature: "simplesigning",
-				storageOpts: config.StorageOpts{
-					PayloadFormat: formats.PayloadTypeSimpleSigning,
-				},
-			},
-			wantErr: false,
+	}{{
+		name: "simplesigning payload",
+		fields: fields{
+			object: objects.NewTaskRunObject(tr),
 		},
-		{
-			name: "into-to payload",
-			fields: fields{
-				object: objects.NewTaskRunObject(tr),
+		args: args{
+			payload:   simple,
+			signature: "simplesigning",
+			storageOpts: config.StorageOpts{
+				PayloadFormat: formats.PayloadTypeSimpleSigning,
 			},
-			args: args{
-				payload:   intotoStatement,
-				signature: "into-to",
-				storageOpts: config.StorageOpts{
-					PayloadFormat: "in-toto",
-				},
-			},
-			wantErr: false,
 		},
-		{
-			name: "no subject",
-			fields: fields{
-				object: objects.NewTaskRunObject(tr),
-			},
-			args: args{
-				payload:   in_toto.Statement{},
-				signature: "",
-				storageOpts: config.StorageOpts{
-					PayloadFormat: "in-toto",
-				},
-			},
-			wantErr: false,
+		wantErr: false,
+	}, {
+		name: "into-to payload",
+		fields: fields{
+			object: objects.NewTaskRunObject(tr),
 		},
-		{
-			name: "simplesigning payload",
-			fields: fields{
-				object: objects.NewPipelineRunObject(pr),
+		args: args{
+			payload:   intotoStatement,
+			signature: "into-to",
+			storageOpts: config.StorageOpts{
+				PayloadFormat: "in-toto",
 			},
-			args: args{
-				payload:   simple,
-				signature: "simplesigning",
-				storageOpts: config.StorageOpts{
-					PayloadFormat: formats.PayloadTypeSimpleSigning,
-				},
-			},
-			wantErr: false,
 		},
-		{
-			name: "into-to payload",
-			fields: fields{
-				object: objects.NewPipelineRunObject(pr),
-			},
-			args: args{
-				payload:   intotoStatement,
-				signature: "into-to",
-				storageOpts: config.StorageOpts{
-					PayloadFormat: "in-toto",
-				},
-			},
-			wantErr: false,
+		wantErr: false,
+	}, {
+		name: "no subject",
+		fields: fields{
+			object: objects.NewTaskRunObject(tr),
 		},
-		{
-			name: "in-toto-and-simple-payload",
-			fields: fields{
-				object: objects.NewTaskRunObject(tr),
+		args: args{
+			payload:   in_toto.Statement{},
+			signature: "",
+			storageOpts: config.StorageOpts{
+				PayloadFormat: "in-toto",
 			},
-			args: args{
-				payload:   simple,
-				signature: "",
-				storageOpts: config.StorageOpts{
-					PayloadFormat: "in-toto",
-				},
-			},
-			wantErr: false,
 		},
-		{
-			name: "tekton-and-simple-payload",
-			fields: fields{
-				object: objects.NewTaskRunObject(tr),
-			},
-			args: args{
-				payload:   simple,
-				signature: "",
-				storageOpts: config.StorageOpts{
-					PayloadFormat: "tekton",
-				},
-			},
-			wantErr: false,
+		wantErr: false,
+	}, {
+		name: "simplesigning payload",
+		fields: fields{
+			object: objects.NewPipelineRunObject(pr),
 		},
-		{
-			name: "no subject",
-			fields: fields{
-				object: objects.NewPipelineRunObject(pr),
+		args: args{
+			payload:   simple,
+			signature: "simplesigning",
+			storageOpts: config.StorageOpts{
+				PayloadFormat: formats.PayloadTypeSimpleSigning,
 			},
-			args: args{
-				payload:   in_toto.Statement{},
-				signature: "",
-				storageOpts: config.StorageOpts{
-					PayloadFormat: "in-toto",
-				},
-			},
-			wantErr: false,
 		},
-	}
+		wantErr: false,
+	}, {
+		name: "into-to payload",
+		fields: fields{
+			object: objects.NewPipelineRunObject(pr),
+		},
+		args: args{
+			payload:   intotoStatement,
+			signature: "into-to",
+			storageOpts: config.StorageOpts{
+				PayloadFormat: "in-toto",
+			},
+		},
+		wantErr: false,
+	}, {
+		name: "in-toto-and-simple-payload",
+		fields: fields{
+			object: objects.NewTaskRunObject(tr),
+		},
+		args: args{
+			payload:   simple,
+			signature: "",
+			storageOpts: config.StorageOpts{
+				PayloadFormat: "in-toto",
+			},
+		},
+		wantErr: false,
+	}, {
+		name: "tekton-and-simple-payload",
+		fields: fields{
+			object: objects.NewTaskRunObject(tr),
+		},
+		args: args{
+			payload:   simple,
+			signature: "",
+			storageOpts: config.StorageOpts{
+				PayloadFormat: "tekton",
+			},
+		},
+		wantErr: false,
+	}, {
+		name: "no subject",
+		fields: fields{
+			object: objects.NewPipelineRunObject(pr),
+		},
+		args: args{
+			payload:   in_toto.Statement{},
+			signature: "",
+			storageOpts: config.StorageOpts{
+				PayloadFormat: "in-toto",
+			},
+		},
+		wantErr: false,
+	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &Backend{
 				logger: logtesting.TestLogger(t),
-				getAuthenticator: func(_ context.Context, _ objects.TektonObject, _ kubernetes.Interface) (remote.Option, error) {
+				getAuthenticator: func(context.Context, objects.TektonObject, kubernetes.Interface) (remote.Option, error) {
 					return remote.WithAuthFromKeychain(authn.DefaultKeychain), nil
 				},
 			}

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -90,7 +90,7 @@ func TestExamples(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			c, ns, cleanup := setup(ctx, t, setupOpts{})
-			defer cleanup()
+			t.Cleanup(cleanup)
 
 			cleanUpInTotoFormatter := setConfigMap(ctx, t, c, test.cm)
 			runInTotoFormatterTests(ctx, t, ns, c, test)


### PR DESCRIPTION
# Changes

There are no expected functional changes in this PR.

Cleanup: use idiomatic Go.

- Use context timeout rather than rolling our own.
- Use `time.Minute` rather than `60*time.Second`.
- In-lined single-use helper functions.
- Added comments with questions around unclear code.
- Use `t.Cleanup` instead of `defer` where appropriate.
- Return after `t.Error` when it's clear that continuing is pointless.

See:
- https://google.github.io/styleguide/go/decisions#matching-braces
- https://google.github.io/styleguide/go/decisions#cuddled-braces
- https://testing.googleblog.com/2017/06/code-health-reduce-nesting-reduce.html
- https://google.github.io/styleguide/go/best-practices#t-fatal
- https://pkg.go.dev/testing#T.Cleanup

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
