### PR TITLE
Fix checks to allow passing in of sha1 digests through StructuredResults.

### DIFF
--- a/pkg/artifacts/signable_test.go
+++ b/pkg/artifacts/signable_test.go
@@ -29,10 +29,16 @@ import (
 )
 
 const (
-	digest1 = "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"
-	digest2 = "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"
-	digest3 = "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b7"
-	digest4 = "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b8"
+	digest1                 = "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"
+	digest2                 = "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"
+	digest3                 = "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b7"
+	digest4                 = "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b8"
+	digest_sha384           = "sha384:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b893c56eeba9ec70f74c9bfd297d951664"
+	digest_sha512           = "sha512:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b805f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b8"
+	digest_sha1             = "sha1:93c56eeba9ec70f74c9bfd297d9516642d366cb5"
+	digest_incorrect_sha1   = "sha1:93c56eeba9ec70f74c9bfd297d9516642d366c5"
+	digest_incorrect_sha512 = "sha512:05f95b26ed1066b7183c1e2da98610e91372fa9f510046d4ce5812addad86b805f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b8"
+	digest_incorrect_sha384 = "sha384:0595b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b893c56eeba9ec70f74c9bfd297d951664"
 )
 
 var ignore = []cmp.Option{cmpopts.IgnoreUnexported(name.Registry{}, name.Repository{}, name.Digest{})}
@@ -413,6 +419,48 @@ func TestExtractStructuredTargetFromResults(t *testing.T) {
 						}),
 					},
 					{
+						Name: "img2_input_sha1" + "_" + ArtifactsInputsResultName,
+						Value: *v1beta1.NewObject(map[string]string{
+							"uri":    "gcr.io/foo/bar",
+							"digest": digest_sha1,
+						}),
+					},
+					{
+						Name: "img2_input_incorrect_sha1" + "_" + ArtifactsInputsResultName,
+						Value: *v1beta1.NewObject(map[string]string{
+							"uri":    "gcr.io/foo/bar",
+							"digest": digest_incorrect_sha1,
+						}),
+					},
+					{
+						Name: "img3_input_sha384" + "_" + ArtifactsInputsResultName,
+						Value: *v1beta1.NewObject(map[string]string{
+							"uri":    "gcr.io/foo/bar",
+							"digest": digest_sha384,
+						}),
+					},
+					{
+						Name: "img3_input_incorrect_sha384" + "_" + ArtifactsInputsResultName,
+						Value: *v1beta1.NewObject(map[string]string{
+							"uri":    "gcr.io/foo/bar",
+							"digest": digest_incorrect_sha384,
+						}),
+					},
+					{
+						Name: "img4_input_sha512" + "_" + ArtifactsInputsResultName,
+						Value: *v1beta1.NewObject(map[string]string{
+							"uri":    "gcr.io/foo/bar",
+							"digest": digest_sha512,
+						}),
+					},
+					{
+						Name: "img4_input_incorrect_sha512" + "_" + ArtifactsInputsResultName,
+						Value: *v1beta1.NewObject(map[string]string{
+							"uri":    "gcr.io/foo/bar",
+							"digest": digest_incorrect_sha512,
+						}),
+					},
+					{
 						Name: "img2_input_no_digest" + "_" + ArtifactsInputsResultName,
 						Value: *v1beta1.NewObject(map[string]string{
 							"uri":    "gcr.io/foo/foo",
@@ -426,6 +474,9 @@ func TestExtractStructuredTargetFromResults(t *testing.T) {
 
 	wantInputs := []*StructuredSignable{
 		{URI: "gcr.io/foo/bar", Digest: digest3},
+		{URI: "gcr.io/foo/bar", Digest: digest_sha1},
+		{URI: "gcr.io/foo/bar", Digest: digest_sha384},
+		{URI: "gcr.io/foo/bar", Digest: digest_sha512},
 	}
 	gotInputs := ExtractStructuredTargetFromResults(objects.NewTaskRunObject(tr), ArtifactsInputsResultName, logtesting.TestLogger(t))
 	if diff := cmp.Diff(gotInputs, wantInputs, cmpopts.SortSlices(func(x, y *StructuredSignable) bool { return x.Digest < y.Digest })); diff != "" {


### PR DESCRIPTION
Fixes https://github.com/tektoncd/chains/issues/636

This PR addresses the issue of artifacts which have sha1 digest not being added into materials.

Before this fix checkDigest would only check if the digest was sha256 and would reject other digests.
This commit fixes checkDigest to ensue that it accepts all valid digests of type sha256, sha512, sha384 and sha1.

Signed-off-by: jagathprakash <31057312+jagathprakash@users.noreply.github.com>

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
