### PR TITLE
Fix to prevent adding empty structs into materials.

### DIFF
--- a/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
@@ -224,11 +224,13 @@ func materials(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) []slsa
 			url = r.Value.StringVal
 		}
 	}
-	url = attest.SPDXGit(url, "")
-	mats = append(mats, slsa.ProvenanceMaterial{
-		URI:    url,
-		Digest: map[string]string{"sha1": commit},
-	})
+	if len(commit) > 0 && len(url) > 0 {
+		url = attest.SPDXGit(url, "")
+		mats = append(mats, slsa.ProvenanceMaterial{
+			URI:    url,
+			Digest: map[string]string{"sha1": commit},
+		})
+	}
 	return mats
 }
 

--- a/pkg/chains/formats/intotoite6/testdata/pipelinerun_structured_results.json
+++ b/pkg/chains/formats/intotoite6/testdata/pipelinerun_structured_results.json
@@ -1,0 +1,264 @@
+{
+    "spec": {
+        "params": [
+            {
+                "name": "IMAGE",
+                "value": "test.io/test/image"
+            }
+        ],
+        "pipelineRef": {
+            "name": "test-pipeline"
+        },
+        "serviceAccountName": "pipeline"
+    },
+    "status": {
+        "startTime": "2021-03-29T09:50:00Z",
+        "completionTime": "2021-03-29T09:50:15Z",
+        "conditions": [
+            {
+                "lastTransitionTime": "2021-03-29T09:50:15Z",
+                "message": "Tasks Completed: 2 (Failed: 0, Cancelled 0), Skipped: 0",
+                "reason": "Succeeded",
+                "status": "True",
+                "type": "Succeeded"
+            }
+        ],
+        "pipelineResults": [
+            {
+                "name": "image-ARTIFACT_INPUTS",
+                "value": {
+                    "uri": "abcd",
+                    "digest": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+                }
+            },
+            {
+                "name": "image-ARTIFACT_OUTPUTS",
+                "value": {
+                    "uri": "hello_world",
+                    "sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+                }
+            }
+        ],
+        "pipelineSpec": {
+            "params": [
+                {
+                    "description": "Image path on registry",
+                    "name": "IMAGE",
+                    "type": "string"
+                }
+            ],
+            "tasks": [
+                {
+                    "name": "git-clone",
+                    "params": [
+                        {
+                            "name": "url",
+                            "value": "https://git.test.com"
+                        },
+                        {
+                            "name": "revision",
+                            "value": ""
+                        }
+                    ],
+                    "taskRef": {
+                        "kind": "ClusterTask",
+                        "name": "git-clone"
+                    }
+                },
+                {
+                    "name": "build",
+                    "params": [
+                        {
+                            "name": "CHAINS-GIT_COMMIT",
+                            "value": "$(tasks.git-clone.results.commit)"
+                        },
+                        {
+                            "name": "CHAINS-GIT_URL",
+                            "value": "$(tasks.git-clone.results.url)"
+                        }
+                    ],
+                    "taskRef": {
+                        "kind": "ClusterTask",
+                        "name": "build"
+                    }
+                }
+            ]
+        },
+        "taskRuns": {
+            "git-clone": {
+                "pipelineTaskName": "git-clone",
+                "status": {
+                  "completionTime": "2021-03-29T09:50:15Z",
+                  "conditions": [
+                    {
+                      "lastTransitionTime": "2021-03-29T09:50:15Z",
+                      "message": "All Steps have completed executing",
+                      "reason": "Succeeded",
+                      "status": "True",
+                      "type": "Succeeded"
+                    }
+                  ],
+                  "podName": "git-clone-pod",
+                  "startTime": "2021-03-29T09:50:00Z",
+                  "steps": [
+                    {
+                      "container": "step-clone",
+                      "imageID": "test.io/test/clone-image",
+                      "name": "clone",
+                      "terminated": {
+                        "exitCode": 0,
+                        "finishedAt": "2021-03-29T09:50:15Z",
+                        "reason": "Completed",
+                        "startedAt": "2022-05-31T19:13:27Z"
+                      }
+                    }
+                  ],
+                  "taskResults": [
+                    {
+                      "name": "commit",
+                      "value": "abcd"
+                    },
+                    {
+                      "name": "url",
+                      "value": "https://git.test.com"
+                    }
+                  ],
+                  "taskSpec": {
+                    "params": [
+                      {
+                        "description": "Repository URL to clone from.",
+                        "name": "url",
+                        "type": "string"
+                      },
+                      {
+                        "default": "",
+                        "description": "Revision to checkout. (branch, tag, sha, ref, etc...)",
+                        "name": "revision",
+                        "type": "string"
+                      }
+                    ],
+                    "results": [
+                      {
+                        "description": "The precise commit SHA that was fetched by this Task.",
+                        "name": "commit"
+                      },
+                      {
+                        "description": "The precise URL that was fetched by this Task.",
+                        "name": "url"
+                      }
+                    ],
+                    "steps": [
+                      {
+                        "env": [
+                          {
+                            "name": "HOME",
+                            "value": "$(params.userHome)"
+                          },
+                          {
+                            "name": "PARAM_URL",
+                            "value": "$(params.url)"
+                          }
+                        ],
+                        "image": "$(params.gitInitImage)",
+                        "name": "clone",
+                        "resources": {},
+                        "script": "git clone"
+                      }
+                    ]
+                  }
+                }
+              },
+            "taskrun-build": {
+                "pipelineTaskName": "build",
+                "status": {
+                    "completionTime": "2021-03-29T09:50:15Z",
+                    "conditions": [
+                        {
+                            "lastTransitionTime": "2021-03-29T09:50:15Z",
+                            "message": "All Steps have completed executing",
+                            "reason": "Succeeded",
+                            "status": "True",
+                            "type": "Succeeded"
+                        }
+                    ],
+                    "podName": "build-pod",
+                    "startTime": "2021-03-29T09:50:00Z",
+                    "steps": [
+                        {
+                            "container": "step-build",
+                            "imageID": "test.io/test/build-image",
+                            "name": "build",
+                            "terminated": {
+                                "exitCode": 0,
+                                "finishedAt": "2022-05-31T19:17:30Z",
+                                "reason": "Completed",
+                                "startedAt": "2021-03-29T09:50:00Z"
+                            }
+                        }
+                    ],
+                    "taskResults": [
+                        {
+                            "name": "IMAGE_DIGEST",
+                            "value": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+                        },
+                        {
+                            "name": "IMAGE_URL",
+                            "value": "test.io/test/image\n"
+                        }
+                    ],
+                    "taskSpec": {
+                        "params": [
+                            {
+                                "description": "Git CHAINS URL",
+                                "name": "CHAINS-GIT_URL",
+                                "type": "string"
+                            },
+                            {
+                                "description": "Git CHAINS Commit",
+                                "name": "CHAINS-GIT_COMMIT",
+                                "type": "string"
+                            }
+                        ],
+                        "results": [
+                            {
+                                "description": "Digest of the image just built.",
+                                "name": "IMAGE_DIGEST"
+                            },
+                            {
+                                "description": "URL of the image just built.",
+                                "name": "IMAGE_URL"
+                            }
+                        ],
+                        "steps": [
+                            {
+                                "command": [
+                                    "buildah",
+                                    "build"
+                                ],
+                                "image": "test.io/test/build-image",
+                                "name": "generate"
+                            },
+                            {
+                                "command": [
+                                    "buildah",
+                                    "push"
+                                ],
+                                "image": "test.io/test/build-image",
+                                "name": "push"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "provenance": {
+          "configSource": {
+            "uri": "github.com/test",
+            "digest": {
+              "sha1": "28b123"
+            },
+            "entryPoint": "pipeline.yaml"
+          }
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: jagathprakash <31057312+jagathprakash@users.noreply.github.com>

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Prior to this change if there was no CHAINS-GIT_URL or CHAINS-GIT_COMMIT results in PipelineRun object, we would add an empty struct to the materials section of the SLSA provenance.
This fixes this to prevent the addition of the empty structs.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
