### PR TITLE
Slsa Branding of Chains Provenance Format

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -51,19 +51,22 @@ Supported keys include:
 
 | Key | Description | Supported Values | Default |
 | :--- | :--- | :--- | :--- |
-| `artifacts.taskrun.format` | The format to store `TaskRun` payloads in. | `in-toto`| `in-toto` |
+| `artifacts.taskrun.format` | The format to store `TaskRun` payloads in. | `in-toto`, `slsa/v1`| `in-toto` |
 | `artifacts.taskrun.storage` | The storage backend to store `TaskRun` signatures in. Multiple backends can be specified with comma-separated list ("tekton,oci"). To disable the `TaskRun` artifact input an empty string ("").  | `tekton`, `oci`, `gcs`, `docdb`, `grafeas` | `tekton` |
 | `artifacts.taskrun.signer` | The signature backend to sign `TaskRun` payloads with. | `x509`, `kms` | `x509` |
+
+> NOTE:, `slsa/v1` is an alias of `in-toto` for backwards compatibality.
 
 ### PipelineRun Configuration
 
 | Key | Description | Supported Values | Default |
 | :--- | :--- | :--- | :--- |
-| `artifacts.pipelinerun.format` | The format to store `PipelineRun` payloads in. | `in-toto`| `in-toto` |
+| `artifacts.pipelinerun.format` | The format to store `PipelineRun` payloads in. | `in-toto`, `slsa/v1`| `in-toto` |
 | `artifacts.pipelinerun.storage` | The storage backend to store `PipelineRun` signatures in. Multiple backends can be specified with comma-separated list ("tekton,oci"). To disable the `PipelineRun` artifact input an empty string ("").  | `tekton`, `oci`, `gcs`, `docdb`, `grafeas` | `tekton` |
 | `artifacts.pipelinerun.signer` | The signature backend to sign `PipelineRun` payloads with. | `x509`, `kms` | `x509` |
 
 > NOTE: For grafeas storage backend, currently we only support Container Analysis. We will make grafeas server address configurabe within a short time.
+> NOTE: `slsa/v1` is an alias of `in-toto` for backwards compatibality.
 
 ### OCI Configuration
 

--- a/docs/intoto.md
+++ b/docs/intoto.md
@@ -20,10 +20,11 @@ The in-toto format can be enabled by running:
 
 ```
 # For TaskRuns
-kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.taskrun.format": "in-toto"}}'
+kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.taskrun.format": "slsa/v1"}}'
 # For PipelineRuns
-kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.pipelinerun.format": "in-toto"}}'
+kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.pipelinerun.format": "slsa/v1"}}'
 ```
+**Note**, you can continue to use the older alias of `slsa/v1`: `in-toto`.
 
 To provide a git URL/commit as material, add a parameter named
 `CHAINS-GIT_COMMIT` and `CHAINS-GIT_URL`. The value of these

