### PR TITLE
Replace deprecated type/function

### DIFF
--- a/pkg/artifacts/signable_test.go
+++ b/pkg/artifacts/signable_test.go
@@ -166,11 +166,11 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						TaskRunResults: []v1beta1.TaskRunResult{
 							{
 								Name:  "IMAGE_URL",
-								Value: *v1beta1.NewArrayOrString("gcr.io/foo/bat"),
+								Value: *v1beta1.NewStructuredValues("gcr.io/foo/bat"),
 							},
 							{
 								Name:  "IMAGE_DIGEST",
-								Value: *v1beta1.NewArrayOrString("sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b4"),
+								Value: *v1beta1.NewStructuredValues("sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b4"),
 							},
 						},
 						TaskSpec: &v1beta1.TaskSpec{
@@ -211,11 +211,11 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						TaskRunResults: []v1beta1.TaskRunResult{
 							{
 								Name:  "IMAGE_URL",
-								Value: *v1beta1.NewArrayOrString("foo"),
+								Value: *v1beta1.NewStructuredValues("foo"),
 							},
 							{
 								Name:  "gibberish",
-								Value: *v1beta1.NewArrayOrString("baz"),
+								Value: *v1beta1.NewStructuredValues("baz"),
 							},
 						},
 						ResourcesResult: []v1beta1.PipelineResourceResult{
@@ -264,7 +264,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						TaskRunResults: []v1beta1.TaskRunResult{
 							{
 								Name:  "IMAGES",
-								Value: *v1beta1.NewArrayOrString(fmt.Sprintf("  \n \tgcr.io/foo/bar@%s\n,gcr.io/baz/bar@%s", digest1, digest2)),
+								Value: *v1beta1.NewStructuredValues(fmt.Sprintf("  \n \tgcr.io/foo/bar@%s\n,gcr.io/baz/bar@%s", digest1, digest2)),
 							},
 						},
 					},
@@ -282,7 +282,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						TaskRunResults: []v1beta1.TaskRunResult{
 							{
 								Name:  "IMAGES",
-								Value: *v1beta1.NewArrayOrString(fmt.Sprintf("gcr.io/foo/bar@%s\ngcr.io/baz/bar@%s\n\n", digest1, digest2)),
+								Value: *v1beta1.NewStructuredValues(fmt.Sprintf("gcr.io/foo/bar@%s\ngcr.io/baz/bar@%s\n\n", digest1, digest2)),
 							},
 						},
 					},
@@ -316,16 +316,16 @@ func TestExtractOCIImagesFromResults(t *testing.T) {
 		Status: v1beta1.TaskRunStatus{
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				TaskRunResults: []v1beta1.TaskRunResult{
-					{Name: "img1_IMAGE_URL", Value: *v1beta1.NewArrayOrString("img1")},
-					{Name: "img1_IMAGE_DIGEST", Value: *v1beta1.NewArrayOrString(digest1)},
-					{Name: "img2_IMAGE_URL", Value: *v1beta1.NewArrayOrString("img2")},
-					{Name: "img2_IMAGE_DIGEST", Value: *v1beta1.NewArrayOrString(digest2)},
-					{Name: "IMAGE_URL", Value: *v1beta1.NewArrayOrString("img3")},
-					{Name: "IMAGE_DIGEST", Value: *v1beta1.NewArrayOrString(digest1)},
-					{Name: "img4_IMAGE_URL", Value: *v1beta1.NewArrayOrString("img4")},
-					{Name: "img5_IMAGE_DIGEST", Value: *v1beta1.NewArrayOrString("sha123:abc")},
-					{Name: "empty_str_IMAGE_DIGEST", Value: *v1beta1.NewArrayOrString("")},
-					{Name: "empty_str_IMAGE_URL", Value: *v1beta1.NewArrayOrString("")},
+					{Name: "img1_IMAGE_URL", Value: *v1beta1.NewStructuredValues("img1")},
+					{Name: "img1_IMAGE_DIGEST", Value: *v1beta1.NewStructuredValues(digest1)},
+					{Name: "img2_IMAGE_URL", Value: *v1beta1.NewStructuredValues("img2")},
+					{Name: "img2_IMAGE_DIGEST", Value: *v1beta1.NewStructuredValues(digest2)},
+					{Name: "IMAGE_URL", Value: *v1beta1.NewStructuredValues("img3")},
+					{Name: "IMAGE_DIGEST", Value: *v1beta1.NewStructuredValues(digest1)},
+					{Name: "img4_IMAGE_URL", Value: *v1beta1.NewStructuredValues("img4")},
+					{Name: "img5_IMAGE_DIGEST", Value: *v1beta1.NewStructuredValues("sha123:abc")},
+					{Name: "empty_str_IMAGE_DIGEST", Value: *v1beta1.NewStructuredValues("")},
+					{Name: "empty_str_IMAGE_URL", Value: *v1beta1.NewStructuredValues("")},
 				},
 			},
 		},
