### PR TITLE
Export builderID in SLSA formatter

### DIFF
--- a/pkg/chains/formats/slsa/v1/intotoite6.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6.go
@@ -39,12 +39,12 @@ func init() {
 }
 
 type InTotoIte6 struct {
-	builderID string
+	BuilderID string
 }
 
 func NewFormatter(cfg config.Config) (formats.Payloader, error) {
 	return &InTotoIte6{
-		builderID: cfg.Builder.ID,
+		BuilderID: cfg.Builder.ID,
 	}, nil
 }
 
@@ -56,9 +56,9 @@ func (i *InTotoIte6) CreatePayload(ctx context.Context, obj interface{}) (interf
 	logger := logging.FromContext(ctx)
 	switch v := obj.(type) {
 	case *objects.TaskRunObject:
-		return taskrun.GenerateAttestation(i.builderID, v, logger)
+		return taskrun.GenerateAttestation(i.BuilderID, v, logger)
 	case *objects.PipelineRunObject:
-		return pipelinerun.GenerateAttestation(i.builderID, v, logger)
+		return pipelinerun.GenerateAttestation(i.BuilderID, v, logger)
 	default:
 		return nil, fmt.Errorf("intoto does not support type: %s", v)
 	}

--- a/pkg/chains/formats/slsa/v2/slsav2.go
+++ b/pkg/chains/formats/slsa/v2/slsav2.go
@@ -35,12 +35,12 @@ func init() {
 }
 
 type Slsa struct {
-	builderID string
+	BuilderID string
 }
 
 func NewFormatter(cfg config.Config) (formats.Payloader, error) {
 	return &Slsa{
-		builderID: cfg.Builder.ID,
+		BuilderID: cfg.Builder.ID,
 	}, nil
 }
 
@@ -51,7 +51,7 @@ func (s *Slsa) Wrap() bool {
 func (s *Slsa) CreatePayload(ctx context.Context, obj interface{}) (interface{}, error) {
 	switch v := obj.(type) {
 	case *objects.TaskRunObject:
-		return taskrun.GenerateAttestation(s.builderID, s.Type(), v, ctx)
+		return taskrun.GenerateAttestation(s.BuilderID, s.Type(), v, ctx)
 	default:
 		return nil, fmt.Errorf("intoto does not support type: %s", v)
 	}


### PR DESCRIPTION


<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Export the `builderID` field in SLSA formatter. This will help vendors who only need the formatting service to set the builderID when creating a formatter.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)

# Release Notes

``` release-note
Export the builderID field in the SLSA formatters.
```
