### PR TITLE
Remove log parameters in favor of context based logging.

### DIFF
--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -14,6 +14,7 @@ limitations under the License.
 package artifacts
 
 import (
+	"context"
 	_ "crypto/sha256" // Recommended by go-digest.
 	_ "crypto/sha512" // Recommended by go-digest.
 	"fmt"
@@ -26,8 +27,8 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/logging"
 )
 
 const (
@@ -40,9 +41,8 @@ var (
 )
 
 type Signable interface {
-	ExtractObjects(obj objects.TektonObject) []interface{}
+	ExtractObjects(ctx context.Context, obj objects.TektonObject) []interface{}
 	StorageBackend(cfg config.Config) sets.Set[string]
-
 	Signer(cfg config.Config) string
 	PayloadFormat(cfg config.Config) config.PayloadType
 	// FullKey returns the full identifier for a signable artifact.
@@ -57,9 +57,7 @@ type Signable interface {
 	Enabled(cfg config.Config) bool
 }
 
-type TaskRunArtifact struct {
-	Logger *zap.SugaredLogger
-}
+type TaskRunArtifact struct{}
 
 var _ Signable = &TaskRunArtifact{}
 
@@ -74,7 +72,7 @@ func (ta *TaskRunArtifact) FullKey(obj interface{}) string {
 	return fmt.Sprintf("%s-%s-%s-%s", gvk.Group, gvk.Version, gvk.Kind, tro.UID)
 }
 
-func (ta *TaskRunArtifact) ExtractObjects(obj objects.TektonObject) []interface{} {
+func (ta *TaskRunArtifact) ExtractObjects(ctx context.Context, obj objects.TektonObject) []interface{} {
 	return []interface{}{obj}
 }
 
@@ -98,9 +96,7 @@ func (ta *TaskRunArtifact) Enabled(cfg config.Config) bool {
 	return cfg.Artifacts.TaskRuns.Enabled()
 }
 
-type PipelineRunArtifact struct {
-	Logger *zap.SugaredLogger
-}
+type PipelineRunArtifact struct{}
 
 var _ Signable = &PipelineRunArtifact{}
 
@@ -115,7 +111,7 @@ func (pa *PipelineRunArtifact) FullKey(obj interface{}) string {
 	return fmt.Sprintf("%s-%s-%s-%s", gvk.Group, gvk.Version, gvk.Kind, pro.UID)
 }
 
-func (pa *PipelineRunArtifact) ExtractObjects(obj objects.TektonObject) []interface{} {
+func (pa *PipelineRunArtifact) ExtractObjects(ctx context.Context, obj objects.TektonObject) []interface{} {
 	return []interface{}{obj}
 }
 
@@ -140,9 +136,7 @@ func (pa *PipelineRunArtifact) Enabled(cfg config.Config) bool {
 	return cfg.Artifacts.PipelineRuns.Enabled()
 }
 
-type OCIArtifact struct {
-	Logger *zap.SugaredLogger
-}
+type OCIArtifact struct{}
 
 var _ Signable = &OCIArtifact{}
 
@@ -159,7 +153,8 @@ type StructuredSignable struct {
 	Digest string
 }
 
-func (oa *OCIArtifact) ExtractObjects(obj objects.TektonObject) []interface{} {
+func (oa *OCIArtifact) ExtractObjects(ctx context.Context, obj objects.TektonObject) []interface{} {
+	log := logging.FromContext(ctx)
 	objs := []interface{}{}
 
 	// TODO: Not applicable to PipelineRuns, should look into a better way to separate this out
@@ -189,7 +184,7 @@ func (oa *OCIArtifact) ExtractObjects(obj objects.TektonObject) []interface{} {
 		for _, image := range imageResourceNames {
 			dgst, err := name.NewDigest(fmt.Sprintf("%s@%s", image.url, image.digest))
 			if err != nil {
-				oa.Logger.Error(err)
+				log.Error(err)
 				continue
 			}
 			objs = append(objs, dgst)
@@ -197,15 +192,16 @@ func (oa *OCIArtifact) ExtractObjects(obj objects.TektonObject) []interface{} {
 	}
 
 	// Now check TaskResults
-	resultImages := ExtractOCIImagesFromResults(obj, oa.Logger)
+	resultImages := ExtractOCIImagesFromResults(ctx, obj)
 	objs = append(objs, resultImages...)
 
 	return objs
 }
 
-func ExtractOCIImagesFromResults(obj objects.TektonObject, logger *zap.SugaredLogger) []interface{} {
+func ExtractOCIImagesFromResults(ctx context.Context, obj objects.TektonObject) []interface{} {
+	logger := logging.FromContext(ctx)
 	objs := []interface{}{}
-	ss := extractTargetFromResults(obj, "IMAGE_URL", "IMAGE_DIGEST", logger)
+	ss := extractTargetFromResults(ctx, obj, "IMAGE_URL", "IMAGE_DIGEST")
 	for _, s := range ss {
 		if s == nil || s.Digest == "" || s.URI == "" {
 			continue
@@ -243,9 +239,10 @@ func ExtractOCIImagesFromResults(obj objects.TektonObject, logger *zap.SugaredLo
 }
 
 // ExtractSignableTargetFromResults extracts signable targets that aim to generate intoto provenance as materials within TaskRun results and store them as StructuredSignable.
-func ExtractSignableTargetFromResults(obj objects.TektonObject, logger *zap.SugaredLogger) []*StructuredSignable {
+func ExtractSignableTargetFromResults(ctx context.Context, obj objects.TektonObject) []*StructuredSignable {
+	logger := logging.FromContext(ctx)
 	objs := []*StructuredSignable{}
-	ss := extractTargetFromResults(obj, "ARTIFACT_URI", "ARTIFACT_DIGEST", logger)
+	ss := extractTargetFromResults(ctx, obj, "ARTIFACT_URI", "ARTIFACT_DIGEST")
 	// Only add it if we got both the signable URI and digest.
 	for _, s := range ss {
 		if s == nil || s.Digest == "" || s.URI == "" {
@@ -267,7 +264,8 @@ func (s *StructuredSignable) FullRef() string {
 	return fmt.Sprintf("%s@%s", s.URI, s.Digest)
 }
 
-func extractTargetFromResults(obj objects.TektonObject, identifierSuffix string, digestSuffix string, logger *zap.SugaredLogger) map[string]*StructuredSignable {
+func extractTargetFromResults(ctx context.Context, obj objects.TektonObject, identifierSuffix string, digestSuffix string) map[string]*StructuredSignable {
+	logger := logging.FromContext(ctx)
 	ss := map[string]*StructuredSignable{}
 
 	for _, res := range obj.GetResults() {
@@ -303,10 +301,11 @@ func extractTargetFromResults(obj objects.TektonObject, identifierSuffix string,
 }
 
 // RetrieveMaterialsFromStructuredResults retrieves structured results from Tekton Object, and convert them into materials.
-func RetrieveMaterialsFromStructuredResults(obj objects.TektonObject, categoryMarker string, logger *zap.SugaredLogger) []common.ProvenanceMaterial {
+func RetrieveMaterialsFromStructuredResults(ctx context.Context, obj objects.TektonObject, categoryMarker string) []common.ProvenanceMaterial {
+	logger := logging.FromContext(ctx)
 	// Retrieve structured provenance for inputs.
 	mats := []common.ProvenanceMaterial{}
-	ssts := ExtractStructuredTargetFromResults(obj, ArtifactsInputsResultName, logger)
+	ssts := ExtractStructuredTargetFromResults(ctx, obj, ArtifactsInputsResultName)
 	for _, s := range ssts {
 		if err := checkDigest(s.Digest); err != nil {
 			logger.Debugf("Digest for %s not in the right format: %s, %v", s.URI, s.Digest, err)
@@ -325,7 +324,8 @@ func RetrieveMaterialsFromStructuredResults(obj objects.TektonObject, categoryMa
 
 // ExtractStructuredTargetFromResults extracts structured signable targets aim to generate intoto provenance as materials within TaskRun results and store them as StructuredSignable.
 // categoryMarker categorizes signable targets into inputs and outputs.
-func ExtractStructuredTargetFromResults(obj objects.TektonObject, categoryMarker string, logger *zap.SugaredLogger) []*StructuredSignable {
+func ExtractStructuredTargetFromResults(ctx context.Context, obj objects.TektonObject, categoryMarker string) []*StructuredSignable {
+	logger := logging.FromContext(ctx)
 	objs := []*StructuredSignable{}
 	if categoryMarker != ArtifactsInputsResultName && categoryMarker != ArtifactsOutputsResultName {
 		return objs

--- a/pkg/chains/formats/slsa/extract/extract.go
+++ b/pkg/chains/formats/slsa/extract/extract.go
@@ -17,6 +17,7 @@ limitations under the License.
 package extract
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -28,7 +29,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
-	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 )
 
 // SubjectDigests returns software artifacts produced from the TaskRun/PipelineRun object
@@ -38,10 +39,11 @@ import (
 //   - have suffix `IMAGE_URL` & `IMAGE_DIGEST` or `ARTIFACT_URI` & `ARTIFACT_DIGEST` pair.
 //   - the `*_DIGEST` field must be in the format of "<algorithm>:<actual-sha>" where the algorithm must be "sha256" and actual sha must be valid per https://github.com/opencontainers/image-spec/blob/main/descriptor.md#sha-256.
 //   - the `*_URL` or `*_URI` fields cannot be empty.
-func SubjectDigests(obj objects.TektonObject, logger *zap.SugaredLogger) []intoto.Subject {
+func SubjectDigests(ctx context.Context, obj objects.TektonObject) []intoto.Subject {
+	logger := logging.FromContext(ctx)
 	var subjects []intoto.Subject
 
-	imgs := artifacts.ExtractOCIImagesFromResults(obj, logger)
+	imgs := artifacts.ExtractOCIImagesFromResults(ctx, obj)
 	for _, i := range imgs {
 		if d, ok := i.(name.Digest); ok {
 			subjects = append(subjects, intoto.Subject{
@@ -53,7 +55,7 @@ func SubjectDigests(obj objects.TektonObject, logger *zap.SugaredLogger) []intot
 		}
 	}
 
-	sts := artifacts.ExtractSignableTargetFromResults(obj, logger)
+	sts := artifacts.ExtractSignableTargetFromResults(ctx, obj)
 	for _, obj := range sts {
 		splits := strings.Split(obj.Digest, ":")
 		if len(splits) != 2 {
@@ -68,7 +70,7 @@ func SubjectDigests(obj objects.TektonObject, logger *zap.SugaredLogger) []intot
 		})
 	}
 
-	ssts := artifacts.ExtractStructuredTargetFromResults(obj, artifacts.ArtifactsOutputsResultName, logger)
+	ssts := artifacts.ExtractStructuredTargetFromResults(ctx, obj, artifacts.ArtifactsOutputsResultName)
 	for _, s := range ssts {
 		splits := strings.Split(s.Digest, ":")
 		alg := splits[0]
@@ -129,9 +131,9 @@ func SubjectDigests(obj objects.TektonObject, logger *zap.SugaredLogger) []intot
 // - It first extracts intoto subjects from run object results and converts the subjects
 // to a slice of string URIs in the format of "NAME" + "@" + "ALGORITHM" + ":" + "DIGEST".
 // - If no subjects could be extracted from results, then an empty slice is returned.
-func RetrieveAllArtifactURIs(obj objects.TektonObject, logger *zap.SugaredLogger) []string {
+func RetrieveAllArtifactURIs(ctx context.Context, obj objects.TektonObject) []string {
 	result := []string{}
-	subjects := SubjectDigests(obj, logger)
+	subjects := SubjectDigests(ctx, obj)
 
 	for _, s := range subjects {
 		for algo, digest := range s.Digest {

--- a/pkg/chains/formats/slsa/extract/extract_test.go
+++ b/pkg/chains/formats/slsa/extract/extract_test.go
@@ -98,6 +98,7 @@ func TestSubjectDigestsAndRetrieveAllArtifactURIs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := logtesting.TestContextWithLogger(t)
 			// test both taskrun object and pipelinerun object
 			runObjects := []objects.TektonObject{
 				createTaskRunObjectWithResults(tc.results),
@@ -105,12 +106,12 @@ func TestSubjectDigestsAndRetrieveAllArtifactURIs(t *testing.T) {
 			}
 
 			for _, o := range runObjects {
-				gotSubjects := extract.SubjectDigests(o, logtesting.TestLogger(t))
+				gotSubjects := extract.SubjectDigests(ctx, o)
 				if diff := cmp.Diff(tc.wantSubjects, gotSubjects, cmpopts.SortSlices(func(x, y intoto.Subject) bool { return x.Name < y.Name })); diff != "" {
 					t.Errorf("Wrong subjects extracted, diff=%s", diff)
 				}
 
-				gotURIs := extract.RetrieveAllArtifactURIs(o, logtesting.TestLogger(t))
+				gotURIs := extract.RetrieveAllArtifactURIs(ctx, o)
 				if diff := cmp.Diff(tc.wantFullURLs, gotURIs, cmpopts.SortSlices(func(x, y string) bool { return x < y })); diff != "" {
 					t.Errorf("Wrong URIs extracted, diff=%s", diff)
 				}

--- a/pkg/chains/formats/slsa/internal/material/material.go
+++ b/pkg/chains/formats/slsa/internal/material/material.go
@@ -17,6 +17,7 @@ limitations under the License.
 package material
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -27,7 +28,6 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
-	"go.uber.org/zap"
 )
 
 const (
@@ -79,7 +79,7 @@ func AddImageIDToMaterials(imageID string, mats *[]common.ProvenanceMaterial) er
 }
 
 // Materials constructs `predicate.materials` section by collecting all the artifacts that influence a taskrun such as source code repo and step&sidecar base images.
-func Materials(tro *objects.TaskRunObject, logger *zap.SugaredLogger) ([]common.ProvenanceMaterial, error) {
+func Materials(ctx context.Context, tro *objects.TaskRunObject) ([]common.ProvenanceMaterial, error) {
 	var mats []common.ProvenanceMaterial
 
 	// add step images
@@ -103,7 +103,7 @@ func Materials(tro *objects.TaskRunObject, logger *zap.SugaredLogger) ([]common.
 		return mats, nil
 	}
 
-	sms := artifacts.RetrieveMaterialsFromStructuredResults(tro, artifacts.ArtifactsInputsResultName, logger)
+	sms := artifacts.RetrieveMaterialsFromStructuredResults(ctx, tro, artifacts.ArtifactsInputsResultName)
 	mats = append(mats, sms...)
 
 	if tro.Spec.Resources != nil {

--- a/pkg/chains/formats/slsa/internal/material/material_test.go
+++ b/pkg/chains/formats/slsa/internal/material/material_test.go
@@ -65,7 +65,8 @@ status:
 		},
 	}
 
-	got, err := Materials(objects.NewTaskRunObject(taskRun), logtesting.TestLogger(t))
+	ctx := logtesting.TestContextWithLogger(t)
+	got, err := Materials(ctx, objects.NewTaskRunObject(taskRun))
 	if err != nil {
 		t.Fatalf("Did not expect an error but got %v", err)
 	}
@@ -238,7 +239,8 @@ func TestMaterials(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mat, err := Materials(objects.NewTaskRunObject(tc.taskRun), logtesting.TestLogger(t))
+			ctx := logtesting.TestContextWithLogger(t)
+			mat, err := Materials(ctx, objects.NewTaskRunObject(tc.taskRun))
 			if err != nil {
 				t.Fatalf("Did not expect an error but got %v", err)
 			}

--- a/pkg/chains/formats/slsa/v1/intotoite6.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v1/taskrun"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
-	"knative.dev/pkg/logging"
 )
 
 const (
@@ -53,12 +52,11 @@ func (i *InTotoIte6) Wrap() bool {
 }
 
 func (i *InTotoIte6) CreatePayload(ctx context.Context, obj interface{}) (interface{}, error) {
-	logger := logging.FromContext(ctx)
 	switch v := obj.(type) {
 	case *objects.TaskRunObject:
-		return taskrun.GenerateAttestation(i.builderID, v, logger)
+		return taskrun.GenerateAttestation(ctx, i.builderID, v)
 	case *objects.PipelineRunObject:
-		return pipelinerun.GenerateAttestation(i.builderID, v, logger)
+		return pipelinerun.GenerateAttestation(ctx, i.builderID, v)
 	default:
 		return nil, fmt.Errorf("intoto does not support type: %s", v)
 	}

--- a/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
@@ -210,7 +210,8 @@ func TestBuildConfig(t *testing.T) {
 			},
 		},
 	}
-	got := buildConfig(pro, logtesting.TestLogger(t))
+	ctx := logtesting.TestContextWithLogger(t)
+	got := buildConfig(ctx, pro)
 	if diff := cmp.Diff(expected, got); diff != "" {
 		t.Errorf("buildConfig(): -want +got: %s", diff)
 	}
@@ -418,7 +419,8 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 			}
 			pro := createPro("../../testdata/pipelinerun1.json")
 			pro.Status.PipelineSpec.Tasks[BUILD_TASK] = pt
-			got := buildConfig(pro, logtesting.TestLogger(t))
+			ctx := logtesting.TestContextWithLogger(t)
+			got := buildConfig(ctx, pro)
 			if diff := cmp.Diff(expected, got); diff != "" {
 				t.Errorf("buildConfig(): -want +got: %s", diff)
 			}
@@ -486,7 +488,8 @@ func TestMaterials(t *testing.T) {
 		{URI: "abc", Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
 		{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
 	}
-	got, err := materials(pro, logtesting.TestLogger(t))
+	ctx := logtesting.TestContextWithLogger(t)
+	got, err := materials(ctx, pro)
 	if err != nil {
 		t.Error(err)
 	}
@@ -519,7 +522,8 @@ func TestStructuredResultMaterials(t *testing.T) {
 			},
 		},
 	}
-	got, err := materials(proStructuredResults, logtesting.TestLogger(t))
+	ctx := logtesting.TestContextWithLogger(t)
+	got, err := materials(ctx, proStructuredResults)
 	if err != nil {
 		t.Errorf("error while extracting materials: %v", err)
 	}
@@ -538,7 +542,8 @@ func TestSubjectDigests(t *testing.T) {
 		},
 	}
 
-	gotSubjects := extract.SubjectDigests(pro, logtesting.TestLogger(t))
+	ctx := logtesting.TestContextWithLogger(t)
+	gotSubjects := extract.SubjectDigests(ctx, pro)
 	opts := append(ignore, cmpopts.SortSlices(func(x, y intoto.Subject) bool { return x.Name < y.Name }))
 	if diff := cmp.Diff(gotSubjects, wantSubjects, opts...); diff != "" {
 		t.Errorf("Differences in subjects: -want +got: %s", diff)

--- a/pkg/chains/formats/slsa/v1/taskrun/provenance_test.go
+++ b/pkg/chains/formats/slsa/v1/taskrun/provenance_test.go
@@ -330,8 +330,9 @@ func TestGetSubjectDigests(t *testing.T) {
 			},
 		},
 	}
+	ctx := logtesting.TestContextWithLogger(t)
 	tro := objects.NewTaskRunObject(tr)
-	got := extract.SubjectDigests(tro, logtesting.TestLogger(t))
+	got := extract.SubjectDigests(ctx, tro)
 	if !reflect.DeepEqual(expected, got) {
 		if d := cmp.Diff(expected, got); d != "" {
 			t.Log(d)

--- a/pkg/chains/formats/slsa/v1/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v1/taskrun/taskrun.go
@@ -14,6 +14,8 @@ limitations under the License.
 package taskrun
 
 import (
+	"context"
+
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
@@ -22,13 +24,12 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/material"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"go.uber.org/zap"
 )
 
-func GenerateAttestation(builderID string, tro *objects.TaskRunObject, logger *zap.SugaredLogger) (interface{}, error) {
-	subjects := extract.SubjectDigests(tro, logger)
+func GenerateAttestation(ctx context.Context, builderID string, tro *objects.TaskRunObject) (interface{}, error) {
+	subjects := extract.SubjectDigests(ctx, tro)
 
-	mat, err := material.Materials(tro, logger)
+	mat, err := material.Materials(ctx, tro)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chains/formats/slsa/v2/slsav2.go
+++ b/pkg/chains/formats/slsa/v2/slsav2.go
@@ -51,7 +51,7 @@ func (s *Slsa) Wrap() bool {
 func (s *Slsa) CreatePayload(ctx context.Context, obj interface{}) (interface{}, error) {
 	switch v := obj.(type) {
 	case *objects.TaskRunObject:
-		return taskrun.GenerateAttestation(s.builderID, s.Type(), v, ctx)
+		return taskrun.GenerateAttestation(ctx, s.builderID, s.Type(), v)
 	default:
 		return nil, fmt.Errorf("intoto does not support type: %s", v)
 	}

--- a/pkg/chains/formats/slsa/v2/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v2/taskrun/taskrun.go
@@ -28,7 +28,6 @@ import (
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"knative.dev/pkg/logging"
 )
 
 // BuildConfig is the custom Chains format to fill out the
@@ -38,11 +37,9 @@ type BuildConfig struct {
 	TaskRunResults []v1beta1.TaskRunResult `json:"taskRunResults"`
 }
 
-func GenerateAttestation(builderID string, payloadType config.PayloadType, tro *objects.TaskRunObject, ctx context.Context) (interface{}, error) {
-	logger := logging.FromContext(ctx)
-	subjects := extract.SubjectDigests(tro, logger)
-
-	mat, err := material.Materials(tro, logger)
+func GenerateAttestation(ctx context.Context, builderID string, payloadType config.PayloadType, tro *objects.TaskRunObject) (interface{}, error) {
+	subjects := extract.SubjectDigests(ctx, tro)
+	mat, err := material.Materials(ctx, tro)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chains/formats/slsa/v2/taskrun/taskrun_test.go
+++ b/pkg/chains/formats/slsa/v2/taskrun/taskrun_test.go
@@ -358,7 +358,8 @@ func TestGetSubjectDigests(t *testing.T) {
 		},
 	}
 	tro := objects.NewTaskRunObject(tr)
-	got := extract.SubjectDigests(tro, logtesting.TestLogger(t))
+	ctx := logtesting.TestContextWithLogger(t)
+	got := extract.SubjectDigests(ctx, tro)
 	if !reflect.DeepEqual(expected, got) {
 		if d := cmp.Diff(expected, got); d != "" {
 			t.Log(d)

--- a/pkg/chains/rekor.go
+++ b/pkg/chains/rekor.go
@@ -27,7 +27,6 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/chains/signing"
 	"github.com/tektoncd/chains/pkg/config"
-	"go.uber.org/zap"
 )
 
 const (
@@ -35,8 +34,7 @@ const (
 )
 
 type rekor struct {
-	c      *client.Rekor
-	logger *zap.SugaredLogger
+	c *client.Rekor
 }
 
 type rekorClient interface {
@@ -75,14 +73,13 @@ func publicKeyOrCert(signer signing.Signer, cert string) ([]byte, error) {
 	return pem, nil
 }
 
-var getRekor = func(url string, l *zap.SugaredLogger) (rekorClient, error) {
+var getRekor = func(url string) (rekorClient, error) {
 	rekorClient, err := rc.GetRekorClient(url)
 	if err != nil {
 		return nil, err
 	}
 	return &rekor{
-		c:      rekorClient,
-		logger: l,
+		c: rekorClient,
 	}, nil
 }
 

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -30,7 +30,6 @@ import (
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/logging"
 )
@@ -48,7 +47,8 @@ type ObjectSigner struct {
 	Pipelineclientset versioned.Interface
 }
 
-func allSigners(ctx context.Context, sp string, cfg config.Config, l *zap.SugaredLogger) map[string]signing.Signer {
+func allSigners(ctx context.Context, sp string, cfg config.Config) map[string]signing.Signer {
+	l := logging.FromContext(ctx)
 	all := map[string]signing.Signer{}
 	neededSigners := map[string]struct{}{
 		cfg.Artifacts.OCI.Signer:          {},
@@ -62,14 +62,14 @@ func allSigners(ctx context.Context, sp string, cfg config.Config, l *zap.Sugare
 		}
 		switch s {
 		case signing.TypeX509:
-			signer, err := x509.NewSigner(ctx, sp, cfg, l)
+			signer, err := x509.NewSigner(ctx, sp, cfg)
 			if err != nil {
 				l.Warnf("error configuring x509 signer: %s", err)
 				continue
 			}
 			all[s] = signer
 		case signing.TypeKMS:
-			signer, err := kms.NewSigner(ctx, cfg.Signers.KMS, l)
+			signer, err := kms.NewSigner(ctx, cfg.Signers.KMS)
 			if err != nil {
 				l.Warnf("error configuring kms signer with config %v: %s", cfg.Signers.KMS, err)
 				continue
@@ -84,16 +84,16 @@ func allSigners(ctx context.Context, sp string, cfg config.Config, l *zap.Sugare
 }
 
 // TODO: Hook this up to config.
-func getSignableTypes(obj objects.TektonObject, logger *zap.SugaredLogger) ([]artifacts.Signable, error) {
+func getSignableTypes(ctx context.Context, obj objects.TektonObject) ([]artifacts.Signable, error) {
 	switch v := obj.GetObject().(type) {
 	case *v1beta1.TaskRun:
 		return []artifacts.Signable{
-			&artifacts.TaskRunArtifact{Logger: logger},
-			&artifacts.OCIArtifact{Logger: logger},
+			&artifacts.TaskRunArtifact{},
+			&artifacts.OCIArtifact{},
 		}, nil
 	case *v1beta1.PipelineRun:
 		return []artifacts.Signable{
-			&artifacts.PipelineRunArtifact{Logger: logger},
+			&artifacts.PipelineRunArtifact{},
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported type of object to be signed: %s", v)
@@ -106,12 +106,12 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 	cfg := *config.FromContext(ctx)
 	logger := logging.FromContext(ctx)
 
-	signableTypes, err := getSignableTypes(tektonObj, logger)
+	signableTypes, err := getSignableTypes(ctx, tektonObj)
 	if err != nil {
 		return err
 	}
 
-	signers := allSigners(ctx, o.SecretPath, cfg, logger)
+	signers := allSigners(ctx, o.SecretPath, cfg)
 
 	var merr *multierror.Error
 	extraAnnotations := map[string]string{}
@@ -129,7 +129,7 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 
 		// Extract all the "things" to be signed.
 		// We might have a few of each type (several binaries, or images)
-		objects := signableType.ExtractObjects(tektonObj)
+		objects := signableType.ExtractObjects(ctx, tektonObj)
 
 		// Go through each object one at a time.
 		for _, obj := range objects {
@@ -188,7 +188,7 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 			}
 
 			if shouldUploadTlog(cfg, tektonObj) {
-				rekorClient, err := getRekor(cfg.Transparency.URL, logger)
+				rekorClient, err := getRekor(cfg.Transparency.URL)
 				if err != nil {
 					return err
 				}

--- a/pkg/chains/signing/x509/x509_test.go
+++ b/pkg/chains/signing/x509/x509_test.go
@@ -15,7 +15,6 @@ package x509
 
 import (
 	"bytes"
-	"context"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/sha256"
@@ -54,8 +53,7 @@ MC4CAQAwBQYDK2VwBCIEIGQn0bJwshjwuVdnd/FylMk3Gvb89aGgH49bQpgzCY0n
 const token = `eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2Nzc1NjAyMTgsImV4cCI6MTY3NzU2MzgxOCwiaXNzIjoidXNlcjEyMyJ9.c-sDgCyuZA6VaIGl7Y3-9XxttW1PUkBeNBLE9gCKG8s`
 
 func TestCreateSignerFulcioEnabled(t *testing.T) {
-	ctx := context.Background()
-	logger := logtesting.TestLogger(t)
+	ctx := logtesting.TestContextWithLogger(t)
 	d := t.TempDir()
 	tk := filepath.Join(d, "token")
 	if err := os.WriteFile(tk, []byte(token), 0644); err != nil {
@@ -77,7 +75,7 @@ func TestCreateSignerFulcioEnabled(t *testing.T) {
 	if !cfg.Signers.X509.FulcioEnabled {
 		t.Fatal("fulcio is not enabled, expected to be enabled")
 	}
-	_, err = NewSigner(ctx, d, *cfg, logger)
+	_, err = NewSigner(ctx, d, *cfg)
 	if err != nil {
 		if !providers.Enabled(ctx) {
 			t.Fatal("fulcio provider not configured")
@@ -90,8 +88,7 @@ func TestCreateSignerFulcioEnabled(t *testing.T) {
 }
 
 func TestCreateSignerFulcioEnabledFilesystemProvider(t *testing.T) {
-	ctx := context.Background()
-	logger := logtesting.TestLogger(t)
+	ctx := logtesting.TestContextWithLogger(t)
 	d := t.TempDir()
 	tk := filepath.Join(d, "token")
 	if err := os.WriteFile(tk, []byte(token), 0644); err != nil {
@@ -114,7 +111,7 @@ func TestCreateSignerFulcioEnabledFilesystemProvider(t *testing.T) {
 	if !cfg.Signers.X509.FulcioEnabled {
 		t.Fatal("fulcio is not enabled, expected to be enabled")
 	}
-	_, err = NewSigner(ctx, d, *cfg, logger)
+	_, err = NewSigner(ctx, d, *cfg)
 	if err != nil {
 		if !providers.Enabled(ctx) {
 			t.Fatal("fulcio provider not configured")
@@ -127,8 +124,7 @@ func TestCreateSignerFulcioEnabledFilesystemProvider(t *testing.T) {
 }
 
 func TestSigner_SignECDSA(t *testing.T) {
-	ctx := context.Background()
-	logger := logtesting.TestLogger(t)
+	ctx := logtesting.TestContextWithLogger(t)
 	d := t.TempDir()
 	p := filepath.Join(d, "x509.pem")
 	if err := os.WriteFile(p, []byte(ecdsaPriv), 0644); err != nil {
@@ -136,7 +132,7 @@ func TestSigner_SignECDSA(t *testing.T) {
 	}
 
 	// create a signer
-	signer, err := NewSigner(ctx, d, config.Config{}, logger)
+	signer, err := NewSigner(ctx, d, config.Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,8 +165,7 @@ func TestSigner_SignECDSA(t *testing.T) {
 
 func TestSigner_SignED25519(t *testing.T) {
 	t.Skip("skip test until ed25519 signing is implemented")
-	ctx := context.Background()
-	logger := logtesting.TestLogger(t)
+	ctx := logtesting.TestContextWithLogger(t)
 	d := t.TempDir()
 	p := filepath.Join(d, "x509.pem")
 	if err := os.WriteFile(p, []byte(ed25519Priv), 0644); err != nil {
@@ -178,7 +173,7 @@ func TestSigner_SignED25519(t *testing.T) {
 	}
 
 	// create a signer
-	signer, err := NewSigner(ctx, d, config.Config{}, logger)
+	signer, err := NewSigner(ctx, d, config.Config{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -28,10 +28,8 @@ import (
 	"github.com/tektoncd/chains/pkg/test/tekton"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
-	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"knative.dev/pkg/logging"
 	rtesting "knative.dev/pkg/reconciler/testing"
 
 	_ "github.com/tektoncd/chains/pkg/chains/formats/all"
@@ -332,8 +330,6 @@ func TestSigner_Transparency(t *testing.T) {
 }
 
 func TestSigningObjects(t *testing.T) {
-	ctx, _ := rtesting.SetupFakeContext(t)
-	logger := logging.FromContext(ctx)
 	tests := []struct {
 		name       string
 		signers    []string
@@ -396,7 +392,8 @@ func TestSigningObjects(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			signers := allSigners(ctx, tt.SecretPath, tt.config, logger)
+			ctx, _ := rtesting.SetupFakeContext(t)
+			signers := allSigners(ctx, tt.SecretPath, tt.config)
 			var signerTypes []string
 			for _, signer := range signers {
 				signerTypes = append(signerTypes, signer.Type())
@@ -418,7 +415,7 @@ func fakeAllBackends(backends []*mockBackend) map[string]storage.Backend {
 
 func setupMocks(rekor *mockRekor) func() {
 	oldRekor := getRekor
-	getRekor = func(_ string, _ *zap.SugaredLogger) (rekorClient, error) {
+	getRekor = func(_ string) (rekorClient, error) {
 		return rekor, nil
 	}
 	return func() {

--- a/pkg/chains/storage/docdb/docdb.go
+++ b/pkg/chains/storage/docdb/docdb.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
-	"go.uber.org/zap"
 	"gocloud.dev/docstore"
 	_ "gocloud.dev/docstore/awsdynamodb"
 	_ "gocloud.dev/docstore/gcpfirestore"
@@ -34,8 +33,7 @@ const (
 // Backend is a storage backend that stores signed payloads in the TaskRun metadata as an annotation.
 // It is stored as base64 encoded JSON.
 type Backend struct {
-	logger *zap.SugaredLogger
-	coll   *docstore.Collection
+	coll *docstore.Collection
 }
 
 type SignedDocument struct {
@@ -48,7 +46,7 @@ type SignedDocument struct {
 }
 
 // NewStorageBackend returns a new Tekton StorageBackend that stores signatures on a TaskRun
-func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, cfg config.Config) (*Backend, error) {
+func NewStorageBackend(ctx context.Context, cfg config.Config) (*Backend, error) {
 	url := cfg.Storage.DocDB.URL
 	coll, err := docstore.OpenCollection(ctx, url)
 	if err != nil {
@@ -56,8 +54,7 @@ func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, cfg confi
 	}
 
 	return &Backend{
-		logger: logger,
-		coll:   coll,
+		coll: coll,
 	}, nil
 }
 

--- a/pkg/chains/storage/docdb/docdb_test.go
+++ b/pkg/chains/storage/docdb/docdb_test.go
@@ -24,6 +24,7 @@ import (
 	_ "gocloud.dev/docstore/memdocstore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
@@ -67,10 +68,10 @@ func TestBackend_StorePayload(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.WithLogger(ctx, logtesting.TestLogger(t))
 			// Prepare the document.
 			b := &Backend{
-				logger: logtesting.TestLogger(t),
-				coll:   coll,
+				coll: coll,
 			}
 			sb, err := json.Marshal(tt.args.rawPayload)
 			if err != nil {

--- a/pkg/chains/storage/gcs/gcs_test.go
+++ b/pkg/chains/storage/gcs/gcs_test.go
@@ -26,12 +26,10 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	logtesting "knative.dev/pkg/logging/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 func TestBackend_StorePayload(t *testing.T) {
-	ctx, _ := rtesting.SetupFakeContext(t)
 
 	type args struct {
 		tr        *v1beta1.TaskRun
@@ -77,11 +75,10 @@ func TestBackend_StorePayload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
+			ctx, _ := rtesting.SetupFakeContext(t)
 			mockGcsWrite := &mockGcsWriter{objects: map[string]*bytes.Buffer{}}
 			mockGcsRead := &mockGcsReader{objects: mockGcsWrite.objects}
 			b := &Backend{
-				logger: logtesting.TestLogger(t),
 				writer: mockGcsWrite,
 				reader: mockGcsRead,
 				cfg:    config.Config{Storage: config.StorageConfigs{GCS: config.GCSStorageConfig{Bucket: "foo"}}},

--- a/pkg/chains/storage/oci/oci_test.go
+++ b/pkg/chains/storage/oci/oci_test.go
@@ -58,8 +58,6 @@ var (
 )
 
 func TestBackend_StorePayload(t *testing.T) {
-	ctx := context.Background()
-
 	// Create registry server
 	s := httptest.NewServer(registry.New())
 	defer s.Close()
@@ -223,8 +221,8 @@ func TestBackend_StorePayload(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := logtesting.TestContextWithLogger(t)
 			b := &Backend{
-				logger: logtesting.TestLogger(t),
 				getAuthenticator: func(context.Context, objects.TektonObject, kubernetes.Interface) (remote.Option, error) {
 					return remote.WithAuthFromKeychain(authn.DefaultKeychain), nil
 				},

--- a/pkg/chains/storage/pubsub/pubsub_test.go
+++ b/pkg/chains/storage/pubsub/pubsub_test.go
@@ -82,8 +82,7 @@ func TestBackend_StorePayload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &Backend{
-				logger: logger,
-				cfg:    tt.fields.cfg,
+				cfg: tt.fields.cfg,
 			}
 			addr := fmt.Sprintf("mem://%s", tt.fields.cfg.Storage.PubSub.Topic)
 			ctx, _ := rtesting.SetupFakeContext(t)

--- a/pkg/chains/storage/storage.go
+++ b/pkg/chains/storage/storage.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/storage/tekton"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 )
@@ -42,7 +41,7 @@ type Backend interface {
 }
 
 // InitializeBackends creates and initializes every configured storage backend.
-func InitializeBackends(ctx context.Context, ps versioned.Interface, kc kubernetes.Interface, logger *zap.SugaredLogger, cfg config.Config) (map[string]Backend, error) {
+func InitializeBackends(ctx context.Context, ps versioned.Interface, kc kubernetes.Interface, cfg config.Config) (map[string]Backend, error) {
 	// Add an entry here for every configured backend
 	configuredBackends := []string{}
 	if cfg.Artifacts.TaskRuns.Enabled() {
@@ -60,30 +59,30 @@ func InitializeBackends(ctx context.Context, ps versioned.Interface, kc kubernet
 	for _, backendType := range configuredBackends {
 		switch backendType {
 		case gcs.StorageBackendGCS:
-			gcsBackend, err := gcs.NewStorageBackend(ctx, logger, cfg)
+			gcsBackend, err := gcs.NewStorageBackend(ctx, cfg)
 			if err != nil {
 				return nil, err
 			}
 			backends[backendType] = gcsBackend
 		case tekton.StorageBackendTekton:
-			backends[backendType] = tekton.NewStorageBackend(ps, logger)
+			backends[backendType] = tekton.NewStorageBackend(ps)
 		case oci.StorageBackendOCI:
-			ociBackend := oci.NewStorageBackend(ctx, logger, kc, cfg)
+			ociBackend := oci.NewStorageBackend(ctx, kc, cfg)
 			backends[backendType] = ociBackend
 		case docdb.StorageTypeDocDB:
-			docdbBackend, err := docdb.NewStorageBackend(ctx, logger, cfg)
+			docdbBackend, err := docdb.NewStorageBackend(ctx, cfg)
 			if err != nil {
 				return nil, err
 			}
 			backends[backendType] = docdbBackend
 		case grafeas.StorageBackendGrafeas:
-			grafeasBackend, err := grafeas.NewStorageBackend(ctx, logger, cfg)
+			grafeasBackend, err := grafeas.NewStorageBackend(ctx, cfg)
 			if err != nil {
 				return nil, err
 			}
 			backends[backendType] = grafeasBackend
 		case pubsub.StorageBackendPubSub:
-			pubsubBackend, err := pubsub.NewStorageBackend(ctx, logger, cfg)
+			pubsubBackend, err := pubsub.NewStorageBackend(ctx, cfg)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/chains/storage/storage_test.go
+++ b/pkg/chains/storage/storage_test.go
@@ -22,6 +22,7 @@ import (
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	"k8s.io/apimachinery/pkg/util/sets"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
@@ -69,18 +70,18 @@ func TestInitializeBackends(t *testing.T) {
 			want: []string{"pubsub"},
 			cfg:  config.Config{Artifacts: config.ArtifactConfigs{TaskRuns: config.Artifact{StorageBackend: sets.New[string]("pubsub")}}}},
 	}
-	logger := logtesting.TestLogger(t)
 	ctx, _ := rtesting.SetupFakeContext(t)
 	ps := fakepipelineclient.Get(ctx)
 	kc := fakekubeclient.Get(ctx)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := InitializeBackends(ctx, ps, kc, logger, tt.cfg)
+			ctx := logging.WithLogger(ctx, logtesting.TestLogger(t))
+			got, err := InitializeBackends(ctx, ps, kc, tt.cfg)
 			if err != nil {
 				t.Errorf("InitializeBackends() error = %v", err)
 				return
 			}
-			logger.Debugf("Backend: %v", got)
+			t.Logf("Backend: %v", got)
 			gotTypes := []string{}
 			for _, g := range got {
 				gotTypes = append(gotTypes, g.Type())

--- a/pkg/chains/storage/tekton/tekton_test.go
+++ b/pkg/chains/storage/tekton/tekton_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	logtesting "knative.dev/pkg/logging/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -87,7 +86,6 @@ func TestBackend_StorePayload(t *testing.T) {
 
 			b := &Backend{
 				pipelineclientset: c,
-				logger:            logtesting.TestLogger(t),
 			}
 			payload, err := json.Marshal(tt.payload)
 			if err != nil {

--- a/pkg/chains/verifier.go
+++ b/pkg/chains/verifier.go
@@ -46,18 +46,18 @@ func (tv *TaskRunVerifier) VerifyTaskRun(ctx context.Context, tr *v1beta1.TaskRu
 
 	// TODO: Hook this up to config.
 	enabledSignableTypes := []artifacts.Signable{
-		&artifacts.TaskRunArtifact{Logger: logger},
-		&artifacts.OCIArtifact{Logger: logger},
+		&artifacts.TaskRunArtifact{},
+		&artifacts.OCIArtifact{},
 	}
 
 	trObj := objects.NewTaskRunObject(tr)
 
 	// Storage
-	allBackends, err := storage.InitializeBackends(ctx, tv.Pipelineclientset, tv.KubeClient, logger, cfg)
+	allBackends, err := storage.InitializeBackends(ctx, tv.Pipelineclientset, tv.KubeClient, cfg)
 	if err != nil {
 		return err
 	}
-	signers := allSigners(ctx, tv.SecretPath, cfg, logger)
+	signers := allSigners(ctx, tv.SecretPath, cfg)
 
 	for _, signableType := range enabledSignableTypes {
 		if !signableType.Enabled(cfg) {

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -57,7 +57,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 			cfg := *value.(*config.Config)
 
 			// get all backends for storing provenance
-			backends, err := storage.InitializeBackends(ctx, pipelineClient, kubeClient, logger, cfg)
+			backends, err := storage.InitializeBackends(ctx, pipelineClient, kubeClient, cfg)
 			if err != nil {
 				logger.Error(err)
 			}

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -52,7 +52,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 			cfg := *value.(*config.Config)
 
 			// get all backends for storing provenance
-			backends, err := storage.InitializeBackends(ctx, pipelineClient, kubeClient, logger, cfg)
+			backends, err := storage.InitializeBackends(ctx, pipelineClient, kubeClient, cfg)
 			if err != nil {
 				logger.Error(err)
 			}

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -39,7 +39,6 @@ import (
 	pipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"knative.dev/pkg/logging"
 )
 
 func getTr(ctx context.Context, t *testing.T, c pipelineclientset.Interface, name, ns string) (tr *v1beta1.TaskRun) {
@@ -236,11 +235,8 @@ func verifySignature(ctx context.Context, t *testing.T, c *clients, obj objects.
 		return
 	}
 
-	// Prepare the logger.
-	logger := logging.FromContext(ctx)
-
 	// Initialize the backend.
-	backends, err := chainsstorage.InitializeBackends(ctx, c.PipelineClient, c.KubeClient, logger, *cfg)
+	backends, err := chainsstorage.InitializeBackends(ctx, c.PipelineClient, c.KubeClient, *cfg)
 	if err != nil {
 		t.Errorf("error initializing backends: %s", err)
 		return


### PR DESCRIPTION

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

This ensures that we're plumbing through added logging contexts to where ever they are being used.



# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Client libraries now use context logging consistently.

BREAKING CHANGE: Client libraries no longer take in explicit loggers. Instead, context logging is used everywhere.
```
