### PR TITLE
Cleanup: generics replace deprecated sets.String.

### DIFF
--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -41,7 +41,8 @@ var (
 
 type Signable interface {
 	ExtractObjects(obj objects.TektonObject) []interface{}
-	StorageBackend(cfg config.Config) sets.String
+	StorageBackend(cfg config.Config) sets.Set[string]
+
 	Signer(cfg config.Config) string
 	PayloadFormat(cfg config.Config) config.PayloadType
 	// FullKey returns the full identifier for a signable artifact.
@@ -81,7 +82,7 @@ func (ta *TaskRunArtifact) Type() string {
 	return "tekton"
 }
 
-func (ta *TaskRunArtifact) StorageBackend(cfg config.Config) sets.String {
+func (ta *TaskRunArtifact) StorageBackend(cfg config.Config) sets.Set[string] {
 	return cfg.Artifacts.TaskRuns.StorageBackend
 }
 
@@ -123,7 +124,7 @@ func (pa *PipelineRunArtifact) Type() string {
 	return "tekton-pipeline-run"
 }
 
-func (pa *PipelineRunArtifact) StorageBackend(cfg config.Config) sets.String {
+func (pa *PipelineRunArtifact) StorageBackend(cfg config.Config) sets.Set[string] {
 	return cfg.Artifacts.PipelineRuns.StorageBackend
 }
 
@@ -409,7 +410,7 @@ func (oa *OCIArtifact) Type() string {
 	return "oci"
 }
 
-func (oa *OCIArtifact) StorageBackend(cfg config.Config) sets.String {
+func (oa *OCIArtifact) StorageBackend(cfg config.Config) sets.Set[string] {
 	return cfg.Artifacts.OCI.StorageBackend
 }
 

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/logging"
 )
 
@@ -171,7 +172,7 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 			}
 
 			// Now store those!
-			for _, backend := range signableType.StorageBackend(cfg).List() {
+			for _, backend := range sets.List[string](signableType.StorageBackend(cfg)) {
 				b := o.Backends[backend]
 				storageOpts := config.StorageOpts{
 					ShortKey:      signableType.ShortKey(obj),

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -58,7 +58,7 @@ func TestSigner_Sign(t *testing.T) {
 		Artifacts: config.ArtifactConfigs{
 			TaskRuns: config.Artifact{
 				Format:         "in-toto",
-				StorageBackend: sets.NewString("mock"),
+				StorageBackend: sets.New[string]("mock"),
 				Signer:         "x509",
 			},
 		},
@@ -68,7 +68,7 @@ func TestSigner_Sign(t *testing.T) {
 		Artifacts: config.ArtifactConfigs{
 			PipelineRuns: config.Artifact{
 				Format:         "in-toto",
-				StorageBackend: sets.NewString("mock"),
+				StorageBackend: sets.New[string]("mock"),
 				Signer:         "x509",
 			},
 		},
@@ -228,7 +228,7 @@ func TestSigner_Transparency(t *testing.T) {
 				Artifacts: config.ArtifactConfigs{
 					TaskRuns: config.Artifact{
 						Format:         "slsa/v1",
-						StorageBackend: sets.NewString("mock"),
+						StorageBackend: sets.New[string]("mock"),
 						Signer:         "x509",
 					},
 				},
@@ -244,7 +244,7 @@ func TestSigner_Transparency(t *testing.T) {
 				Artifacts: config.ArtifactConfigs{
 					PipelineRuns: config.Artifact{
 						Format:         "slsa/v1",
-						StorageBackend: sets.NewString("mock"),
+						StorageBackend: sets.New[string]("mock"),
 						Signer:         "x509",
 					},
 				},
@@ -347,7 +347,7 @@ func TestSigningObjects(t *testing.T) {
 				Artifacts: config.ArtifactConfigs{
 					TaskRuns: config.Artifact{
 						Format:         "in-toto",
-						StorageBackend: sets.NewString("mock"),
+						StorageBackend: sets.New[string]("mock"),
 						Signer:         "x509",
 					},
 				},
@@ -361,12 +361,12 @@ func TestSigningObjects(t *testing.T) {
 				Artifacts: config.ArtifactConfigs{
 					TaskRuns: config.Artifact{
 						Format:         "in-toto",
-						StorageBackend: sets.NewString("mock"),
+						StorageBackend: sets.New[string]("mock"),
 						Signer:         "x509",
 					},
 					OCI: config.Artifact{
 						Format:         "in-toto",
-						StorageBackend: sets.NewString("mock"),
+						StorageBackend: sets.New[string]("mock"),
 						Signer:         "x509",
 					},
 				},
@@ -380,11 +380,11 @@ func TestSigningObjects(t *testing.T) {
 				Artifacts: config.ArtifactConfigs{
 					TaskRuns: config.Artifact{
 						Format:         "in-toto",
-						StorageBackend: sets.NewString("mock"),
+						StorageBackend: sets.New[string]("mock"),
 					},
 					OCI: config.Artifact{
 						Format:         "in-toto",
-						StorageBackend: sets.NewString("mock"),
+						StorageBackend: sets.New[string]("mock"),
 					},
 				},
 				Transparency: config.TransparencyConfig{

--- a/pkg/chains/storage/storage.go
+++ b/pkg/chains/storage/storage.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -45,13 +46,13 @@ func InitializeBackends(ctx context.Context, ps versioned.Interface, kc kubernet
 	// Add an entry here for every configured backend
 	configuredBackends := []string{}
 	if cfg.Artifacts.TaskRuns.Enabled() {
-		configuredBackends = append(configuredBackends, cfg.Artifacts.TaskRuns.StorageBackend.List()...)
+		configuredBackends = append(configuredBackends, sets.List[string](cfg.Artifacts.TaskRuns.StorageBackend)...)
 	}
 	if cfg.Artifacts.OCI.Enabled() {
-		configuredBackends = append(configuredBackends, cfg.Artifacts.OCI.StorageBackend.List()...)
+		configuredBackends = append(configuredBackends, sets.List[string](cfg.Artifacts.OCI.StorageBackend)...)
 	}
 	if cfg.Artifacts.PipelineRuns.Enabled() {
-		configuredBackends = append(configuredBackends, cfg.Artifacts.PipelineRuns.StorageBackend.List()...)
+		configuredBackends = append(configuredBackends, sets.List[string](cfg.Artifacts.PipelineRuns.StorageBackend)...)
 	}
 
 	// Now only initialize and return the configured ones.

--- a/pkg/chains/storage/storage_test.go
+++ b/pkg/chains/storage/storage_test.go
@@ -40,34 +40,34 @@ func TestInitializeBackends(t *testing.T) {
 		{
 			name: "tekton",
 			want: []string{"tekton"},
-			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("tekton")}}},
+			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.New[string]("tekton")}}},
 		},
 		// TODO: Re-enable this test when it doesn't rely on ambient GCP credentials.
 		//{
 		//	name: "gcs",
 		//	want: []string{"gcs"},
-		//	cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("gcs")}}},
+		//	cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.New[string]("gcs")}}},
 		//},
 		{
 			name: "oci",
 			want: []string{"oci"},
-			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("oci")}}},
+			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.New[string]("oci")}}},
 		},
 		// TODO: Re-enable this test when it doesn't rely on ambient GCP credentials.
 		// {
 		// 	name: "grafeas",
 		// 	want: []string{"grafeas"},
-		// 	cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("grafeas")}}},
+		// 	cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.New[string]("grafeas")}}},
 		// },
 		{
 			name: "multi",
 			want: []string{"oci", "tekton"},
-			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("oci", "tekton")}}},
+			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.New[string]("oci", "tekton")}}},
 		},
 		{
 			name: "pubsub",
 			want: []string{"pubsub"},
-			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.NewString("pubsub")}}}},
+			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.New[string]("pubsub")}}}},
 	}
 	logger := logtesting.TestLogger(t)
 	ctx, _ := rtesting.SetupFakeContext(t)

