### PR TITLE
Remove PipelineResources

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -10,11 +10,11 @@ weight: 20
 `Chains` works by observing `TaskRun` and `PipelineRun` executions, capturing relevant information, and storing it in a cryptographically-signed format.
 
 `TaskRuns` and `PipelineRuns` can indicate inputs and outputs which are then captured and surfaced in the `Chains` payload formats, where relevant.
-`Chains` uses the standard mechanisms (`Results` and `PipelineResources`) where possible, and provides a few other mechanisms to *hint* at the correct inputs and outputs. These are outlined below:
+`Chains` uses the standard mechanisms (`Results`) where possible, and provides a few other mechanisms to *hint* at the correct inputs and outputs. These are outlined below:
 
 ## Chains Type Hinting
 
-When outputting an OCI image without using a `PipelineResource`, `Chains` will look for the following Results:
+`Chains` will look for the following Results:
 
 * `*IMAGE_URL` - The URL to the built OCI image
 * `*IMAGE_DIGEST` - The Digest of the built OCI image
@@ -39,8 +39,6 @@ When processing a `PipelineRun`, Chains will only attest each image. Thus, if bo
 
 For in-toto attestations, see [intoto.md](intoto.md) for description
 of in-toto specific type hinting.
-
-Note that these are provided automatically when using `PipelineResources`.
 
 ## Chains Configuration
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -25,4 +25,5 @@ So, if a feature is deprecated at v0.1.0, then it would be removed in v0.3.0.
 
 | Feature Being Deprecated  | Deprecation Announcement  | API Compatibility Policy | Earliest Date or Release of Removal |
 | ------------------------- | ------------------------- | ------------------------ | ----------------------------------- |
+| Support for PipelineResources was removed, see [TEP0074](https://github.com/tektoncd/community/blob/main/teps/0074-deprecate-pipelineresources.md) | [v0.16.0 (https://github.com/tektoncd/chains/releases/tag/v0.16.0) | Alpha | v0.16.0 |
 | [`tekton-provenance` format is deprecated](https://github.com/tektoncd/chains/issues/293)  | [v0.6.0](https://github.com/tektoncd/pipeline/releases/tag/v0.6.0) | Alpha | v0.8.0 |

--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -164,14 +164,6 @@ func (oa *OCIArtifact) ExtractObjects(obj objects.TektonObject) []interface{} {
 	// TODO: Not applicable to PipelineRuns, should look into a better way to separate this out
 	if tr, ok := obj.GetObject().(*v1beta1.TaskRun); ok {
 		imageResourceNames := map[string]*image{}
-		if tr.Status.TaskSpec != nil && tr.Status.TaskSpec.Resources != nil {
-			for _, output := range tr.Status.TaskSpec.Resources.Outputs {
-				if output.Type == v1beta1.PipelineResourceTypeImage {
-					imageResourceNames[output.Name] = &image{}
-				}
-			}
-		}
-
 		for _, rr := range tr.Status.ResourcesResult {
 			img, ok := imageResourceNames[rr.ResourceName]
 			if !ok {

--- a/pkg/chains/formats/slsa/extract/extract.go
+++ b/pkg/chains/formats/slsa/extract/extract.go
@@ -27,7 +27,6 @@ import (
 	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"go.uber.org/zap"
 )
 
@@ -91,34 +90,6 @@ func SubjectDigests(obj objects.TektonObject, logger *zap.SugaredLogger) []intot
 		return subjects
 	}
 
-	// go through resourcesResult
-	for _, output := range tr.Spec.Resources.Outputs {
-		name := output.Name
-		if output.PipelineResourceBinding.ResourceSpec == nil {
-			continue
-		}
-		// similarly, we could do this for other pipeline resources or whatever thing replaces them
-		if output.PipelineResourceBinding.ResourceSpec.Type == v1alpha1.PipelineResourceTypeImage {
-			// get the url and digest, and save as a subject
-			var url, digest string
-			for _, s := range tr.Status.ResourcesResult {
-				if s.ResourceName == name {
-					if s.Key == "url" {
-						url = s.Value
-					}
-					if s.Key == "digest" {
-						digest = s.Value
-					}
-				}
-			}
-			subjects = append(subjects, intoto.Subject{
-				Name: url,
-				Digest: common.DigestSet{
-					"sha256": strings.TrimPrefix(digest, "sha256:"),
-				},
-			})
-		}
-	}
 	sort.Slice(subjects, func(i, j int) bool {
 		return subjects[i].Name <= subjects[j].Name
 	})

--- a/pkg/chains/formats/slsa/v1/taskrun/provenance_test.go
+++ b/pkg/chains/formats/slsa/v1/taskrun/provenance_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logtesting "knative.dev/pkg/logging/testing"
 )
@@ -198,24 +197,6 @@ status:
 
 func TestGetSubjectDigests(t *testing.T) {
 	tr := &v1beta1.TaskRun{
-		Spec: v1beta1.TaskRunSpec{
-			Resources: &v1beta1.TaskRunResources{
-				Outputs: []v1beta1.TaskResourceBinding{
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: "nil-check",
-						},
-					}, {
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: "built-image",
-							ResourceSpec: &v1alpha1.PipelineResourceSpec{
-								Type: v1alpha1.PipelineResourceTypeImage,
-							},
-						},
-					},
-				},
-			},
-		},
 		Status: v1beta1.TaskRunStatus{
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				TaskRunResults: []v1beta1.TaskRunResult{
@@ -277,36 +258,15 @@ func TestGetSubjectDigests(t *testing.T) {
 						}),
 					},
 				},
-				ResourcesResult: []v1beta1.PipelineResourceResult{
-					{
-						ResourceName: "built-image",
-						Key:          "url",
-						Value:        "registry/resource-image",
-					}, {
-						ResourceName: "built-image",
-						Key:          "digest",
-						Value:        digest2,
-					},
-				},
 			},
 		},
 	}
 
 	expected := []in_toto.Subject{
 		{
-			Name: "com.google.guava:guava:1.0-jre.pom",
-			Digest: common.DigestSet{
-				"sha256": strings.TrimPrefix(digest2, "sha256:"),
-			},
-		}, {
 			Name: "index.docker.io/registry/myimage",
 			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest1, "sha256:"),
-			},
-		}, {
-			Name: "maven-test-0.1.1-sources.jar",
-			Digest: common.DigestSet{
-				"sha256": strings.TrimPrefix(digest5, "sha256:"),
 			},
 		}, {
 			Name: "maven-test-0.1.1.jar",
@@ -319,12 +279,17 @@ func TestGetSubjectDigests(t *testing.T) {
 				"sha256": strings.TrimPrefix(digest4, "sha256:"),
 			},
 		}, {
+			Name: "maven-test-0.1.1-sources.jar",
+			Digest: common.DigestSet{
+				"sha256": strings.TrimPrefix(digest5, "sha256:"),
+			},
+		}, {
 			Name: "projects/test-project-1/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre",
 			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest1, "sha256:"),
 			},
 		}, {
-			Name: "registry/resource-image",
+			Name: "com.google.guava:guava:1.0-jre.pom",
 			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest2, "sha256:"),
 			},

