### PR TITLE
[TEP0122] Add feature flags field to Invocation.Environment

### DIFF
--- a/pkg/chains/formats/slsa/v2/taskrun/taskrun_test.go
+++ b/pkg/chains/formats/slsa/v2/taskrun/taskrun_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
 	slsav1 "github.com/tektoncd/chains/pkg/chains/formats/slsa/v1/taskrun"
 	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
@@ -152,6 +153,16 @@ status:
     - name: my-default-empty-array-param
       type: array
       default: []
+  provenance:
+    featureFlags:
+      AwaitSidecarReadiness: true
+      CustomTaskVersion: v1beta1
+      EnableAPIFields: stable
+      EnableProvenanceInStatus: true
+      MaxResultSize: 4096
+      ResourceVerificationMode: skip
+      ResultExtractionMethod: termination-message
+      RunningInEnvWithInjectedSidecars: true
 `
 
 	var taskRun *v1beta1.TaskRun
@@ -188,6 +199,18 @@ status:
 			"StepOverrides":      []v1beta1.TaskRunStepOverride(nil),
 			"Timeout":            (*metav1.Duration)(nil),
 			"Workspaces":         []v1beta1.WorkspaceBinding(nil),
+		},
+		Environment: map[string]any{
+			"tekton-pipelines-feature-flags": &config.FeatureFlags{
+				RunningInEnvWithInjectedSidecars: true,
+				EnableAPIFields:                  "stable",
+				AwaitSidecarReadiness:            true,
+				ResourceVerificationMode:         "skip",
+				EnableProvenanceInStatus:         true,
+				ResultExtractionMethod:           "termination-message",
+				MaxResultSize:                    4096,
+				CustomTaskVersion:                "v1beta1",
+			},
 		},
 	}
 	got := invocation(objects.NewTaskRunObject(taskRun))


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

For completeness of build instructions, Tekton Chains needs to pick up the feature flags used for the build. This PR adds it to `invocation.Environment` section of the slsav0.2 predicate. Like ConfigSource, this field is only populated if the feature flag: `enable-provenance-in-status` is set to `"true"`.

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Add feature flags field to Invocation.Environment
```
/kind feature