--- a/pkg/chains/verifier.go
+++ b/pkg/chains/verifier.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/logging"
 )
@@ -70,7 +71,7 @@ func (tv *TaskRunVerifier) VerifyTaskRun(ctx context.Context, tr *v1beta1.TaskRu
 			continue
 		}
 
-		for _, backend := range signableType.StorageBackend(cfg).List() {
+		for _, backend := range sets.List[string](signableType.StorageBackend(cfg)) {
 			b := allBackends[backend]
 			signatures, err := b.RetrieveSignatures(ctx, trObj, config.StorageOpts{})
 			if err != nil {

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -99,17 +99,17 @@ var defaultBuilder = BuilderConfig{
 var defaultArtifacts = ArtifactConfigs{
 	TaskRuns: Artifact{
 		Format:         "in-toto",
-		StorageBackend: sets.NewString("tekton"),
+		StorageBackend: sets.New[string]("tekton"),
 		Signer:         "x509",
 	},
 	PipelineRuns: Artifact{
 		Format:         "in-toto",
 		Signer:         "x509",
-		StorageBackend: sets.NewString("tekton"),
+		StorageBackend: sets.New[string]("tekton"),
 	},
 	OCI: Artifact{
 		Format:         "simplesigning",
-		StorageBackend: sets.NewString("oci"),
+		StorageBackend: sets.New[string]("oci"),
 		Signer:         "x509",
 	},
 }
@@ -189,17 +189,17 @@ func TestParse(t *testing.T) {
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
 						Format:         "in-toto",
-						StorageBackend: sets.NewString("tekton", "oci"),
+						StorageBackend: sets.New[string]("tekton", "oci"),
 						Signer:         "x509",
 					},
 					PipelineRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					OCI: Artifact{
 						Format:         "simplesigning",
-						StorageBackend: sets.NewString("oci"),
+						StorageBackend: sets.New[string]("oci"),
 						Signer:         "x509",
 					},
 				},
@@ -218,17 +218,17 @@ func TestParse(t *testing.T) {
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
 						Format:         "in-toto",
-						StorageBackend: sets.NewString(""),
+						StorageBackend: sets.New[string](""),
 						Signer:         "x509",
 					},
 					PipelineRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					OCI: Artifact{
 						Format:         "simplesigning",
-						StorageBackend: sets.NewString("oci"),
+						StorageBackend: sets.New[string]("oci"),
 						Signer:         "x509",
 					},
 				},
@@ -247,17 +247,17 @@ func TestParse(t *testing.T) {
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
 						Format:         "in-toto",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 						Signer:         "x509",
 					},
 					PipelineRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					OCI: Artifact{
 						Format:         "simplesigning",
-						StorageBackend: sets.NewString("oci", "tekton"),
+						StorageBackend: sets.New[string]("oci", "tekton"),
 						Signer:         "x509",
 					},
 				},
@@ -276,17 +276,17 @@ func TestParse(t *testing.T) {
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
 						Format:         "in-toto",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 						Signer:         "x509",
 					},
 					PipelineRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					OCI: Artifact{
 						Format:         "simplesigning",
-						StorageBackend: sets.NewString(""),
+						StorageBackend: sets.New[string](""),
 						Signer:         "x509",
 					},
 				},
