### PR TITLE
Hygiene: enabled presets properly.

### DIFF
--- a/.golang-ci.yaml
+++ b/.golang-ci.yaml
@@ -34,10 +34,10 @@ linters:
   - usestdlibvars
   - whitespace
   - wrapcheck
-# Enabling presets means that new linters that we automatically adopt new
-# linters that augment a preset. This also opts us in for replacement linters
-# when a linter is deprecated.
-presets:
+  # Enabling presets means that new linters that we automatically adopt new
+  # linters that augment a preset. This also opts us in for replacement linters
+  # when a linter is deprecated.
+  presets:
   - bugs
   - comment
   - complexity
@@ -63,8 +63,8 @@ issues:
   max-same-issues: 0
   include:
   # Enable off-by-default rules for revive requiring that all exported elements have a properly formatted comment.
-  - EXC0012
-  - EXC0014
+  - EXC0012 # https://golangci-lint.run/usage/false-positives/#exc0012
+  - EXC0014 # https://golangci-lint.run/usage/false-positives/#exc0014
 run:
   issues-exit-code: 1
   build-tags:


### PR DESCRIPTION
# Changes

This change _looks_ like it's whitespace only, but in fact it enables the `presets` in the config!

Prior to this change, the top-level `presets:` field was ignored. This change properly indents `  presets:`
so that it's a field in the `linters:` block -- thereby enabling the presets.

Also: added comments documenting the enabled `issues.include` items.

There are no functional changes in this PR.

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
