### PR TITLE
Fix getting started docs for intoto verification.

### DIFF
--- a/docs/tutorials/getting-started-tutorial.md
+++ b/docs/tutorials/getting-started-tutorial.md
@@ -82,14 +82,13 @@ base64-encoded annotations):
 
 ```shell
 export TASKRUN_UID=$(tkn tr describe --last -o  jsonpath='{.metadata.uid}')
-tkn tr describe --last -o jsonpath="{.metadata.annotations.chains\.tekton\.dev/signature-taskrun-$TASKRUN_UID}" > signature
-tkn tr describe --last -o jsonpath="{.metadata.annotations.chains\.tekton\.dev/payload-taskrun-$TASKRUN_UID}" | base64 -d > payload
+tkn tr describe --last -o jsonpath="{.metadata.annotations.chains\.tekton\.dev/signature-taskrun-$TASKRUN_UID}" | base64 -d > sig
 ```
 
 Finally, we can check the signature with [cosign]:
 
 ```shell
-$ cosign verify-blob --key k8s://tekton-chains/signing-secrets --signature ./signature ./payload
+$ cosign verify-blob --key k8s://tekton-chains/signing-secrets --signature sig sig
 Verified OK
 ```
 


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Since intoto uses DSSE and DSSE requires a checksum over the payload + type, we need to use the whole signature for verification.

See https://github.com/secure-systems-lab/dsse/blob/master/protocol.md#protocol for more details.

Fixes #698 

NOTE: This breaks with the cosign v2 rc. We're looking into this upstream. 👀 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