--- a/pkg/chains/formats/slsa/v2/taskrun/taskrun_test.go
+++ b/pkg/chains/formats/slsa/v2/taskrun/taskrun_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -225,24 +224,6 @@ status:
 
 func TestGetSubjectDigests(t *testing.T) {
 	tr := &v1beta1.TaskRun{
-		Spec: v1beta1.TaskRunSpec{
-			Resources: &v1beta1.TaskRunResources{
-				Outputs: []v1beta1.TaskResourceBinding{
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: "nil-check",
-						},
-					}, {
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: "built-image",
-							ResourceSpec: &v1alpha1.PipelineResourceSpec{
-								Type: v1alpha1.PipelineResourceTypeImage,
-							},
-						},
-					},
-				},
-			},
-		},
 		Status: v1beta1.TaskRunStatus{
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				TaskRunResults: []v1beta1.TaskRunResult{
@@ -304,36 +285,15 @@ func TestGetSubjectDigests(t *testing.T) {
 						}),
 					},
 				},
-				ResourcesResult: []v1beta1.PipelineResourceResult{
-					{
-						ResourceName: "built-image",
-						Key:          "url",
-						Value:        "registry/resource-image",
-					}, {
-						ResourceName: "built-image",
-						Key:          "digest",
-						Value:        digest2,
-					},
-				},
 			},
 		},
 	}
 
 	expected := []in_toto.Subject{
 		{
-			Name: "com.google.guava:guava:1.0-jre.pom",
-			Digest: common.DigestSet{
-				"sha256": strings.TrimPrefix(digest2, "sha256:"),
-			},
-		}, {
 			Name: "index.docker.io/registry/myimage",
 			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest1, "sha256:"),
-			},
-		}, {
-			Name: "maven-test-0.1.1-sources.jar",
-			Digest: common.DigestSet{
-				"sha256": strings.TrimPrefix(digest5, "sha256:"),
 			},
 		}, {
 			Name: "maven-test-0.1.1.jar",
@@ -346,12 +306,17 @@ func TestGetSubjectDigests(t *testing.T) {
 				"sha256": strings.TrimPrefix(digest4, "sha256:"),
 			},
 		}, {
+			Name: "maven-test-0.1.1-sources.jar",
+			Digest: common.DigestSet{
+				"sha256": strings.TrimPrefix(digest5, "sha256:"),
+			},
+		}, {
 			Name: "projects/test-project-1/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre",
 			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest1, "sha256:"),
 			},
 		}, {
-			Name: "registry/resource-image",
+			Name: "com.google.guava:guava:1.0-jre.pom",
 			Digest: common.DigestSet{
 				"sha256": strings.TrimPrefix(digest2, "sha256:"),
 			},


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Removes PipelineResources.

These have been removed from Tekton Pipelines in v0.46.0.

See https://github.com/tektoncd/community/blob/main/teps/0074-deprecate-pipelineresources.md See https://tekton.dev/docs/pipelines/deprecations/#removed-pipelineresources-related-features

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
PiplelineResource output images are no longer supported.
```
