### PR TITLE
Use `common` package from intoto-golang.

### DIFF
--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	"github.com/opencontainers/go-digest"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
@@ -302,9 +302,9 @@ func extractTargetFromResults(obj objects.TektonObject, identifierSuffix string,
 }
 
 // RetrieveMaterialsFromStructuredResults retrieves structured results from Tekton Object, and convert them into materials.
-func RetrieveMaterialsFromStructuredResults(obj objects.TektonObject, categoryMarker string, logger *zap.SugaredLogger) []slsa.ProvenanceMaterial {
+func RetrieveMaterialsFromStructuredResults(obj objects.TektonObject, categoryMarker string, logger *zap.SugaredLogger) []common.ProvenanceMaterial {
 	// Retrieve structured provenance for inputs.
-	mats := []slsa.ProvenanceMaterial{}
+	mats := []common.ProvenanceMaterial{}
 	ssts := ExtractStructuredTargetFromResults(obj, ArtifactsInputsResultName, logger)
 	for _, s := range ssts {
 		if err := checkDigest(s.Digest); err != nil {
@@ -314,7 +314,7 @@ func RetrieveMaterialsFromStructuredResults(obj objects.TektonObject, categoryMa
 		splits := strings.Split(s.Digest, ":")
 		alg := splits[0]
 		digest := splits[1]
-		mats = append(mats, slsa.ProvenanceMaterial{
+		mats = append(mats, common.ProvenanceMaterial{
 			URI:    s.URI,
 			Digest: map[string]string{alg: digest},
 		})

--- a/pkg/artifacts/signable_test.go
+++ b/pkg/artifacts/signable_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-containerregistry/pkg/name"
-	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -524,7 +524,7 @@ func TestRetrieveMaterialsFromStructuredResults(t *testing.T) {
 			},
 		},
 	}
-	wantMaterials := []slsa.ProvenanceMaterial{
+	wantMaterials := []common.ProvenanceMaterial{
 		{
 			URI:    "gcr.io/foo/bar",
 			Digest: map[string]string{"sha256": "05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b7"},

--- a/pkg/chains/formats/slsa/extract/extract.go
+++ b/pkg/chains/formats/slsa/extract/extract.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
-	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -46,7 +46,7 @@ func SubjectDigests(obj objects.TektonObject, logger *zap.SugaredLogger) []intot
 		if d, ok := i.(name.Digest); ok {
 			subjects = append(subjects, intoto.Subject{
 				Name: d.Repository.Name(),
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": strings.TrimPrefix(d.DigestStr(), "sha256:"),
 				},
 			})
@@ -62,7 +62,7 @@ func SubjectDigests(obj objects.TektonObject, logger *zap.SugaredLogger) []intot
 		}
 		subjects = append(subjects, intoto.Subject{
 			Name: obj.URI,
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				splits[0]: splits[1],
 			},
 		})
@@ -75,7 +75,7 @@ func SubjectDigests(obj objects.TektonObject, logger *zap.SugaredLogger) []intot
 		digest := splits[1]
 		subjects = append(subjects, intoto.Subject{
 			Name: s.URI,
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				alg: digest,
 			},
 		})
@@ -113,7 +113,7 @@ func SubjectDigests(obj objects.TektonObject, logger *zap.SugaredLogger) []intot
 			}
 			subjects = append(subjects, intoto.Subject{
 				Name: url,
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": strings.TrimPrefix(digest, "sha256:"),
 				},
 			})

--- a/pkg/chains/formats/slsa/internal/material/material.go
+++ b/pkg/chains/formats/slsa/internal/material/material.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/attest"
 	"github.com/tektoncd/chains/pkg/chains/objects"
@@ -36,7 +36,7 @@ const (
 )
 
 // AddStepImagesToMaterials adds step images to predicate.materials
-func AddStepImagesToMaterials(steps []v1beta1.StepState, mats *[]slsa.ProvenanceMaterial) error {
+func AddStepImagesToMaterials(steps []v1beta1.StepState, mats *[]common.ProvenanceMaterial) error {
 	for _, stepState := range steps {
 		if err := AddImageIDToMaterials(stepState.ImageID, mats); err != nil {
 			return err
@@ -46,7 +46,7 @@ func AddStepImagesToMaterials(steps []v1beta1.StepState, mats *[]slsa.Provenance
 }
 
 // AddSidecarImagesToMaterials adds sidecar images to predicate.materials
-func AddSidecarImagesToMaterials(sidecars []v1beta1.SidecarState, mats *[]slsa.ProvenanceMaterial) error {
+func AddSidecarImagesToMaterials(sidecars []v1beta1.SidecarState, mats *[]common.ProvenanceMaterial) error {
 	for _, sidecarState := range sidecars {
 		if err := AddImageIDToMaterials(sidecarState.ImageID, mats); err != nil {
 			return err
@@ -56,9 +56,9 @@ func AddSidecarImagesToMaterials(sidecars []v1beta1.SidecarState, mats *[]slsa.P
 }
 
 // AddImageIDToMaterials converts an imageId with format <uri>@sha256:<digest> and then adds it to a provenance materials.
-func AddImageIDToMaterials(imageID string, mats *[]slsa.ProvenanceMaterial) error {
-	m := slsa.ProvenanceMaterial{
-		Digest: slsa.DigestSet{},
+func AddImageIDToMaterials(imageID string, mats *[]common.ProvenanceMaterial) error {
+	m := common.ProvenanceMaterial{
+		Digest: common.DigestSet{},
 	}
 	uriDigest := strings.Split(imageID, uriSeparator)
 	if len(uriDigest) == 2 {
@@ -79,8 +79,8 @@ func AddImageIDToMaterials(imageID string, mats *[]slsa.ProvenanceMaterial) erro
 }
 
 // Materials constructs `predicate.materials` section by collecting all the artifacts that influence a taskrun such as source code repo and step&sidecar base images.
-func Materials(tro *objects.TaskRunObject, logger *zap.SugaredLogger) ([]slsa.ProvenanceMaterial, error) {
-	var mats []slsa.ProvenanceMaterial
+func Materials(tro *objects.TaskRunObject, logger *zap.SugaredLogger) ([]common.ProvenanceMaterial, error) {
+	var mats []common.ProvenanceMaterial
 
 	// add step images
 	if err := AddStepImagesToMaterials(tro.Status.Steps, &mats); err != nil {
@@ -96,7 +96,7 @@ func Materials(tro *objects.TaskRunObject, logger *zap.SugaredLogger) ([]slsa.Pr
 
 	// Store git rev as Materials and Recipe.Material
 	if gitCommit != "" && gitURL != "" {
-		mats = append(mats, slsa.ProvenanceMaterial{
+		mats = append(mats, common.ProvenanceMaterial{
 			URI:    gitURL,
 			Digest: map[string]string{"sha1": gitCommit},
 		})
@@ -113,8 +113,8 @@ func Materials(tro *objects.TaskRunObject, logger *zap.SugaredLogger) ([]slsa.Pr
 				continue
 			}
 
-			m := slsa.ProvenanceMaterial{
-				Digest: slsa.DigestSet{},
+			m := common.ProvenanceMaterial{
+				Digest: common.DigestSet{},
 			}
 
 			for _, rr := range tro.Status.ResourcesResult {
@@ -195,8 +195,8 @@ func gitInfo(tro *objects.TaskRunObject) (commit string, url string) {
 
 // RemoveDuplicateMaterials removes duplicate materials from the slice of materials.
 // Original order of materials is retained.
-func RemoveDuplicateMaterials(mats []slsa.ProvenanceMaterial) ([]slsa.ProvenanceMaterial, error) {
-	out := make([]slsa.ProvenanceMaterial, 0, len(mats))
+func RemoveDuplicateMaterials(mats []common.ProvenanceMaterial) ([]common.ProvenanceMaterial, error) {
+	out := make([]common.ProvenanceMaterial, 0, len(mats))
 
 	// make map to store seen materials
 	seen := map[string]bool{}

--- a/pkg/chains/formats/slsa/internal/material/material_test.go
+++ b/pkg/chains/formats/slsa/internal/material/material_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
-	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -56,10 +56,10 @@ status:
 		t.Fatal(err)
 	}
 
-	want := []slsa.ProvenanceMaterial{
+	want := []common.ProvenanceMaterial{
 		{
 			URI: "git+https://github.com/GoogleContainerTools/distroless.git",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha1": "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
 			},
 		},
@@ -78,7 +78,7 @@ func TestMaterials(t *testing.T) {
 	tests := []struct {
 		name    string
 		taskRun *v1beta1.TaskRun
-		want    []slsa.ProvenanceMaterial
+		want    []common.ProvenanceMaterial
 	}{{
 		name: "materials from pipeline resources",
 		taskRun: &v1beta1.TaskRun{
@@ -128,16 +128,16 @@ func TestMaterials(t *testing.T) {
 				},
 			},
 		},
-		want: []slsa.ProvenanceMaterial{
+		want: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/foo/bar",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": strings.TrimPrefix(digest, "sha256:"),
 				},
 			},
 			{
 				URI: "git+https://github.com/GoogleContainerTools/distroless.git",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha1": "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
 				},
 			},
@@ -155,10 +155,10 @@ func TestMaterials(t *testing.T) {
 				}},
 			},
 		},
-		want: []slsa.ProvenanceMaterial{
+		want: []common.ProvenanceMaterial{
 			{
 				URI: "git+github.com/something.git",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha1": "my-commit",
 				},
 			},
@@ -181,16 +181,16 @@ func TestMaterials(t *testing.T) {
 				},
 			},
 		},
-		want: []slsa.ProvenanceMaterial{
+		want: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 			{
 				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},
 			},
@@ -217,20 +217,20 @@ func TestMaterials(t *testing.T) {
 				},
 			},
 		},
-		want: []slsa.ProvenanceMaterial{
+		want: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			}, {
 				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},
 			}, {
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/sidecar-git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "a1234f6e7a69617db57b685893256f978436277094c21d43b153994acd8a09567",
 				},
 			},
@@ -253,7 +253,7 @@ func TestAddStepImagesToMaterials(t *testing.T) {
 	tests := []struct {
 		name      string
 		steps     []v1beta1.StepState
-		want      []slsa.ProvenanceMaterial
+		want      []common.ProvenanceMaterial
 		wantError error
 	}{{
 		name: "steps with proper imageID",
@@ -267,22 +267,22 @@ func TestAddStepImagesToMaterials(t *testing.T) {
 			Name:    "build",
 			ImageID: "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 		}},
-		want: []slsa.ProvenanceMaterial{
+		want: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 			{
 				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},
 			},
@@ -293,7 +293,7 @@ func TestAddStepImagesToMaterials(t *testing.T) {
 			Name:    "git-source-repo-jwqcl",
 			ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init-sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 		}},
-		want:      []slsa.ProvenanceMaterial{{}},
+		want:      []common.ProvenanceMaterial{{}},
 		wantError: fmt.Errorf("expected imageID gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init-sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247 to be separable by @"),
 	}, {
 		name: "step with bad imageId - no digest",
@@ -301,11 +301,11 @@ func TestAddStepImagesToMaterials(t *testing.T) {
 			Name:    "git-source-repo-jwqcl",
 			ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256-b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 		}},
-		want:      []slsa.ProvenanceMaterial{{}},
+		want:      []common.ProvenanceMaterial{{}},
 		wantError: fmt.Errorf("expected imageID gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256-b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247 to be separable by @ and :"),
 	}}
 	for _, tc := range tests {
-		var mat []slsa.ProvenanceMaterial
+		var mat []common.ProvenanceMaterial
 		if err := AddStepImagesToMaterials(tc.steps, &mat); err != nil {
 			if err.Error() != tc.wantError.Error() {
 				t.Fatalf("Expected error %v but got %v", tc.wantError, err)
@@ -323,7 +323,7 @@ func TestAddSidecarImagesToMaterials(t *testing.T) {
 	tests := []struct {
 		name      string
 		sidecars  []v1beta1.SidecarState
-		want      []slsa.ProvenanceMaterial
+		want      []common.ProvenanceMaterial
 		wantError error
 	}{{
 		name: "sidecars with proper imageID",
@@ -337,22 +337,22 @@ func TestAddSidecarImagesToMaterials(t *testing.T) {
 			Name:    "build",
 			ImageID: "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 		}},
-		want: []slsa.ProvenanceMaterial{
+		want: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 			{
 				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},
 			},
@@ -363,7 +363,7 @@ func TestAddSidecarImagesToMaterials(t *testing.T) {
 			Name:    "git-source-repo-jwqcl",
 			ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init-sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 		}},
-		want:      []slsa.ProvenanceMaterial{{}},
+		want:      []common.ProvenanceMaterial{{}},
 		wantError: fmt.Errorf("expected imageID gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init-sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247 to be separable by @"),
 	}, {
 		name: "sidecars with bad imageId - no digest",
@@ -371,11 +371,11 @@ func TestAddSidecarImagesToMaterials(t *testing.T) {
 			Name:    "git-source-repo-jwqcl",
 			ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256-b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 		}},
-		want:      []slsa.ProvenanceMaterial{{}},
+		want:      []common.ProvenanceMaterial{{}},
 		wantError: fmt.Errorf("expected imageID gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256-b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247 to be separable by @ and :"),
 	}}
 	for _, tc := range tests {
-		var mat []slsa.ProvenanceMaterial
+		var mat []common.ProvenanceMaterial
 		if err := AddSidecarImagesToMaterials(tc.sidecars, &mat); err != nil {
 			if err.Error() != tc.wantError.Error() {
 				t.Fatalf("Expected error %v but got %v", tc.wantError, err)
@@ -393,15 +393,15 @@ func TestAddImageIDToMaterials(t *testing.T) {
 	tests := []struct {
 		name      string
 		imageID   string
-		want      []slsa.ProvenanceMaterial
+		want      []common.ProvenanceMaterial
 		wantError error
 	}{{
 		name:    "proper ImageID",
 		imageID: "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
-		want: []slsa.ProvenanceMaterial{
+		want: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},
 			},
@@ -409,11 +409,11 @@ func TestAddImageIDToMaterials(t *testing.T) {
 	}, {
 		name:      "bad ImageID",
 		imageID:   "badImageId",
-		want:      []slsa.ProvenanceMaterial{},
+		want:      []common.ProvenanceMaterial{},
 		wantError: fmt.Errorf("expected imageID badImageId to be separable by @"),
 	}}
 	for _, tc := range tests {
-		mat := []slsa.ProvenanceMaterial{}
+		mat := []common.ProvenanceMaterial{}
 		if err := AddImageIDToMaterials(tc.imageID, &mat); err != nil {
 			if err.Error() != tc.wantError.Error() {
 				t.Fatalf("Expected error %v but got %v", tc.wantError, err)
@@ -430,121 +430,121 @@ func TestAddImageIDToMaterials(t *testing.T) {
 func TestRemoveDuplicates(t *testing.T) {
 	tests := []struct {
 		name string
-		mats []slsa.ProvenanceMaterial
-		want []slsa.ProvenanceMaterial
+		mats []common.ProvenanceMaterial
+		want []common.ProvenanceMaterial
 	}{{
 		name: "no duplicate materials",
-		mats: []slsa.ProvenanceMaterial{
+		mats: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			}, {
 				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},
 			}, {
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/sidecar-git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "a1234f6e7a69617db57b685893256f978436277094c21d43b153994acd8a09567",
 				},
 			},
 		},
-		want: []slsa.ProvenanceMaterial{
+		want: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			}, {
 				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},
 			}, {
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/sidecar-git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "a1234f6e7a69617db57b685893256f978436277094c21d43b153994acd8a09567",
 				},
 			},
 		},
 	}, {
 		name: "same uri and digest",
-		mats: []slsa.ProvenanceMaterial{
+		mats: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			}, {
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 		},
-		want: []slsa.ProvenanceMaterial{
+		want: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 		},
 	}, {
 		name: "same uri but different digest",
-		mats: []slsa.ProvenanceMaterial{
+		mats: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			}, {
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01248",
 				},
 			},
 		},
-		want: []slsa.ProvenanceMaterial{
+		want: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			}, {
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01248",
 				},
 			},
 		},
 	}, {
 		name: "same uri but different digest, swap order",
-		mats: []slsa.ProvenanceMaterial{
+		mats: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01248",
 				},
 			}, {
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 		},
-		want: []slsa.ProvenanceMaterial{
+		want: []common.ProvenanceMaterial{
 			{
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01248",
 				},
 			}, {
 				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: slsa.DigestSet{
+				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},

--- a/pkg/chains/formats/slsa/v1/intotoite6_test.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -58,7 +59,7 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 			Subject: []in_toto.Subject{
 				{
 					Name: "gcr.io/my/image",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 					},
 				},
@@ -69,20 +70,20 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 				BuildStartedOn:  &e1BuildStart,
 				BuildFinishedOn: &e1BuildFinished,
 			},
-			Materials: []slsa.ProvenanceMaterial{
+			Materials: []common.ProvenanceMaterial{
 				{
 					URI:    "docker-pullable://gcr.io/test1/test1",
-					Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
 				{
 					URI:    "docker-pullable://gcr.io/test2/test2",
-					Digest: slsa.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+					Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 				},
 				{
 					URI:    "docker-pullable://gcr.io/test3/test3",
-					Digest: slsa.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+					Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 				},
-				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "sha:taskrun"}},
+				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskrun"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{
@@ -99,7 +100,7 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 					"labels": {"tekton.dev/pipelineTask": "build"},
 				},
 			},
-			Builder: slsa.ProvenanceBuilder{
+			Builder: common.ProvenanceBuilder{
 				ID: "test_builder-1",
 			},
 			BuildType: "tekton.dev/v1beta1/TaskRun",
@@ -162,7 +163,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 			Subject: []in_toto.Subject{
 				{
 					Name: "test.io/test/image",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 					},
 				},
@@ -179,24 +180,24 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 				},
 				Reproducible: false,
 			},
-			Materials: []slsa.ProvenanceMaterial{
-				{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "28b123"}},
+			Materials: []common.ProvenanceMaterial{
+				{URI: "github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
 				{
 					URI:    "docker-pullable://gcr.io/test1/test1",
-					Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
-				{URI: "github.com/catalog", Digest: slsa.DigestSet{"sha1": "x123"}},
+				{URI: "github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
 				{
 					URI:    "docker-pullable://gcr.io/test2/test2",
-					Digest: slsa.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+					Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 				},
 				{
 					URI:    "docker-pullable://gcr.io/test3/test3",
-					Digest: slsa.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+					Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 				},
-				{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "ab123"}},
-				{URI: "abc", Digest: slsa.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
-				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "abcd"}},
+				{URI: "github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
+				{URI: "abc", Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
+				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{
@@ -208,7 +209,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 					"IMAGE": {Type: "string", StringVal: "test.io/test/image"},
 				},
 			},
-			Builder: slsa.ProvenanceBuilder{
+			Builder: common.ProvenanceBuilder{
 				ID: "test_builder-1",
 			},
 			BuildType: "tekton.dev/v1beta1/PipelineRun",
@@ -238,7 +239,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 						Invocation: slsa.ProvenanceInvocation{
 							ConfigSource: slsa.ConfigSource{
 								URI:        "github.com/catalog",
-								Digest:     slsa.DigestSet{"sha1": "x123"},
+								Digest:     common.DigestSet{"sha1": "x123"},
 								EntryPoint: "git-clone.yaml",
 							},
 							Parameters: map[string]v1beta1.ArrayOrString{
@@ -386,7 +387,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 			Subject: []in_toto.Subject{
 				{
 					Name: "test.io/test/image",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 					},
 				},
@@ -403,22 +404,22 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 				},
 				Reproducible: false,
 			},
-			Materials: []slsa.ProvenanceMaterial{
+			Materials: []common.ProvenanceMaterial{
 				{
 					URI:    "docker-pullable://gcr.io/test1/test1",
-					Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
-				{URI: "github.com/catalog", Digest: slsa.DigestSet{"sha1": "x123"}},
+				{URI: "github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
 				{
 					URI:    "docker-pullable://gcr.io/test2/test2",
-					Digest: slsa.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+					Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 				},
 				{
 					URI:    "docker-pullable://gcr.io/test3/test3",
-					Digest: slsa.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+					Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 				},
-				{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "ab123"}},
-				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "abcd"}},
+				{URI: "github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
+				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{},
@@ -426,7 +427,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 					"IMAGE": {Type: "string", StringVal: "test.io/test/image"},
 				},
 			},
-			Builder: slsa.ProvenanceBuilder{
+			Builder: common.ProvenanceBuilder{
 				ID: "test_builder-1",
 			},
 			BuildType: "tekton.dev/v1beta1/PipelineRun",
@@ -456,7 +457,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 						Invocation: slsa.ProvenanceInvocation{
 							ConfigSource: slsa.ConfigSource{
 								URI:        "github.com/catalog",
-								Digest:     slsa.DigestSet{"sha1": "x123"},
+								Digest:     common.DigestSet{"sha1": "x123"},
 								EntryPoint: "git-clone.yaml",
 							},
 							Parameters: map[string]v1beta1.ArrayOrString{
@@ -608,20 +609,20 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 				BuildStartedOn:  &e1BuildStart,
 				BuildFinishedOn: &e1BuildFinished,
 			},
-			Builder: slsa.ProvenanceBuilder{
+			Builder: common.ProvenanceBuilder{
 				ID: "test_builder-2",
 			},
-			Materials: []slsa.ProvenanceMaterial{
+			Materials: []common.ProvenanceMaterial{
 				{
 					URI:    "docker-pullable://gcr.io/test1/test1",
-					Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
-				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "sha:taskdefault"}},
+				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskdefault"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{
 					URI:        "github.com/catalog",
-					Digest:     slsa.DigestSet{"sha1": "x123"},
+					Digest:     common.DigestSet{"sha1": "x123"},
 					EntryPoint: "git-clone.yaml",
 				},
 				Parameters: map[string]v1beta1.ArrayOrString{
@@ -680,12 +681,12 @@ func TestMultipleSubjects(t *testing.T) {
 			Subject: []in_toto.Subject{
 				{
 					Name: "gcr.io/myimage",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 					},
 				}, {
 					Name: "gcr.io/myimage",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "daa1a56e13c85cf164e7d9e595006649e3a04c47fe4a8261320e18a0bf3b0367",
 					},
 				},
@@ -694,13 +695,13 @@ func TestMultipleSubjects(t *testing.T) {
 		Predicate: slsa.ProvenancePredicate{
 			BuildType: "tekton.dev/v1beta1/TaskRun",
 			Metadata:  &slsa.ProvenanceMetadata{},
-			Builder: slsa.ProvenanceBuilder{
+			Builder: common.ProvenanceBuilder{
 				ID: "test_builder-multiple",
 			},
-			Materials: []slsa.ProvenanceMaterial{
+			Materials: []common.ProvenanceMaterial{
 				{
 					URI:    "docker-pullable://gcr.io/test1/test1",
-					Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
 			},
 			Invocation: slsa.ProvenanceInvocation{

--- a/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/attest"
@@ -59,7 +60,7 @@ func GenerateAttestation(builderID string, pro *objects.PipelineRunObject, logge
 			Subject:       subjects,
 		},
 		Predicate: slsa.ProvenancePredicate{
-			Builder: slsa.ProvenanceBuilder{
+			Builder: common.ProvenanceBuilder{
 				ID: builderID,
 			},
 			BuildType:   pro.GetGVK(),
@@ -187,10 +188,10 @@ func metadata(pro *objects.PipelineRunObject) *slsa.ProvenanceMetadata {
 }
 
 // add any Git specification to materials
-func materials(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) ([]slsa.ProvenanceMaterial, error) {
-	var mats []slsa.ProvenanceMaterial
+func materials(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) ([]common.ProvenanceMaterial, error) {
+	var mats []common.ProvenanceMaterial
 	if p := pro.Status.Provenance; p != nil && p.ConfigSource != nil {
-		m := slsa.ProvenanceMaterial{
+		m := common.ProvenanceMaterial{
 			URI:    p.ConfigSource.URI,
 			Digest: p.ConfigSource.Digest,
 		}
@@ -219,7 +220,7 @@ func materials(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) ([]sls
 
 			// add remote task configsource information in materials
 			if tr.Status.Provenance != nil && tr.Status.Provenance.ConfigSource != nil {
-				m := slsa.ProvenanceMaterial{
+				m := common.ProvenanceMaterial{
 					URI:    tr.Status.Provenance.ConfigSource.URI,
 					Digest: tr.Status.Provenance.ConfigSource.Digest,
 				}
@@ -269,7 +270,7 @@ func materials(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) ([]sls
 	}
 	if len(commit) > 0 && len(url) > 0 {
 		url = attest.SPDXGit(url, "")
-		mats = append(mats, slsa.ProvenanceMaterial{
+		mats = append(mats, common.ProvenanceMaterial{
 			URI:    url,
 			Digest: map[string]string{"sha1": commit},
 		})

--- a/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-containerregistry/pkg/name"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/attest"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
@@ -106,7 +107,7 @@ func TestBuildConfig(t *testing.T) {
 				Invocation: slsa.ProvenanceInvocation{
 					ConfigSource: slsa.ConfigSource{
 						URI:        "github.com/catalog",
-						Digest:     slsa.DigestSet{"sha1": "x123"},
+						Digest:     common.DigestSet{"sha1": "x123"},
 						EntryPoint: "git-clone.yaml",
 					},
 					Parameters: map[string]v1beta1.ArrayOrString{
@@ -296,7 +297,7 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 						Invocation: slsa.ProvenanceInvocation{
 							ConfigSource: slsa.ConfigSource{
 								URI:        "github.com/catalog",
-								Digest:     slsa.DigestSet{"sha1": "x123"},
+								Digest:     common.DigestSet{"sha1": "x123"},
 								EntryPoint: "git-clone.yaml",
 							},
 							Parameters: map[string]v1beta1.ArrayOrString{
@@ -466,24 +467,24 @@ func TestMetadataInTimeZone(t *testing.T) {
 }
 
 func TestMaterials(t *testing.T) {
-	expected := []slsa.ProvenanceMaterial{
-		{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "28b123"}},
+	expected := []common.ProvenanceMaterial{
+		{URI: "github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
 		{
 			URI:    "docker-pullable://gcr.io/test1/test1",
-			Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+			Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 		},
-		{URI: "github.com/catalog", Digest: slsa.DigestSet{"sha1": "x123"}},
+		{URI: "github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
 		{
 			URI:    "docker-pullable://gcr.io/test2/test2",
-			Digest: slsa.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+			Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 		},
 		{
 			URI:    "docker-pullable://gcr.io/test3/test3",
-			Digest: slsa.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+			Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 		},
-		{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "ab123"}},
-		{URI: "abc", Digest: slsa.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
-		{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "abcd"}},
+		{URI: "github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
+		{URI: "abc", Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
+		{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
 	}
 	got, err := materials(pro, logtesting.TestLogger(t))
 	if err != nil {
@@ -495,25 +496,25 @@ func TestMaterials(t *testing.T) {
 }
 
 func TestStructuredResultMaterials(t *testing.T) {
-	want := []slsa.ProvenanceMaterial{
-		{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "28b123"}},
+	want := []common.ProvenanceMaterial{
+		{URI: "github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
 		{
 			URI:    "docker-pullable://gcr.io/test1/test1",
-			Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+			Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 		},
-		{URI: "github.com/catalog", Digest: slsa.DigestSet{"sha1": "x123"}},
+		{URI: "github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
 		{
 			URI:    "docker-pullable://gcr.io/test2/test2",
-			Digest: slsa.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+			Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 		},
 		{
 			URI:    "docker-pullable://gcr.io/test3/test3",
-			Digest: slsa.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+			Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 		},
-		{URI: "github.com/test", Digest: slsa.DigestSet{"sha1": "ab123"}},
+		{URI: "github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
 		{
 			URI: "abcd",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 			},
 		},
@@ -533,7 +534,7 @@ func TestSubjectDigests(t *testing.T) {
 	wantSubjects := []intoto.Subject{
 		{
 			Name:   "test.io/test/image",
-			Digest: slsa.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"},
+			Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"},
 		},
 	}
 

--- a/pkg/chains/formats/slsa/v1/taskrun/provenance_test.go
+++ b/pkg/chains/formats/slsa/v1/taskrun/provenance_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 
 	"github.com/ghodss/yaml"
@@ -294,37 +295,37 @@ func TestGetSubjectDigests(t *testing.T) {
 	expected := []in_toto.Subject{
 		{
 			Name: "com.google.guava:guava:1.0-jre.pom",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest2, "sha256:"),
 			},
 		}, {
 			Name: "index.docker.io/registry/myimage",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest1, "sha256:"),
 			},
 		}, {
 			Name: "maven-test-0.1.1-sources.jar",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest5, "sha256:"),
 			},
 		}, {
 			Name: "maven-test-0.1.1.jar",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest3, "sha256:"),
 			},
 		}, {
 			Name: "maven-test-0.1.1.pom",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest4, "sha256:"),
 			},
 		}, {
 			Name: "projects/test-project-1/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest1, "sha256:"),
 			},
 		}, {
 			Name: "registry/resource-image",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest2, "sha256:"),
 			},
 		},

--- a/pkg/chains/formats/slsa/v1/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v1/taskrun/taskrun.go
@@ -15,6 +15,7 @@ package taskrun
 
 import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/attest"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
@@ -38,7 +39,7 @@ func GenerateAttestation(builderID string, tro *objects.TaskRunObject, logger *z
 			Subject:       subjects,
 		},
 		Predicate: slsa.ProvenancePredicate{
-			Builder: slsa.ProvenanceBuilder{
+			Builder: common.ProvenanceBuilder{
 				ID: builderID,
 			},
 			BuildType:   tro.GetGVK(),

--- a/pkg/chains/formats/slsa/v2/slsav2_test.go
+++ b/pkg/chains/formats/slsa/v2/slsav2_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -62,7 +63,7 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 			Subject: []in_toto.Subject{
 				{
 					Name: "gcr.io/my/image",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 					},
 				},
@@ -73,20 +74,20 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 				BuildStartedOn:  &e1BuildStart,
 				BuildFinishedOn: &e1BuildFinished,
 			},
-			Materials: []slsa.ProvenanceMaterial{
+			Materials: []common.ProvenanceMaterial{
 				{
 					URI:    "docker-pullable://gcr.io/test1/test1",
-					Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
 				{
 					URI:    "docker-pullable://gcr.io/test2/test2",
-					Digest: slsa.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+					Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 				},
 				{
 					URI:    "docker-pullable://gcr.io/test3/test3",
-					Digest: slsa.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+					Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 				},
-				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "sha:taskrun"}},
+				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskrun"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{
@@ -123,7 +124,7 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 					"Workspaces":         []v1beta1.WorkspaceBinding(nil),
 				},
 			},
-			Builder: slsa.ProvenanceBuilder{
+			Builder: common.ProvenanceBuilder{
 				ID: "test_builder-1",
 			},
 			BuildType: "https://chains.tekton.dev/format/slsa/v2alpha1/type/tekton.dev/v1beta1/TaskRun",
@@ -190,20 +191,20 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 				BuildStartedOn:  &e1BuildStart,
 				BuildFinishedOn: &e1BuildFinished,
 			},
-			Builder: slsa.ProvenanceBuilder{
+			Builder: common.ProvenanceBuilder{
 				ID: "test_builder-2",
 			},
-			Materials: []slsa.ProvenanceMaterial{
+			Materials: []common.ProvenanceMaterial{
 				{
 					URI:    "docker-pullable://gcr.io/test1/test1",
-					Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
-				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "sha:taskdefault"}},
+				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskdefault"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{
 					URI:        "github.com/catalog",
-					Digest:     slsa.DigestSet{"sha1": "x123"},
+					Digest:     common.DigestSet{"sha1": "x123"},
 					EntryPoint: "git-clone.yaml",
 				},
 				Parameters: map[string]any{
@@ -285,12 +286,12 @@ func TestMultipleSubjects(t *testing.T) {
 			Subject: []in_toto.Subject{
 				{
 					Name: "gcr.io/myimage",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 					},
 				}, {
 					Name: "gcr.io/myimage",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "daa1a56e13c85cf164e7d9e595006649e3a04c47fe4a8261320e18a0bf3b0367",
 					},
 				},
@@ -299,13 +300,13 @@ func TestMultipleSubjects(t *testing.T) {
 		Predicate: slsa.ProvenancePredicate{
 			BuildType: "https://chains.tekton.dev/format/slsa/v2alpha1/type/tekton.dev/v1beta1/TaskRun",
 			Metadata:  &slsa.ProvenanceMetadata{},
-			Builder: slsa.ProvenanceBuilder{
+			Builder: common.ProvenanceBuilder{
 				ID: "test_builder-multiple",
 			},
-			Materials: []slsa.ProvenanceMaterial{
+			Materials: []common.ProvenanceMaterial{
 				{
 					URI:    "docker-pullable://gcr.io/test1/test1",
-					Digest: slsa.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
 			},
 			Invocation: slsa.ProvenanceInvocation{

--- a/pkg/chains/formats/slsa/v2/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v2/taskrun/taskrun.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/material"
@@ -52,7 +53,7 @@ func GenerateAttestation(builderID string, payloadType config.PayloadType, tro *
 			Subject:       subjects,
 		},
 		Predicate: slsa.ProvenancePredicate{
-			Builder: slsa.ProvenanceBuilder{
+			Builder: common.ProvenanceBuilder{
 				ID: builderID,
 			},
 			BuildType:   fmt.Sprintf("https://chains.tekton.dev/format/%v/type/%s", payloadType, tro.GetGVK()),

--- a/pkg/chains/formats/slsa/v2/taskrun/taskrun_test.go
+++ b/pkg/chains/formats/slsa/v2/taskrun/taskrun_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 
 	"github.com/ghodss/yaml"
@@ -321,37 +322,37 @@ func TestGetSubjectDigests(t *testing.T) {
 	expected := []in_toto.Subject{
 		{
 			Name: "com.google.guava:guava:1.0-jre.pom",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest2, "sha256:"),
 			},
 		}, {
 			Name: "index.docker.io/registry/myimage",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest1, "sha256:"),
 			},
 		}, {
 			Name: "maven-test-0.1.1-sources.jar",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest5, "sha256:"),
 			},
 		}, {
 			Name: "maven-test-0.1.1.jar",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest3, "sha256:"),
 			},
 		}, {
 			Name: "maven-test-0.1.1.pom",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest4, "sha256:"),
 			},
 		}, {
 			Name: "projects/test-project-1/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest1, "sha256:"),
 			},
 		}, {
 			Name: "registry/resource-image",
-			Digest: slsa.DigestSet{
+			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest2, "sha256:"),
 			},
 		},

--- a/pkg/chains/storage/grafeas/grafeas_test.go
+++ b/pkg/chains/storage/grafeas/grafeas_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
@@ -83,10 +84,10 @@ var (
 	// clone taskrun provenance
 	cloneTaskRunProvenance = intoto.ProvenanceStatement{
 		Predicate: slsa.ProvenancePredicate{
-			Materials: []slsa.ProvenanceMaterial{
+			Materials: []common.ProvenanceMaterial{
 				{
 					URI: repoURL,
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha1": commitSHA,
 					},
 				},
@@ -122,13 +123,13 @@ var (
 			Subject: []intoto.Subject{
 				{
 					Name: artifactURL1,
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": artifactDigest1,
 					},
 				},
 				{
 					Name: artifactURL2,
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": artifactDigest2,
 					},
 				},

--- a/pkg/chains/storage/oci/oci_test.go
+++ b/pkg/chains/storage/oci/oci_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -92,7 +93,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			Subject: []in_toto.Subject{
 				{
 					Name: u.Host + "/task/" + tr.Name,
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						algo: hex,
 					},
 				},


### PR DESCRIPTION


# Changes


fixes https://github.com/tektoncd/chains/issues/555

intoto-golang has moved `ProvenanceMaterial`, `DigestSet`, `ProvenanceBuilder` to the `common` package.

This PR uses common package to access those types.

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

# Release Notes

``` release-note
NONE
```
