### PR TITLE
Set metadata completeness for parameters as true for slsav2/alpha1

### DIFF
--- a/pkg/chains/formats/slsa/v2/slsav2_test.go
+++ b/pkg/chains/formats/slsa/v2/slsav2_test.go
@@ -73,6 +73,9 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 			Metadata: &slsa.ProvenanceMetadata{
 				BuildStartedOn:  &e1BuildStart,
 				BuildFinishedOn: &e1BuildFinished,
+				Completeness: slsa.ProvenanceComplete{
+					Parameters: true,
+				},
 			},
 			Materials: []common.ProvenanceMaterial{
 				{
@@ -190,6 +193,9 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 			Metadata: &slsa.ProvenanceMetadata{
 				BuildStartedOn:  &e1BuildStart,
 				BuildFinishedOn: &e1BuildFinished,
+				Completeness: slsa.ProvenanceComplete{
+					Parameters: true,
+				},
 			},
 			Builder: common.ProvenanceBuilder{
 				ID: "test_builder-2",
@@ -299,7 +305,11 @@ func TestMultipleSubjects(t *testing.T) {
 		},
 		Predicate: slsa.ProvenancePredicate{
 			BuildType: "https://chains.tekton.dev/format/slsa/v2alpha1/type/tekton.dev/v1beta1/TaskRun",
-			Metadata:  &slsa.ProvenanceMetadata{},
+			Metadata: &slsa.ProvenanceMetadata{
+				Completeness: slsa.ProvenanceComplete{
+					Parameters: true,
+				},
+			},
 			Builder: common.ProvenanceBuilder{
 				ID: "test_builder-multiple",
 			},

--- a/pkg/chains/formats/slsa/v2/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v2/taskrun/taskrun.go
@@ -59,11 +59,19 @@ func GenerateAttestation(builderID string, payloadType config.PayloadType, tro *
 			BuildType:   fmt.Sprintf("https://chains.tekton.dev/format/%v/type/%s", payloadType, tro.GetGVK()),
 			Invocation:  invocation(tro),
 			BuildConfig: BuildConfig{TaskSpec: tro.Status.TaskSpec, TaskRunResults: tro.Status.TaskRunResults},
-			Metadata:    slsav1.Metadata(tro),
+			Metadata:    metadata(tro),
 			Materials:   mat,
 		},
 	}
 	return att, nil
+}
+
+func metadata(tro *objects.TaskRunObject) *slsa.ProvenanceMetadata {
+	m := slsav1.Metadata(tro)
+	m.Completeness = slsa.ProvenanceComplete{
+		Parameters: true,
+	}
+	return m
 }
 
 // invocation describes the event that kicked off the build

--- a/test/testdata/slsa/v2/task-output-image.json
+++ b/test/testdata/slsa/v2/task-output-image.json
@@ -70,7 +70,7 @@
             "buildStartedOn": "{{index .BuildStartTimes 0}}",
             "buildFinishedOn": "{{index .BuildFinishedTimes 0}}",
             "completeness": {
-                "parameters": false,
+                "parameters": true,
                 "environment": false,
                 "materials": false
             },


### PR DESCRIPTION
[TEP 0122 - Complete Build Instructions](https://github.com/tektoncd/community/blob/main/teps/0122-complete-build-instructions-and-parameters.md) identified all missing run-time parameters. We have captured all the run time parameters and implemented it for `slsa/v2alpha1`.

This PR marks the `Metadata.Completeness.Parameters` as `true`.

This PR addresses Issue https://github.com/tektoncd/chains/issues/751

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Set metadata completeness for parameters as true for slsav2/alpha1
```
/kind feature