### PR TITLE
Add labels and annotations to attestation

### DIFF
--- a/docs/intoto.md
+++ b/docs/intoto.md
@@ -454,3 +454,17 @@ results:
                digest: sha256@89dedecaca1b85346600c7db9939a4fe090a42ez
 ```
 
+### Invocation Environment
+
+TaskRun attestations include the annotations and labels of the underlying TaskRun resource. The
+same is true for PipelineRun attestations. These are included under the path
+`.predicate.invocation.environment.annotations` and `.predicate.invocation.environment.labels`
+repectively.
+
+PipelineRun attestations also include the annotations and labels of the TaskRuns used at
+`.predicate.buildConfig.tasks[].invocation.environment`.
+
+The following annotations are always excluded:
+
+* `kubectl.kubernetes.io/last-applied-configuration`
+* Annotations starting with `chains.tekton.dev/`

--- a/pkg/chains/formats/slsa/v1/intotoite6_test.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6_test.go
@@ -96,6 +96,9 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 					"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 					"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 				},
+				Environment: map[string]map[string]string{
+					"labels": {"tekton.dev/pipelineTask": "build"},
+				},
 			},
 			Builder: slsa.ProvenanceBuilder{
 				ID: "test_builder-1",
@@ -245,6 +248,9 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 								"revision":          {Type: "string", StringVal: ""},
 								"url":               {Type: "string", StringVal: "https://git.test.com"},
 							},
+							Environment: map[string]map[string]string{
+								"labels": {"tekton.dev/pipelineTask": "git-clone"},
+							},
 						},
 						Results: []v1beta1.TaskRunResult{
 							{
@@ -312,6 +318,9 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 								"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
+							},
+							Environment: map[string]map[string]string{
+								"labels": {"tekton.dev/pipelineTask": "build"},
 							},
 						},
 						Results: []v1beta1.TaskRunResult{
@@ -457,6 +466,9 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 								"revision":          {Type: "string", StringVal: ""},
 								"url":               {Type: "string", StringVal: "https://git.test.com"},
 							},
+							Environment: map[string]map[string]string{
+								"labels": {"tekton.dev/pipelineTask": "git-clone"},
+							},
 						},
 						Results: []v1beta1.TaskRunResult{
 							{
@@ -524,6 +536,9 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 								"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
+							},
+							Environment: map[string]map[string]string{
+								"labels": {"tekton.dev/pipelineTask": "build"},
 							},
 						},
 						Results: []v1beta1.TaskRunResult{
@@ -615,6 +630,9 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 					"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 					"revision":          {Type: "string"},
 					"url":               {Type: "string", StringVal: "https://git.test.com"},
+				},
+				Environment: map[string]map[string]string{
+					"labels": {"tekton.dev/pipelineTask": "git-clone"},
 				},
 			},
 			BuildType: "tekton.dev/v1beta1/TaskRun",

--- a/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
@@ -82,7 +82,7 @@ func invocation(pro *objects.PipelineRunObject) slsa.ProvenanceInvocation {
 	if p := pro.Status.Provenance; p != nil {
 		source = p.ConfigSource
 	}
-	return attest.Invocation(source, pro.Spec.Params, paramSpecs)
+	return attest.Invocation(source, pro.Spec.Params, paramSpecs, pro.GetObjectMeta())
 }
 
 func buildConfig(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) BuildConfig {
@@ -153,7 +153,7 @@ func buildConfig(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) Buil
 			FinishedOn: tr.Status.CompletionTime.Time.UTC(),
 			Status:     getStatus(tr.Status.Conditions),
 			Steps:      steps,
-			Invocation: attest.Invocation(source, params, paramSpecs),
+			Invocation: attest.Invocation(source, params, paramSpecs, &tr.ObjectMeta),
 			Results:    tr.Status.TaskRunResults,
 		}
 

--- a/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
@@ -116,6 +116,9 @@ func TestBuildConfig(t *testing.T) {
 						"revision":          {Type: "string", StringVal: ""},
 						"url":               {Type: "string", StringVal: "https://git.test.com"},
 					},
+					Environment: map[string]map[string]string{
+						"labels": {"tekton.dev/pipelineTask": "git-clone"},
+					},
 				},
 				Results: []v1beta1.TaskRunResult{
 					{
@@ -183,6 +186,9 @@ func TestBuildConfig(t *testing.T) {
 						"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 						"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 						"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
+					},
+					Environment: map[string]map[string]string{
+						"labels": {"tekton.dev/pipelineTask": "build"},
 					},
 				},
 				Results: []v1beta1.TaskRunResult{
@@ -300,6 +306,11 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 								"url":               {Type: "string", StringVal: "https://git.test.com"},
 								"revision":          {Type: "string", StringVal: ""},
 							},
+							Environment: map[string]map[string]string{
+								"labels": {
+									"tekton.dev/pipelineTask": "git-clone",
+								},
+							},
 						},
 						Results: []v1beta1.TaskRunResult{
 							{
@@ -369,6 +380,11 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 								"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
+							},
+							Environment: map[string]map[string]string{
+								"labels": {
+									"tekton.dev/pipelineTask": "build",
+								},
 							},
 						},
 						Results: []v1beta1.TaskRunResult{

--- a/pkg/chains/formats/slsa/v1/taskrun/provenance_test.go
+++ b/pkg/chains/formats/slsa/v1/taskrun/provenance_test.go
@@ -106,6 +106,14 @@ func TestInvocation(t *testing.T) {
 kind: TaskRun
 metadata:
   uid: my-uid
+  annotations:
+    ann1: ann-one
+    ann2: ann-two
+    kubectl.kubernetes.io/last-applied-configuration: ignored
+    chains.tekton.dev/any: "ignored"
+  labels:
+    label1: label-one
+    label2: label-two
 spec:
   params:
   - name: my-param
@@ -165,6 +173,16 @@ status:
 			"my-empty-array-param":          {Type: "array", ArrayVal: []string{}},
 			"my-default-empty-string-param": {Type: "string", StringVal: ""},
 			"my-default-empty-array-param":  {Type: "array", ArrayVal: []string{}},
+		},
+		Environment: map[string]map[string]string{
+			"annotations": {
+				"ann1": "ann-one",
+				"ann2": "ann-two",
+			},
+			"labels": {
+				"label1": "label-one",
+				"label2": "label-two",
+			},
 		},
 	}
 

--- a/pkg/chains/formats/slsa/v1/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v1/taskrun/taskrun.go
@@ -62,7 +62,7 @@ func invocation(tro *objects.TaskRunObject) slsa.ProvenanceInvocation {
 	if p := tro.Status.Provenance; p != nil {
 		source = p.ConfigSource
 	}
-	return attest.Invocation(source, tro.Spec.Params, paramSpecs)
+	return attest.Invocation(source, tro.Spec.Params, paramSpecs, tro.GetObjectMeta())
 }
 
 func metadata(tro *objects.TaskRunObject) *slsa.ProvenanceMetadata {


### PR DESCRIPTION
Fixes #591

# Changes

Labels and annotations are added to the PipelineRun and TaskRun attestations in `.predicate.invocation.environment`. Additionally, for PipelineRun attestations, each task also contains its own `.invocation.environment` with the corresponding labels and annotations.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
- Annotations and labels are included in the attestation.
```