@@ -353,19 +353,19 @@ func TestExtractSignableTargetFromResults(t *testing.T) {
 		Status: v1beta1.TaskRunStatus{
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				TaskRunResults: []v1beta1.TaskRunResult{
-					{Name: "mvn1_ARTIFACT_URI", Value: *v1beta1.NewArrayOrString("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre")},
-					{Name: "mvn1_ARTIFACT_DIGEST", Value: *v1beta1.NewArrayOrString(digest1)},
-					{Name: "mvn1_pom_ARTIFACT_URI", Value: *v1beta1.NewArrayOrString("com.google.guava:guava:31.0-jre.pom")},
-					{Name: "mvn1_pom_ARTIFACT_DIGEST", Value: *v1beta1.NewArrayOrString(digest2)},
-					{Name: "mvn1_src_ARTIFACT_URI", Value: *v1beta1.NewArrayOrString("com.google.guava:guava:31.0-jre-sources.jar")},
-					{Name: "mvn1_src_ARTIFACT_DIGEST", Value: *v1beta1.NewArrayOrString(digest3)},
-					{Name: "mvn2_ARTIFACT_URI", Value: *v1beta1.NewArrayOrString("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/a.b.c:d:1.0-jre")},
-					{Name: "mvn2_ARTIFACT_DIGEST", Value: *v1beta1.NewArrayOrString(digest4)},
-					{Name: "ARTIFACT_URI", Value: *v1beta1.NewArrayOrString("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/empty_prefix")},
-					{Name: "ARTIFACT_DIGEST", Value: *v1beta1.NewArrayOrString(digest1)},
-					{Name: "miss_target_name_ARTIFACT_DIGEST", Value: *v1beta1.NewArrayOrString(digest1)},
-					{Name: "wrong_digest_format_ARTIFACT_URI", Value: *v1beta1.NewArrayOrString("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/wrong_digest_format")},
-					{Name: "wrong_digest_format_ARTIFACT_DIGEST", Value: *v1beta1.NewArrayOrString("abc")},
+					{Name: "mvn1_ARTIFACT_URI", Value: *v1beta1.NewStructuredValues("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre")},
+					{Name: "mvn1_ARTIFACT_DIGEST", Value: *v1beta1.NewStructuredValues(digest1)},
+					{Name: "mvn1_pom_ARTIFACT_URI", Value: *v1beta1.NewStructuredValues("com.google.guava:guava:31.0-jre.pom")},
+					{Name: "mvn1_pom_ARTIFACT_DIGEST", Value: *v1beta1.NewStructuredValues(digest2)},
+					{Name: "mvn1_src_ARTIFACT_URI", Value: *v1beta1.NewStructuredValues("com.google.guava:guava:31.0-jre-sources.jar")},
+					{Name: "mvn1_src_ARTIFACT_DIGEST", Value: *v1beta1.NewStructuredValues(digest3)},
+					{Name: "mvn2_ARTIFACT_URI", Value: *v1beta1.NewStructuredValues("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/a.b.c:d:1.0-jre")},
+					{Name: "mvn2_ARTIFACT_DIGEST", Value: *v1beta1.NewStructuredValues(digest4)},
+					{Name: "ARTIFACT_URI", Value: *v1beta1.NewStructuredValues("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/empty_prefix")},
+					{Name: "ARTIFACT_DIGEST", Value: *v1beta1.NewStructuredValues(digest1)},
+					{Name: "miss_target_name_ARTIFACT_DIGEST", Value: *v1beta1.NewStructuredValues(digest1)},
+					{Name: "wrong_digest_format_ARTIFACT_URI", Value: *v1beta1.NewStructuredValues("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/wrong_digest_format")},
+					{Name: "wrong_digest_format_ARTIFACT_DIGEST", Value: *v1beta1.NewStructuredValues("abc")},
 				},
 			},
 		},