@@ -308,17 +308,17 @@ func TestParse(t *testing.T) {
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
 						Format:         "in-toto",
-						StorageBackend: sets.NewString("tekton", "oci"),
+						StorageBackend: sets.New[string]("tekton", "oci"),
 						Signer:         "x509",
 					},
 					PipelineRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					OCI: Artifact{
 						Format:         "simplesigning",
-						StorageBackend: sets.NewString(""),
+						StorageBackend: sets.New[string](""),
 						Signer:         "x509",
 					},
 				},
@@ -340,17 +340,17 @@ func TestParse(t *testing.T) {
 				Artifacts: ArtifactConfigs{
 					TaskRuns: Artifact{
 						Format:         "in-toto",
-						StorageBackend: sets.NewString(""),
+						StorageBackend: sets.New[string](""),
 						Signer:         "x509",
 					},
 					PipelineRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					OCI: Artifact{
 						Format:         "simplesigning",
-						StorageBackend: sets.NewString("oci", "tekton"),
+						StorageBackend: sets.New[string]("oci", "tekton"),
 						Signer:         "x509",
 					},
 				},
@@ -370,16 +370,16 @@ func TestParse(t *testing.T) {
 					TaskRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					PipelineRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					OCI: Artifact{
 						Format:         "simplesigning",
-						StorageBackend: sets.NewString("oci"),
+						StorageBackend: sets.New[string]("oci"),
 						Signer:         "x509",
 					},
 				},
@@ -419,16 +419,16 @@ func TestParse(t *testing.T) {
 					TaskRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					PipelineRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					OCI: Artifact{
 						Format:         "simplesigning",
-						StorageBackend: sets.NewString("oci"),
+						StorageBackend: sets.New[string]("oci"),
 						Signer:         "x509",
 					},
 				},
@@ -451,16 +451,16 @@ func TestParse(t *testing.T) {
 					TaskRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					PipelineRuns: Artifact{
 						Format:         "in-toto",
 						Signer:         "x509",
-						StorageBackend: sets.NewString("tekton"),
+						StorageBackend: sets.New[string]("tekton"),
 					},
 					OCI: Artifact{
 						Format:         "simplesigning",
-						StorageBackend: sets.NewString("oci"),
+						StorageBackend: sets.New[string]("oci"),
 						Signer:         "x509",
 					},
 				},

--- a/pkg/config/zz_generated.deepcopy.go
+++ b/pkg/config/zz_generated.deepcopy.go
@@ -30,7 +30,7 @@ func (in *Artifact) DeepCopyInto(out *Artifact) {
 	*out = *in
 	if in.StorageBackend != nil {
 		in, out := &in.StorageBackend, &out.StorageBackend
-		*out = make(sets.String, len(*in))
+		*out = make(sets.Set[string], len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -38,6 +38,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/logging"
 )
 
@@ -249,10 +250,10 @@ func verifySignature(ctx context.Context, t *testing.T, c *clients, obj objects.
 	var key string
 	switch obj.GetObject().(type) {
 	case *objects.TaskRunObject:
-		configuredBackends = cfg.Artifacts.TaskRuns.StorageBackend.List()
+		configuredBackends = sets.List[string](cfg.Artifacts.TaskRuns.StorageBackend)
 		key = fmt.Sprintf("taskrun-%s", obj.GetUID())
 	case *objects.PipelineRunObject:
-		configuredBackends = cfg.Artifacts.PipelineRuns.StorageBackend.List()
+		configuredBackends = sets.List[string](cfg.Artifacts.PipelineRuns.StorageBackend)
 		key = fmt.Sprintf("pipelinerun-%s", obj.GetUID())
 	}
 


### PR DESCRIPTION
# Changes

There are no expected functional changes in this PR.

In the k8s.io/apimachinery/pkg/util/sets package, the specified Set types like `sets.String` have been deprecated in favor of generics like `sets.Set[string]`. This PR changes to the generic type across our repository.

See: https://pkg.go.dev/k8s.io/apimachinery/pkg/util/sets

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

/kind cleanup

# Release Notes

``` release-note
ACTION REQUIRED: users who build against Tekton Chains may need to adjust their code to use
generic `sets.Set[string]` types in place of `sets.String` types. See https://pkg.go.dev/k8s.io/apimachinery/pkg/util/sets for details.
```
