### PR TITLE
Re-add support for full task status for backward compatibility

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -72,8 +72,21 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *v1beta1.PipelineRun) 
 
 	// Get TaskRun names depending on whether embeddedstatus feature is set or not
 	var trs []string
-	for _, cr := range pr.Status.ChildReferences {
-		trs = append(trs, cr.Name)
+	if len(pr.Status.ChildReferences) == 0 || len(pr.Status.TaskRuns) > 0 || len(pr.Status.Runs) > 0 { //nolint:all //incompatible with pipelines v0.45
+		for trName, ptrs := range pr.Status.TaskRuns { //nolint:all //incompatible with pipelines v0.45
+			// TaskRuns within a PipelineRun may not have been finalized yet if the PipelineRun timeout
+			// has exceeded. Wait to process the PipelineRun on the next update, see
+			// https://github.com/tektoncd/pipeline/issues/4916
+			if ptrs.Status == nil || ptrs.Status.CompletionTime == nil {
+				logging.FromContext(ctx).Infof("taskrun %s within pipelinerun is not yet finalized: embedded status is not complete", trName)
+				return nil
+			}
+			trs = append(trs, trName)
+		}
+	} else {
+		for _, cr := range pr.Status.ChildReferences {
+			trs = append(trs, cr.Name)
+		}
 	}
 
 	// Signing both taskruns and pipelineruns causes a race condition when using oci storage


### PR DESCRIPTION
Tektoncd/pipelines release v0.45 came with some breaking changes. As a result, Chains needed to be updated. Support for fully embedded task status in pipelinerun status had to be removed. This PR re-adds support for those fields to make chains compatible with  older versions of Tekton pipelines (<v0.45).

This PR will close out Issue https://github.com/tektoncd/chains/issues/711

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Re-add support for full task status for backward compatibility
```
/kind feature