--- a/pkg/chains/formats/slsa/attest/attest.go
+++ b/pkg/chains/formats/slsa/attest/attest.go
@@ -61,7 +61,7 @@ func Invocation(source *v1beta1.ConfigSource, params []v1beta1.Param, paramSpecs
 	i := slsa.ProvenanceInvocation{
 		ConfigSource: convertConfigSource(source),
 	}
-	iParams := make(map[string]v1beta1.ArrayOrString)
+	iParams := make(map[string]v1beta1.ParamValue)
 
 	// get implicit parameters from defaults
 	for _, p := range paramSpecs {

--- a/pkg/chains/formats/slsa/v1/intotoite6_test.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6_test.go
@@ -91,7 +91,7 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 					Digest:     map[string]string{"sha1": "ab123"},
 					EntryPoint: "build.yaml",
 				},
-				Parameters: map[string]v1beta1.ArrayOrString{
+				Parameters: map[string]v1beta1.ParamValue{
 					"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
 					"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 					"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
@@ -205,7 +205,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 					Digest:     map[string]string{"sha1": "28b123"},
 					EntryPoint: "pipeline.yaml",
 				},
-				Parameters: map[string]v1beta1.ArrayOrString{
+				Parameters: map[string]v1beta1.ParamValue{
 					"IMAGE": {Type: "string", StringVal: "test.io/test/image"},
 				},
 			},
@@ -242,7 +242,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 								Digest:     common.DigestSet{"sha1": "x123"},
 								EntryPoint: "git-clone.yaml",
 							},
-							Parameters: map[string]v1beta1.ArrayOrString{
+							Parameters: map[string]v1beta1.ParamValue{
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 								"revision":          {Type: "string", StringVal: ""},
@@ -255,14 +255,14 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 						Results: []v1beta1.TaskRunResult{
 							{
 								Name: "some-uri_DIGEST",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 								},
 							},
 							{
 								Name: "some-uri",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "pkg:deb/debian/curl@7.50.3-1",
 								},
@@ -314,7 +314,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 								Digest:     map[string]string{"sha1": "ab123"},
 								EntryPoint: "build.yaml",
 							},
-							Parameters: map[string]v1beta1.ArrayOrString{
+							Parameters: map[string]v1beta1.ParamValue{
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 								"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
@@ -326,14 +326,14 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 						Results: []v1beta1.TaskRunResult{
 							{
 								Name: "IMAGE_DIGEST",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 								},
 							},
 							{
 								Name: "IMAGE_URL",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "gcr.io/my/image",
 								},
@@ -423,7 +423,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{},
-				Parameters: map[string]v1beta1.ArrayOrString{
+				Parameters: map[string]v1beta1.ParamValue{
 					"IMAGE": {Type: "string", StringVal: "test.io/test/image"},
 				},
 			},
@@ -460,7 +460,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 								Digest:     common.DigestSet{"sha1": "x123"},
 								EntryPoint: "git-clone.yaml",
 							},
-							Parameters: map[string]v1beta1.ArrayOrString{
+							Parameters: map[string]v1beta1.ParamValue{
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 								"revision":          {Type: "string", StringVal: ""},
@@ -473,14 +473,14 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 						Results: []v1beta1.TaskRunResult{
 							{
 								Name: "some-uri_DIGEST",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 								},
 							},
 							{
 								Name: "some-uri",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "pkg:deb/debian/curl@7.50.3-1",
 								},
@@ -532,7 +532,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 								Digest:     map[string]string{"sha1": "ab123"},
 								EntryPoint: "build.yaml",
 							},
-							Parameters: map[string]v1beta1.ArrayOrString{
+							Parameters: map[string]v1beta1.ParamValue{
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 								"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
@@ -544,14 +544,14 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 						Results: []v1beta1.TaskRunResult{
 							{
 								Name: "IMAGE_DIGEST",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 								},
 							},
 							{
 								Name: "IMAGE_URL",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "gcr.io/my/image",
 								},
@@ -625,7 +625,7 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 					Digest:     common.DigestSet{"sha1": "x123"},
 					EntryPoint: "git-clone.yaml",
 				},
-				Parameters: map[string]v1beta1.ArrayOrString{
+				Parameters: map[string]v1beta1.ParamValue{
 					"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
 					"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 					"revision":          {Type: "string"},
@@ -705,7 +705,7 @@ func TestMultipleSubjects(t *testing.T) {
 				},
 			},
 			Invocation: slsa.ProvenanceInvocation{
-				Parameters: map[string]v1beta1.ArrayOrString{},
+				Parameters: map[string]v1beta1.ParamValue{},
 			},
 			BuildConfig: taskrun.BuildConfig{
 				Steps: []attest.StepAttestation{

--- a/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
@@ -70,7 +70,7 @@ func TestInvocation(t *testing.T) {
 			Digest:     map[string]string{"sha1": "28b123"},
 			EntryPoint: "pipeline.yaml",
 		},
-		Parameters: map[string]v1beta1.ArrayOrString{
+		Parameters: map[string]v1beta1.ParamValue{
 			"IMAGE": {Type: "string", StringVal: "test.io/test/image"},
 		},
 	}
@@ -110,7 +110,7 @@ func TestBuildConfig(t *testing.T) {
 						Digest:     common.DigestSet{"sha1": "x123"},
 						EntryPoint: "git-clone.yaml",
 					},
-					Parameters: map[string]v1beta1.ArrayOrString{
+					Parameters: map[string]v1beta1.ParamValue{
 						"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
 						"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 						"revision":          {Type: "string", StringVal: ""},
@@ -123,14 +123,14 @@ func TestBuildConfig(t *testing.T) {
 				Results: []v1beta1.TaskRunResult{
 					{
 						Name: "some-uri_DIGEST",
-						Value: v1beta1.ArrayOrString{
+						Value: v1beta1.ParamValue{
 							Type:      v1beta1.ParamTypeString,
 							StringVal: "sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 						},
 					},
 					{
 						Name: "some-uri",
-						Value: v1beta1.ArrayOrString{
+						Value: v1beta1.ParamValue{
 							Type:      v1beta1.ParamTypeString,
 							StringVal: "pkg:deb/debian/curl@7.50.3-1",
 						},
@@ -182,7 +182,7 @@ func TestBuildConfig(t *testing.T) {
 						Digest:     map[string]string{"sha1": "ab123"},
 						EntryPoint: "build.yaml",
 					},
-					Parameters: map[string]v1beta1.ArrayOrString{
+					Parameters: map[string]v1beta1.ParamValue{
 						"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
 						"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 						"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
@@ -194,14 +194,14 @@ func TestBuildConfig(t *testing.T) {
 				Results: []v1beta1.TaskRunResult{
 					{
 						Name: "IMAGE_DIGEST",
-						Value: v1beta1.ArrayOrString{
+						Value: v1beta1.ParamValue{
 							Type:      v1beta1.ParamTypeString,
 							StringVal: "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 						},
 					},
 					{
 						Name: "IMAGE_URL",
-						Value: v1beta1.ArrayOrString{
+						Value: v1beta1.ParamValue{
 							Type:      v1beta1.ParamTypeString,
 							StringVal: "gcr.io/my/image",
 						},
@@ -230,11 +230,11 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 			params: []v1beta1.Param{
 				{
 					Name:  "CHAINS-GIT_COMMIT",
-					Value: v1beta1.ArrayOrString{Type: "string", StringVal: "$(tasks.git-clone.results.commit)"},
+					Value: v1beta1.ParamValue{Type: "string", StringVal: "$(tasks.git-clone.results.commit)"},
 				},
 				{
 					Name:  "CHAINS-GIT_URL",
-					Value: v1beta1.ArrayOrString{Type: "string", StringVal: "$(tasks.git-clone.results.url)"},
+					Value: v1beta1.ParamValue{Type: "string", StringVal: "$(tasks.git-clone.results.url)"},
 				},
 			},
 			whenExpressions: nil,
@@ -301,7 +301,7 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 								Digest:     common.DigestSet{"sha1": "x123"},
 								EntryPoint: "git-clone.yaml",
 							},
-							Parameters: map[string]v1beta1.ArrayOrString{
+							Parameters: map[string]v1beta1.ParamValue{
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
 								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
 								"url":               {Type: "string", StringVal: "https://git.test.com"},
@@ -316,14 +316,14 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 						Results: []v1beta1.TaskRunResult{
 							{
 								Name: "some-uri_DIGEST",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 								},
 							},
 							{
 								Name: "some-uri",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "pkg:deb/debian/curl@7.50.3-1",
 								},
@@ -375,7 +375,7 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 								Digest:     map[string]string{"sha1": "ab123"},
 								EntryPoint: "build.yaml",
 							},
-							Parameters: map[string]v1beta1.ArrayOrString{
+							Parameters: map[string]v1beta1.ParamValue{
 								// TODO: Is this right?
 								// "CHAINS-GIT_COMMIT": {Type: "string", StringVal: "abcd"},
 								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
@@ -391,14 +391,14 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 						Results: []v1beta1.TaskRunResult{
 							{
 								Name: "IMAGE_DIGEST",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 								},
 							},
 							{
 								Name: "IMAGE_URL",
-								Value: v1beta1.ArrayOrString{
+								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
 									StringVal: "gcr.io/my/image",
 								},

--- a/pkg/chains/formats/slsa/v1/taskrun/provenance_test.go
+++ b/pkg/chains/formats/slsa/v1/taskrun/provenance_test.go
@@ -165,7 +165,7 @@ status:
 	}
 
 	expected := slsa.ProvenanceInvocation{
-		Parameters: map[string]v1beta1.ArrayOrString{
+		Parameters: map[string]v1beta1.ParamValue{
 			"my-param":                      {Type: "string", StringVal: "string-param"},
 			"my-array-param":                {Type: "array", ArrayVal: []string{"my", "array"}},
 			"my-default-param":              {Type: "string", StringVal: "string-default-param"},
@@ -221,39 +221,39 @@ func TestGetSubjectDigests(t *testing.T) {
 				TaskRunResults: []v1beta1.TaskRunResult{
 					{
 						Name:  "IMAGE_URL",
-						Value: *v1beta1.NewArrayOrString("registry/myimage"),
+						Value: *v1beta1.NewStructuredValues("registry/myimage"),
 					},
 					{
 						Name:  "IMAGE_DIGEST",
-						Value: *v1beta1.NewArrayOrString(digest1),
+						Value: *v1beta1.NewStructuredValues(digest1),
 					},
 					{
 						Name:  "mvn1_ARTIFACT_URI",
-						Value: *v1beta1.NewArrayOrString("maven-test-0.1.1.jar"),
+						Value: *v1beta1.NewStructuredValues("maven-test-0.1.1.jar"),
 					},
 					{
 						Name:  "mvn1_ARTIFACT_DIGEST",
-						Value: *v1beta1.NewArrayOrString(digest3),
+						Value: *v1beta1.NewStructuredValues(digest3),
 					},
 					{
 						Name:  "mvn1_pom_ARTIFACT_URI",
-						Value: *v1beta1.NewArrayOrString("maven-test-0.1.1.pom"),
+						Value: *v1beta1.NewStructuredValues("maven-test-0.1.1.pom"),
 					},
 					{
 						Name:  "mvn1_pom_ARTIFACT_DIGEST",
-						Value: *v1beta1.NewArrayOrString(digest4),
+						Value: *v1beta1.NewStructuredValues(digest4),
 					},
 					{
 						Name:  "mvn1_src_ARTIFACT_URI",
-						Value: *v1beta1.NewArrayOrString("maven-test-0.1.1-sources.jar"),
+						Value: *v1beta1.NewStructuredValues("maven-test-0.1.1-sources.jar"),
 					},
 					{
 						Name:  "mvn1_src_ARTIFACT_DIGEST",
-						Value: *v1beta1.NewArrayOrString(digest5),
+						Value: *v1beta1.NewStructuredValues(digest5),
 					},
 					{
 						Name:  "invalid_ARTIFACT_DIGEST",
-						Value: *v1beta1.NewArrayOrString(digest5),
+						Value: *v1beta1.NewStructuredValues(digest5),
 					},
 					{
 						Name: "mvn1_pkg" + "-" + artifacts.ArtifactsOutputsResultName,

--- a/pkg/chains/formats/slsa/v2/taskrun/taskrun_test.go
+++ b/pkg/chains/formats/slsa/v2/taskrun/taskrun_test.go
@@ -248,39 +248,39 @@ func TestGetSubjectDigests(t *testing.T) {
 				TaskRunResults: []v1beta1.TaskRunResult{
 					{
 						Name:  "IMAGE_URL",
-						Value: *v1beta1.NewArrayOrString("registry/myimage"),
+						Value: *v1beta1.NewStructuredValues("registry/myimage"),
 					},
 					{
 						Name:  "IMAGE_DIGEST",
-						Value: *v1beta1.NewArrayOrString(digest1),
+						Value: *v1beta1.NewStructuredValues(digest1),
 					},
 					{
 						Name:  "mvn1_ARTIFACT_URI",
-						Value: *v1beta1.NewArrayOrString("maven-test-0.1.1.jar"),
+						Value: *v1beta1.NewStructuredValues("maven-test-0.1.1.jar"),
 					},
 					{
 						Name:  "mvn1_ARTIFACT_DIGEST",
-						Value: *v1beta1.NewArrayOrString(digest3),
+						Value: *v1beta1.NewStructuredValues(digest3),
 					},
 					{
 						Name:  "mvn1_pom_ARTIFACT_URI",
-						Value: *v1beta1.NewArrayOrString("maven-test-0.1.1.pom"),
+						Value: *v1beta1.NewStructuredValues("maven-test-0.1.1.pom"),
 					},
 					{
 						Name:  "mvn1_pom_ARTIFACT_DIGEST",
-						Value: *v1beta1.NewArrayOrString(digest4),
+						Value: *v1beta1.NewStructuredValues(digest4),
 					},
 					{
 						Name:  "mvn1_src_ARTIFACT_URI",
-						Value: *v1beta1.NewArrayOrString("maven-test-0.1.1-sources.jar"),
+						Value: *v1beta1.NewStructuredValues("maven-test-0.1.1-sources.jar"),
 					},
 					{
 						Name:  "mvn1_src_ARTIFACT_DIGEST",
-						Value: *v1beta1.NewArrayOrString(digest5),
+						Value: *v1beta1.NewStructuredValues(digest5),
 					},
 					{
 						Name:  "invalid_ARTIFACT_DIGEST",
-						Value: *v1beta1.NewArrayOrString(digest5),
+						Value: *v1beta1.NewStructuredValues(digest5),
 					},
 					{
 						Name: "mvn1_pkg" + "-" + artifacts.ArtifactsOutputsResultName,

--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -44,7 +44,7 @@ type Object interface {
 type Result struct {
 	Name  string
 	Type  v1beta1.ResultsType
-	Value v1beta1.ArrayOrString
+	Value v1beta1.ParamValue
 }
 
 // Tekton object is an extended Kubernetes object with operations specific

--- a/pkg/chains/objects/objects_test.go
+++ b/pkg/chains/objects/objects_test.go
@@ -53,8 +53,8 @@ func getTaskRun() *v1beta1.TaskRun {
 							"digest": "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b7",
 						}),
 					},
-					{Name: "mvn1_ARTIFACT_URI", Value: *v1beta1.NewArrayOrString("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre")},
-					{Name: "mvn1_ARTIFACT_DIGEST", Value: *v1beta1.NewArrayOrString("sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
+					{Name: "mvn1_ARTIFACT_URI", Value: *v1beta1.NewStructuredValues("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre")},
+					{Name: "mvn1_ARTIFACT_DIGEST", Value: *v1beta1.NewStructuredValues("sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
 				},
 			},
 		},
@@ -78,8 +78,8 @@ func getPipelineRun() *v1beta1.PipelineRun {
 							"digest": "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b7",
 						}),
 					},
-					{Name: "mvn1_ARTIFACT_URI", Value: *v1beta1.NewArrayOrString("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre")},
-					{Name: "mvn1_ARTIFACT_DIGEST", Value: *v1beta1.NewArrayOrString("sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
+					{Name: "mvn1_ARTIFACT_URI", Value: *v1beta1.NewStructuredValues("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre")},
+					{Name: "mvn1_ARTIFACT_DIGEST", Value: *v1beta1.NewStructuredValues("sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
 				},
 			},
 		},
@@ -170,8 +170,8 @@ func TestPipelineRun_GetResults(t *testing.T) {
 					"digest": "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b7",
 				}),
 			},
-			{Name: "mvn1_ARTIFACT_URI", Value: *v1beta1.NewArrayOrString("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre")},
-			{Name: "mvn1_ARTIFACT_DIGEST", Value: *v1beta1.NewArrayOrString("sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
+			{Name: "mvn1_ARTIFACT_URI", Value: *v1beta1.NewStructuredValues("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre")},
+			{Name: "mvn1_ARTIFACT_DIGEST", Value: *v1beta1.NewStructuredValues("sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
 		})
 	})
 
@@ -190,8 +190,8 @@ func TestTaskRun_GetResults(t *testing.T) {
 					"digest": "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b7",
 				}),
 			},
-			{Name: "mvn1_ARTIFACT_URI", Value: *v1beta1.NewArrayOrString("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre")},
-			{Name: "mvn1_ARTIFACT_DIGEST", Value: *v1beta1.NewArrayOrString("sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
+			{Name: "mvn1_ARTIFACT_URI", Value: *v1beta1.NewStructuredValues("projects/test-project/locations/us-west4/repositories/test-repo/mavenArtifacts/com.google.guava:guava:31.0-jre")},
+			{Name: "mvn1_ARTIFACT_DIGEST", Value: *v1beta1.NewStructuredValues("sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
 		})
 	})
 

--- a/pkg/chains/storage/tekton/tekton_test.go
+++ b/pkg/chains/storage/tekton/tekton_test.go
@@ -50,7 +50,7 @@ func TestBackend_StorePayload(t *testing.T) {
 				Status: v1beta1.TaskRunStatus{
 					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 						TaskRunResults: []v1beta1.TaskRunResult{
-							{Name: "IMAGE_URL", Value: *v1beta1.NewArrayOrString("mockImage")},
+							{Name: "IMAGE_URL", Value: *v1beta1.NewStructuredValues("mockImage")},
 						},
 					},
 				},
@@ -70,7 +70,7 @@ func TestBackend_StorePayload(t *testing.T) {
 				Status: v1beta1.PipelineRunStatus{
 					PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 						PipelineResults: []v1beta1.PipelineRunResult{
-							{Name: "IMAGE_URL", Value: *v1beta1.NewArrayOrString("mockImage")},
+							{Name: "IMAGE_URL", Value: *v1beta1.NewStructuredValues("mockImage")},
 						},
 					},
 				},

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -725,9 +725,9 @@ func TestProvenanceMaterials(t *testing.T) {
 			commit := "my-git-commit"
 			url := "https://my-git-url"
 			params := []v1beta1.Param{{
-				Name: "CHAINS-GIT_COMMIT", Value: *v1beta1.NewArrayOrString(commit),
+				Name: "CHAINS-GIT_COMMIT", Value: *v1beta1.NewStructuredValues(commit),
 			}, {
-				Name: "CHAINS-GIT_URL", Value: *v1beta1.NewArrayOrString(url),
+				Name: "CHAINS-GIT_URL", Value: *v1beta1.NewStructuredValues(url),
 			}}
 			obj := test.getObjectWithParams(ns, params)
 

--- a/test/kaniko.go
+++ b/test/kaniko.go
@@ -48,10 +48,10 @@ func kanikoPipelineRun(ns string) objects.TektonObject {
 				}},
 				Results: []v1beta1.PipelineResult{{
 					Name:  "IMAGE_URL",
-					Value: *v1beta1.NewArrayOrString("$(tasks.kaniko.results.IMAGE_URL)"),
+					Value: *v1beta1.NewStructuredValues("$(tasks.kaniko.results.IMAGE_URL)"),
 				}, {
 					Name:  "IMAGE_DIGEST",
-					Value: *v1beta1.NewArrayOrString("$(tasks.kaniko.results.IMAGE_DIGEST)"),
+					Value: *v1beta1.NewStructuredValues("$(tasks.kaniko.results.IMAGE_DIGEST)"),
 				}},
 			},
 		},
@@ -133,7 +133,7 @@ func kanikoTask(t *testing.T, namespace, destinationImage string) *v1beta1.Task 
 
 func verifyKanikoTaskRun(namespace, destinationImage, publicKey string) objects.TektonObject {
 	script := `#!/busybox/sh
-	
+
 # save the public key
 echo "%s" > cosign.pub
 


### PR DESCRIPTION


<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

/kind cleanup

`ArrayOrString` type and `NewArrayOrString` function have been deprecated in Pipeline.

This commit replaces ArrayOrString with `ParamValue` and replace NewArrayOrString with `NewStructuredValues`.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

# Release Notes

``` release-note
NONE
```