--- a/docs/tutorials/signed-provenance-tutorial.md
+++ b/docs/tutorials/signed-provenance-tutorial.md
@@ -55,17 +55,19 @@ kubectl create secret generic [DOCKERCONFIG_SECRET_NAME] --from-file [PATH TO CO
 
 You'll need to make these changes to the Tekton Chains Config:
 
-* `artifacts.taskrun.format=in-toto`
+* `artifacts.taskrun.format=slsa/v1`
 * `artifacts.taskrun.storage=oci`
 * `transparency.enabled=true`
 
 You can set these fields by running
 
 ```shell
-kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.taskrun.format": "in-toto"}}'
+kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.taskrun.format": "slsa/v1"}}'
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.taskrun.storage": "oci"}}'
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"transparency.enabled": "true"}}'
 ```
+
+**Note**, you can continue to use the older alias of `slsa/v1`: `in-toto` above.
 
 This tells Chains to generate an in-toto attestation and store it in the specified OCI registry.
 Attestations will also be stored in [rekor](https://github.com/sigstore/rekor) since transparency is enabled.

--- a/pkg/chains/formats/format.go
+++ b/pkg/chains/formats/format.go
@@ -31,10 +31,12 @@ const (
 	PayloadTypeTekton        config.PayloadType = "tekton"
 	PayloadTypeSimpleSigning config.PayloadType = "simplesigning"
 	PayloadTypeInTotoIte6    config.PayloadType = "in-toto"
+	PayloadTypeSlsav1        config.PayloadType = "slsa/v1"
 )
 
 var (
-	payloaderMap = map[config.PayloadType]PayloaderInit{}
+	IntotoAttestationSet = map[config.PayloadType]struct{}{PayloadTypeInTotoIte6: {}, PayloadTypeSlsav1: {}}
+	payloaderMap         = map[config.PayloadType]PayloaderInit{}
 )
 
 // PayloaderInit initializes a new Payloader instance for the given config.

--- a/pkg/chains/formats/slsa/README.md
+++ b/pkg/chains/formats/slsa/README.md
@@ -1,0 +1,14 @@
+# SLSA Branding of Tekton Chains Provenance Format
+
+`Tekton Chains` is migrating the naming of provenance formats from `intotoite6` to `slsa`.
+As different versions of provenance formats are rolled out in the future, they will take 
+the form `slsa/v1, slsa/v2` and the `package names` will be `v1`, `v2` and so on, respectively.
+
+**Note**: the `slsa` branding in `Tekton Chains` does not map directly to the slsa predicate release.
+Tekton chains `slsa/v1` is not the same as `slsav1.0`.
+
+Shown below is the mapping between Tekton chains proveance and SLSA predicate.
+
+|Tekton Chains Provenance Format version     | SLSA predicate | Notes |
+|:------------------------------------------|---------------:|------:|
+|**slsa/v1**| **slsa v0.2**  | same as currently supported `in-toto` format|

--- a/pkg/chains/formats/slsa/v1/intotoite6.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6.go
@@ -30,10 +30,12 @@ import (
 
 const (
 	PayloadTypeInTotoIte6 = formats.PayloadTypeInTotoIte6
+	PayloadTypeSlsav1     = formats.PayloadTypeSlsav1
 )
 
 func init() {
 	formats.RegisterPayloader(PayloadTypeInTotoIte6, NewFormatter)
+	formats.RegisterPayloader(PayloadTypeSlsav1, NewFormatter)
 }
 
 type InTotoIte6 struct {
@@ -63,5 +65,5 @@ func (i *InTotoIte6) CreatePayload(ctx context.Context, obj interface{}) (interf
 }
 
 func (i *InTotoIte6) Type() config.PayloadType {
-	return formats.PayloadTypeInTotoIte6
+	return formats.PayloadTypeSlsav1
 }

--- a/pkg/chains/formats/slsa/v1/intotoite6_test.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6_test.go
@@ -759,7 +759,7 @@ func TestCreatePayloadError(t *testing.T) {
 
 func TestCorrectPayloadType(t *testing.T) {
 	var i InTotoIte6
-	if i.Type() != formats.PayloadTypeInTotoIte6 {
+	if i.Type() != formats.PayloadTypeSlsav1 {
 		t.Errorf("Invalid type returned: %s", i.Type())
 	}
 }

--- a/pkg/chains/rekor.go
+++ b/pkg/chains/rekor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/chains/signing"
 	"github.com/tektoncd/chains/pkg/config"
@@ -46,7 +47,7 @@ func (r *rekor) UploadTlog(ctx context.Context, signer signing.Signer, signature
 	if err != nil {
 		return nil, errors.Wrap(err, "public key or cert")
 	}
-	if payloadFormat == "in-toto" {
+	if _, ok := formats.IntotoAttestationSet[config.PayloadType(payloadFormat)]; ok {
 		return cosign.TLogUploadInTotoAttestation(ctx, r.c, signature, pkoc)
 	}
 	return cosign.TLogUpload(ctx, r.c, signature, rawPayload, pkoc)

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -229,7 +229,7 @@ func TestSigner_Transparency(t *testing.T) {
 			cfg: &config.Config{
 				Artifacts: config.ArtifactConfigs{
 					TaskRuns: config.Artifact{
-						Format:         "in-toto",
+						Format:         "slsa/v1",
 						StorageBackend: sets.NewString("mock"),
 						Signer:         "x509",
 					},
@@ -245,7 +245,7 @@ func TestSigner_Transparency(t *testing.T) {
 			cfg: &config.Config{
 				Artifacts: config.ArtifactConfigs{
 					PipelineRuns: config.Artifact{
-						Format:         "in-toto",
+						Format:         "slsa/v1",
 						StorageBackend: sets.NewString("mock"),
 						Signer:         "x509",
 					},

--- a/pkg/chains/storage/gcs/gcs_test.go
+++ b/pkg/chains/storage/gcs/gcs_test.go
@@ -56,7 +56,7 @@ func TestBackend_StorePayload(t *testing.T) {
 				},
 				signed:    []byte("signed"),
 				signature: "signature",
-				opts:      config.StorageOpts{ShortKey: "foo.uuid", PayloadFormat: formats.PayloadTypeInTotoIte6},
+				opts:      config.StorageOpts{ShortKey: "foo.uuid", PayloadFormat: formats.PayloadTypeSlsav1},
 			},
 		},
 		{

--- a/pkg/chains/storage/grafeas/grafeas.go
+++ b/pkg/chains/storage/grafeas/grafeas.go
@@ -90,7 +90,7 @@ func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, cfg confi
 // StorePayload implements the storage.Backend interface.
 func (b *Backend) StorePayload(ctx context.Context, obj objects.TektonObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
 	// We only support simplesigning for OCI images, and in-toto for taskrun & pipelinerun.
-	if opts.PayloadFormat != formats.PayloadTypeInTotoIte6 && opts.PayloadFormat != formats.PayloadTypeSimpleSigning {
+	if _, ok := formats.IntotoAttestationSet[opts.PayloadFormat]; !ok && opts.PayloadFormat != formats.PayloadTypeSimpleSigning {
 		return errors.New("Grafeas storage backend only supports simplesigning and intoto payload format.")
 	}
 
@@ -386,7 +386,7 @@ func (b *Backend) getAllOccurrences(ctx context.Context, obj objects.TektonObjec
 	uriFilters := extract.RetrieveAllArtifactURIs(obj, b.logger)
 
 	// step 2: find all build occurrences
-	if opts.PayloadFormat == formats.PayloadTypeInTotoIte6 {
+	if _, ok := formats.IntotoAttestationSet[opts.PayloadFormat]; ok {
 		occs, err := b.findOccurrencesForCriteria(ctx, b.getBuildNotePath(obj), uriFilters)
 		if err != nil {
 			return nil, err

--- a/pkg/chains/storage/grafeas/grafeas_test.go
+++ b/pkg/chains/storage/grafeas/grafeas_test.go
@@ -264,7 +264,7 @@ func TestGrafeasBackend_StoreAndRetrieve(t *testing.T) {
 				},
 				payload:   getRawPayload(t, cloneTaskRunProvenance),
 				signature: "clone taskrun signatures",
-				opts:      config.StorageOpts{PayloadFormat: formats.PayloadTypeInTotoIte6},
+				opts:      config.StorageOpts{PayloadFormat: formats.PayloadTypeSlsav1},
 			},
 			wantOccurrences: nil,
 			wantErr:         false,
@@ -277,7 +277,7 @@ func TestGrafeasBackend_StoreAndRetrieve(t *testing.T) {
 				},
 				payload:   getRawPayload(t, buildTaskRunProvenance),
 				signature: "build taskrun signature",
-				opts:      config.StorageOpts{PayloadFormat: formats.PayloadTypeInTotoIte6},
+				opts:      config.StorageOpts{PayloadFormat: formats.PayloadTypeSlsav1},
 			},
 			wantOccurrences: []*pb.Occurrence{getTaskRunBuildOcc(t, artifactIdentifier1), getTaskRunBuildOcc(t, artifactIdentifier2)},
 			wantErr:         false,
@@ -303,7 +303,7 @@ func TestGrafeasBackend_StoreAndRetrieve(t *testing.T) {
 				},
 				payload:   getRawPayload(t, ciPipelineRunProvenance),
 				signature: "ci pipelinerun signature",
-				opts:      config.StorageOpts{PayloadFormat: formats.PayloadTypeInTotoIte6},
+				opts:      config.StorageOpts{PayloadFormat: formats.PayloadTypeSlsav1},
 			},
 			wantOccurrences: []*pb.Occurrence{getPipelineRunBuildOcc(t, artifactIdentifier1), getPipelineRunBuildOcc(t, artifactIdentifier2)},
 			wantErr:         false,
@@ -397,7 +397,7 @@ func testStoreAndRetrieveHelper(ctx context.Context, t *testing.T, test testConf
 	if test.args.opts.PayloadFormat == formats.PayloadTypeSimpleSigning {
 		expectSignature[test.args.opts.FullKey] = []string{test.args.signature}
 	}
-	if test.args.opts.PayloadFormat == formats.PayloadTypeInTotoIte6 {
+	if _, ok := formats.IntotoAttestationSet[test.args.opts.PayloadFormat]; ok {
 		allURIs := extract.RetrieveAllArtifactURIs(test.args.runObject, backend.logger)
 		for _, u := range allURIs {
 			expectSignature[u] = []string{test.args.signature}
@@ -419,7 +419,7 @@ func testStoreAndRetrieveHelper(ctx context.Context, t *testing.T, test testConf
 	if test.args.opts.PayloadFormat == formats.PayloadTypeSimpleSigning {
 		expectPayload[test.args.opts.FullKey] = string(test.args.payload)
 	}
-	if test.args.opts.PayloadFormat == formats.PayloadTypeInTotoIte6 {
+	if _, ok := formats.IntotoAttestationSet[test.args.opts.PayloadFormat]; ok {
 		allURIs := extract.RetrieveAllArtifactURIs(test.args.runObject, backend.logger)
 		for _, u := range allURIs {
 			expectPayload[u] = string(test.args.payload)

--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -88,7 +88,7 @@ func (b *Backend) StorePayload(ctx context.Context, obj objects.TektonObject, ra
 		return b.uploadSignature(format, rawPayload, signature, storageOpts, auth)
 	}
 
-	if storageOpts.PayloadFormat == formats.PayloadTypeInTotoIte6 {
+	if _, ok := formats.IntotoAttestationSet[storageOpts.PayloadFormat]; ok {
 		attestation := in_toto.Statement{}
 		if err := json.Unmarshal(rawPayload, &attestation); err != nil {
 			return errors.Wrap(err, "unmarshal attestation")

--- a/pkg/chains/storage/oci/oci_test.go
+++ b/pkg/chains/storage/oci/oci_test.go
@@ -136,7 +136,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			payload:   intotoStatement,
 			signature: "into-to",
 			storageOpts: config.StorageOpts{
-				PayloadFormat: "in-toto",
+				PayloadFormat: formats.PayloadTypeSlsav1,
 			},
 		},
 		wantErr: false,
@@ -149,7 +149,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			payload:   in_toto.Statement{},
 			signature: "",
 			storageOpts: config.StorageOpts{
-				PayloadFormat: "in-toto",
+				PayloadFormat: formats.PayloadTypeSlsav1,
 			},
 		},
 		wantErr: false,
@@ -175,7 +175,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			payload:   intotoStatement,
 			signature: "into-to",
 			storageOpts: config.StorageOpts{
-				PayloadFormat: "in-toto",
+				PayloadFormat: formats.PayloadTypeSlsav1,
 			},
 		},
 		wantErr: false,
@@ -188,7 +188,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			payload:   simple,
 			signature: "",
 			storageOpts: config.StorageOpts{
-				PayloadFormat: "in-toto",
+				PayloadFormat: formats.PayloadTypeSlsav1,
 			},
 		},
 		wantErr: false,
@@ -214,7 +214,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			payload:   in_toto.Statement{},
 			signature: "",
 			storageOpts: config.StorageOpts{
-				PayloadFormat: "in-toto",
+				PayloadFormat: formats.PayloadTypeSlsav1,
 			},
 		},
 		wantErr: false,

--- a/pkg/chains/storage/pubsub/pubsub_test.go
+++ b/pkg/chains/storage/pubsub/pubsub_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -71,7 +72,7 @@ func TestBackend_StorePayload(t *testing.T) {
 				rawPayload: sampleIntotoStatementBytes,
 				signature:  "signature",
 				storageOpts: config.StorageOpts{
-					PayloadFormat: "in-toto",
+					PayloadFormat: formats.PayloadTypeSlsav1,
 				},
 			},
 			wantErr: false,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -250,12 +250,12 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	if err := cm.Parse(data,
 		// Artifact-specific configs
 		// TaskRuns
-		asString(taskrunFormatKey, &cfg.Artifacts.TaskRuns.Format, "in-toto"),
+		asString(taskrunFormatKey, &cfg.Artifacts.TaskRuns.Format, "in-toto", "slsa/v1"),
 		asStringSet(taskrunStorageKey, &cfg.Artifacts.TaskRuns.StorageBackend, sets.NewString("tekton", "oci", "gcs", "docdb", "grafeas", "kafka")),
 		asString(taskrunSignerKey, &cfg.Artifacts.TaskRuns.Signer, "x509", "kms"),
 
 		// PipelineRuns
-		asString(pipelinerunFormatKey, &cfg.Artifacts.PipelineRuns.Format, "in-toto"),
+		asString(pipelinerunFormatKey, &cfg.Artifacts.PipelineRuns.Format, "in-toto", "slsa/v1"),
 		asStringSet(pipelinerunStorageKey, &cfg.Artifacts.PipelineRuns.StorageBackend, sets.NewString("tekton", "oci", "grafeas")),
 		asString(pipelinerunSignerKey, &cfg.Artifacts.PipelineRuns.Signer, "x509", "kms"),
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -312,7 +312,7 @@ func TestFulcio(t *testing.T) {
 	resetConfig := setConfigMap(ctx, t, c, map[string]string{
 		"artifacts.taskrun.storage":   "tekton",
 		"artifacts.taskrun.signer":    "x509",
-		"artifacts.taskrun.format":    "in-toto",
+		"artifacts.taskrun.format":    "slsa/v1",
 		"artifacts.oci.signer":        "x509",
 		"signers.x509.fulcio.enabled": "true",
 		"transparency.enabled":        "false",
@@ -404,7 +404,7 @@ func TestOCIStorage(t *testing.T) {
 		"artifacts.oci.format":            "simplesigning",
 		"artifacts.oci.storage":           "oci",
 		"artifacts.oci.signer":            "x509",
-		"artifacts.taskrun.format":        "in-toto",
+		"artifacts.taskrun.format":        "slsa/v1",
 		"artifacts.taskrun.signer":        "x509",
 		"artifacts.taskrun.storage":       "oci",
 		"storage.oci.repository.insecure": "true",
@@ -459,7 +459,7 @@ func TestMultiBackendStorage(t *testing.T) {
 				"artifacts.oci.format":            "simplesigning",
 				"artifacts.oci.storage":           "tekton,oci",
 				"artifacts.oci.signer":            "x509",
-				"artifacts.taskrun.format":        "in-toto",
+				"artifacts.taskrun.format":        "slsa/v1",
 				"artifacts.taskrun.signer":        "x509",
 				"artifacts.taskrun.storage":       "tekton,oci",
 				"storage.oci.repository.insecure": "true",
@@ -469,7 +469,7 @@ func TestMultiBackendStorage(t *testing.T) {
 		{
 			name: "pipelinerun",
 			cm: map[string]string{
-				"artifacts.pipelinerun.format":    "in-toto",
+				"artifacts.pipelinerun.format":    "slsa/v1",
 				"artifacts.pipelinerun.signer":    "x509",
 				"artifacts.pipelinerun.storage":   "tekton,oci",
 				"storage.oci.repository.insecure": "true",
@@ -546,7 +546,7 @@ func TestRetryFailed(t *testing.T) {
 				"transparency.url":              "doesnotexist",
 				"transparency.enabled":          "true",
 				"artifacts.pipelinerun.storage": "tekton",
-				"artifacts.pipelinerun.format":  "in-toto",
+				"artifacts.pipelinerun.format":  "slsa/v1",
 			},
 			opts: setupOpts{
 				registry:        true,
@@ -693,7 +693,7 @@ func TestProvenanceMaterials(t *testing.T) {
 		{
 			name: "taskrun",
 			cm: map[string]string{
-				"artifacts.taskrun.format":  "in-toto",
+				"artifacts.taskrun.format":  "slsa/v1",
 				"artifacts.taskrun.signer":  "x509",
 				"artifacts.taskrun.storage": "tekton",
 			},
@@ -703,7 +703,7 @@ func TestProvenanceMaterials(t *testing.T) {
 		{
 			name: "pipelinerun",
 			cm: map[string]string{
-				"artifacts.pipelinerun.format":  "in-toto",
+				"artifacts.pipelinerun.format":  "slsa/v1",
 				"artifacts.pipelinerun.signer":  "x509",
 				"artifacts.pipelinerun.storage": "tekton",
 			},

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -67,7 +67,7 @@ func TestExamples(t *testing.T) {
 		{
 			name: "taskrun-examples",
 			cm: map[string]string{
-				"artifacts.taskrun.format": "in-toto",
+				"artifacts.taskrun.format": "slsa/v1",
 				"artifacts.oci.storage":    "tekton",
 			},
 			getExampleObjects: getTaskRunExamples,
@@ -77,7 +77,7 @@ func TestExamples(t *testing.T) {
 		{
 			name: "pipelinerun-examples",
 			cm: map[string]string{
-				"artifacts.pipelinerun.format":  "in-toto",
+				"artifacts.pipelinerun.format":  "slsa/v1",
 				"artifacts.pipelinerun.storage": "tekton",
 			},
 			getExampleObjects: getPipelineRunExamples,


### PR DESCRIPTION
This PR adds a new format `slsa/v1` which generates the same provenance as that generated when requesting `in-toto` format. The unit tests and documentation have been updated to use the new branding.

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
SLSA branding of the tekton generated provenance format. 
```
/kind feature