### PR TITLE
Do not initialize Rekor client if transparency is not enabled. Issue #520

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Current features include:
 - Signing `TaskRun` results with user provided cryptographic keys, including
   `TaskRun`s themselves and OCI Images
 - Attestation formats like [intoto](docs/intoto.md)
-- Signing with a variety of cryptograhic key types and services (x509, KMS)
+- Signing with a variety of cryptographic key types and services (x509, KMS)
 - Support for multiple storage backends for signatures
 
 ### Installation

--- a/config/100-deployment.yaml
+++ b/config/100-deployment.yaml
@@ -48,6 +48,8 @@ metadata:
 #   artifacts.oci.storage: oci
 #   artifacts.oci.format: simplesigning
 #   artifacts.oci.signer: x509
+#   transparency.enabled: false
+#   transparency.url: https://rekor.sigstore.dev
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/pkg/chains/rekor.go
+++ b/pkg/chains/rekor.go
@@ -68,7 +68,6 @@ func publicKeyOrCert(signer signing.Signer, cert string) ([]byte, error) {
 	return pem, nil
 }
 
-// for testing
 var getRekor = func(url string, l *zap.SugaredLogger) (rekorClient, error) {
 	rekorClient, err := rc.GetRekorClient(url)
 	if err != nil {

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -112,11 +112,6 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 
 	signers := allSigners(ctx, o.SecretPath, cfg, logger)
 
-	rekorClient, err := getRekor(cfg.Transparency.URL, logger)
-	if err != nil {
-		return err
-	}
-
 	var merr *multierror.Error
 	extraAnnotations := map[string]string{}
 	for _, signableType := range signableTypes {
@@ -192,6 +187,11 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 			}
 
 			if shouldUploadTlog(cfg, tektonObj) {
+				rekorClient, err := getRekor(cfg.Transparency.URL, logger)
+				if err != nil {
+					return err
+				}
+
 				entry, err := rekorClient.UploadTlog(ctx, signer, signature, rawPayload, signer.Cert(), string(payloadFormat))
 				if err != nil {
 					merr = multierror.Append(merr, err)

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -138,8 +138,6 @@ func TestSigner_Sign(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cleanup := setupMocks(&mockRekor{})
-			defer cleanup()
 
 			ctx, _ := rtesting.SetupFakeContext(t)
 			ps := fakepipelineclient.Get(ctx)


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
Issue #520 
Moved the initalization of rekorClient to be gated inside the shouldUploadTlog function to ensure transparency is enabled

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
