### PR TITLE
Conform provenance.materials.uri to URI syntax

### DIFF
--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -35,6 +35,8 @@ import (
 const (
 	ArtifactsInputsResultName  = "ARTIFACT_INPUTS"
 	ArtifactsOutputsResultName = "ARTIFACT_OUTPUTS"
+	OCIScheme                  = "oci://"
+	GitSchemePrefix            = "git+"
 )
 
 var (

--- a/pkg/artifacts/signable_test.go
+++ b/pkg/artifacts/signable_test.go
@@ -503,21 +503,21 @@ func TestRetrieveMaterialsFromStructuredResults(t *testing.T) {
 					{
 						Name: "img1_input" + "_" + ArtifactsInputsResultName,
 						Value: *v1beta1.NewObject(map[string]string{
-							"uri":    "gcr.io/foo/bar",
+							"uri":    OCIScheme + "gcr.io/foo/bar",
 							"digest": "sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b7",
 						}),
 					},
 					{
 						Name: "img2_input_no_digest" + "_" + ArtifactsInputsResultName,
 						Value: *v1beta1.NewObject(map[string]string{
-							"uri":    "gcr.io/foo/foo",
+							"uri":    OCIScheme + "gcr.io/foo/foo",
 							"digest": "",
 						}),
 					},
 					{
 						Name: "img2_input_invalid_digest" + "_" + ArtifactsInputsResultName,
 						Value: *v1beta1.NewObject(map[string]string{
-							"uri":    "gcr.io/foo/foo",
+							"uri":    OCIScheme + "gcr.io/foo/foo",
 							"digest": "sha:123",
 						}),
 					},
@@ -527,7 +527,7 @@ func TestRetrieveMaterialsFromStructuredResults(t *testing.T) {
 	}
 	wantMaterials := []common.ProvenanceMaterial{
 		{
-			URI:    "gcr.io/foo/bar",
+			URI:    OCIScheme + "gcr.io/foo/bar",
 			Digest: map[string]string{"sha256": "05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b7"},
 		},
 	}

--- a/pkg/chains/formats/slsa/attest/attest.go
+++ b/pkg/chains/formats/slsa/attest/attest.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,7 +51,7 @@ func Step(step *v1beta1.Step, stepState *v1beta1.StepState) StepAttestation {
 	attestation.Arguments = step.Args
 
 	env := map[string]interface{}{}
-	env["image"] = stepState.ImageID
+	env["image"] = artifacts.OCIScheme + strings.TrimPrefix(stepState.ImageID, "docker-pullable://")
 	env["container"] = stepState.Name
 	attestation.Environment = env
 
@@ -118,9 +119,8 @@ func convertConfigSource(source *v1beta1.RefSource) slsa.ConfigSource {
 // ref: https://spdx.dev/spdx-specification-21-web-version/#h.49x2ik5
 // ref: https://github.com/in-toto/attestation/blob/849867bee97e33678f61cc6bd5da293097f84c25/spec/field_types.md
 func SPDXGit(url, revision string) string {
-	prefix := "git+"
 	if revision == "" {
-		return prefix + url + ".git"
+		return artifacts.GitSchemePrefix + url + ".git"
 	}
-	return prefix + url + fmt.Sprintf("@%s", revision)
+	return artifacts.GitSchemePrefix + url + fmt.Sprintf("@%s", revision)
 }

--- a/pkg/chains/formats/slsa/internal/material/material.go
+++ b/pkg/chains/formats/slsa/internal/material/material.go
@@ -66,7 +66,8 @@ func AddImageIDToMaterials(imageID string, mats *[]common.ProvenanceMaterial) er
 		if len(digest) == 2 {
 			// no point in partially populating the material
 			// do it if both conditions are valid.
-			m.URI = uriDigest[0]
+			uri := strings.TrimPrefix(uriDigest[0], "docker-pullable://")
+			m.URI = artifacts.OCIScheme + uri
 			m.Digest[digest[0]] = digest[1]
 			*mats = append(*mats, m)
 		} else {

--- a/pkg/chains/formats/slsa/internal/material/material_test.go
+++ b/pkg/chains/formats/slsa/internal/material/material_test.go
@@ -59,7 +59,7 @@ status:
 
 	want := []common.ProvenanceMaterial{
 		{
-			URI: "git+https://github.com/GoogleContainerTools/distroless.git",
+			URI: artifacts.GitSchemePrefix + "https://github.com/GoogleContainerTools/distroless.git",
 			Digest: common.DigestSet{
 				"sha1": "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
 			},
@@ -138,7 +138,7 @@ func TestMaterials(t *testing.T) {
 				},
 			},
 			{
-				URI: "git+https://github.com/GoogleContainerTools/distroless.git",
+				URI: artifacts.GitSchemePrefix + "https://github.com/GoogleContainerTools/distroless.git",
 				Digest: common.DigestSet{
 					"sha1": "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
 				},
@@ -159,7 +159,7 @@ func TestMaterials(t *testing.T) {
 		},
 		want: []common.ProvenanceMaterial{
 			{
-				URI: "git+github.com/something.git",
+				URI: artifacts.GitSchemePrefix + "github.com/something.git",
 				Digest: common.DigestSet{
 					"sha1": "my-commit",
 				},
@@ -185,13 +185,13 @@ func TestMaterials(t *testing.T) {
 		},
 		want: []common.ProvenanceMaterial{
 			{
-				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
+				URI: artifacts.OCIScheme + "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
 				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 			{
-				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
+				URI: artifacts.OCIScheme + "gcr.io/cloud-marketplace-containers/google/bazel",
 				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},
@@ -221,17 +221,17 @@ func TestMaterials(t *testing.T) {
 		},
 		want: []common.ProvenanceMaterial{
 			{
-				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
+				URI: artifacts.OCIScheme + "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
 				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			}, {
-				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
+				URI: artifacts.OCIScheme + "gcr.io/cloud-marketplace-containers/google/bazel",
 				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},
 			}, {
-				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/sidecar-git-init",
+				URI: artifacts.OCIScheme + "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/sidecar-git-init",
 				Digest: common.DigestSet{
 					"sha256": "a1234f6e7a69617db57b685893256f978436277094c21d43b153994acd8a09567",
 				},
@@ -272,19 +272,19 @@ func TestAddStepImagesToMaterials(t *testing.T) {
 		}},
 		want: []common.ProvenanceMaterial{
 			{
-				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
+				URI: artifacts.OCIScheme + "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
 				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 			{
-				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
+				URI: artifacts.OCIScheme + "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
 				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 			{
-				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
+				URI: artifacts.OCIScheme + "gcr.io/cloud-marketplace-containers/google/bazel",
 				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},
@@ -342,19 +342,19 @@ func TestAddSidecarImagesToMaterials(t *testing.T) {
 		}},
 		want: []common.ProvenanceMaterial{
 			{
-				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
+				URI: artifacts.OCIScheme + "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
 				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 			{
-				URI: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
+				URI: artifacts.OCIScheme + "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
 				Digest: common.DigestSet{
 					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 				},
 			},
 			{
-				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
+				URI: artifacts.OCIScheme + "gcr.io/cloud-marketplace-containers/google/bazel",
 				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},
@@ -403,7 +403,7 @@ func TestAddImageIDToMaterials(t *testing.T) {
 		imageID: "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 		want: []common.ProvenanceMaterial{
 			{
-				URI: "gcr.io/cloud-marketplace-containers/google/bazel",
+				URI: artifacts.OCIScheme + "gcr.io/cloud-marketplace-containers/google/bazel",
 				Digest: common.DigestSet{
 					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 				},

--- a/pkg/chains/formats/slsa/v1/intotoite6_test.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/attest"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v1/pipelinerun"
@@ -72,18 +73,18 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 			},
 			Materials: []common.ProvenanceMaterial{
 				{
-					URI:    "docker-pullable://gcr.io/test1/test1",
+					URI:    artifacts.OCIScheme + "gcr.io/test1/test1",
 					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
 				{
-					URI:    "docker-pullable://gcr.io/test2/test2",
+					URI:    artifacts.OCIScheme + "gcr.io/test2/test2",
 					Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 				},
 				{
-					URI:    "docker-pullable://gcr.io/test3/test3",
+					URI:    artifacts.OCIScheme + "gcr.io/test3/test3",
 					Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 				},
-				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskrun"}},
+				{URI: artifacts.GitSchemePrefix + "https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskrun"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{
@@ -110,21 +111,21 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 						Arguments: []string(nil),
 						Environment: map[string]interface{}{
 							"container": string("step1"),
-							"image":     string("docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"),
+							"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 						},
 					},
 					{
 						Arguments: []string(nil),
 						Environment: map[string]interface{}{
 							"container": string("step2"),
-							"image":     string("docker-pullable://gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"),
+							"image":     artifacts.OCIScheme + "gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
 						},
 					},
 					{
 						Arguments: []string(nil),
 						Environment: map[string]interface{}{
 							"container": string("step3"),
-							"image":     string("docker-pullable://gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"),
+							"image":     artifacts.OCIScheme + "gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
 						},
 					},
 				},
@@ -183,21 +184,21 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 			Materials: []common.ProvenanceMaterial{
 				{URI: "github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
 				{
-					URI:    "docker-pullable://gcr.io/test1/test1",
+					URI:    artifacts.OCIScheme + "gcr.io/test1/test1",
 					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
 				{URI: "github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
 				{
-					URI:    "docker-pullable://gcr.io/test2/test2",
+					URI:    artifacts.OCIScheme + "gcr.io/test2/test2",
 					Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 				},
 				{
-					URI:    "docker-pullable://gcr.io/test3/test3",
+					URI:    artifacts.OCIScheme + "gcr.io/test3/test3",
 					Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 				},
 				{URI: "github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
 				{URI: "abc", Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
-				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
+				{URI: artifacts.GitSchemePrefix + "https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{
@@ -231,7 +232,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
 									"container": "step1",
-									"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+									"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 								},
 								Annotations: nil,
 							},
@@ -284,7 +285,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 								EntryPoint: "",
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
-									"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+									"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 									"container": "step1",
 								},
 								Annotations: nil,
@@ -293,7 +294,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 								EntryPoint: "",
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
-									"image":     "docker-pullable://gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
+									"image":     artifacts.OCIScheme + "gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
 									"container": "step2",
 								},
 								Annotations: nil,
@@ -302,7 +303,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 								EntryPoint: "",
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
-									"image":     "docker-pullable://gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
+									"image":     artifacts.OCIScheme + "gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
 									"container": "step3",
 								},
 								Annotations: nil,
@@ -406,20 +407,20 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 			},
 			Materials: []common.ProvenanceMaterial{
 				{
-					URI:    "docker-pullable://gcr.io/test1/test1",
+					URI:    artifacts.OCIScheme + "gcr.io/test1/test1",
 					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
 				{URI: "github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
 				{
-					URI:    "docker-pullable://gcr.io/test2/test2",
+					URI:    artifacts.OCIScheme + "gcr.io/test2/test2",
 					Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 				},
 				{
-					URI:    "docker-pullable://gcr.io/test3/test3",
+					URI:    artifacts.OCIScheme + "gcr.io/test3/test3",
 					Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 				},
 				{URI: "github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
-				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
+				{URI: artifacts.GitSchemePrefix + "https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{},
@@ -449,7 +450,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
 									"container": "step1",
-									"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+									"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 								},
 								Annotations: nil,
 							},
@@ -502,7 +503,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 								EntryPoint: "",
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
-									"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+									"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 									"container": "step1",
 								},
 								Annotations: nil,
@@ -511,7 +512,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 								EntryPoint: "",
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
-									"image":     "docker-pullable://gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
+									"image":     artifacts.OCIScheme + "gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
 									"container": "step2",
 								},
 								Annotations: nil,
@@ -520,7 +521,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 								EntryPoint: "",
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
-									"image":     "docker-pullable://gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
+									"image":     artifacts.OCIScheme + "gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
 									"container": "step3",
 								},
 								Annotations: nil,
@@ -614,10 +615,10 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 			},
 			Materials: []common.ProvenanceMaterial{
 				{
-					URI:    "docker-pullable://gcr.io/test1/test1",
+					URI:    artifacts.OCIScheme + "gcr.io/test1/test1",
 					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
-				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskdefault"}},
+				{URI: artifacts.GitSchemePrefix + "https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskdefault"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{
@@ -643,7 +644,7 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 						Arguments:  []string(nil),
 						Environment: map[string]interface{}{
 							"container": string("step1"),
-							"image":     string("docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"),
+							"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 						},
 					},
 				},
@@ -700,7 +701,7 @@ func TestMultipleSubjects(t *testing.T) {
 			},
 			Materials: []common.ProvenanceMaterial{
 				{
-					URI:    "docker-pullable://gcr.io/test1/test1",
+					URI:    artifacts.OCIScheme + "gcr.io/test1/test1",
 					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
 			},
@@ -713,7 +714,7 @@ func TestMultipleSubjects(t *testing.T) {
 						Arguments: []string(nil),
 						Environment: map[string]interface{}{
 							"container": string("step1"),
-							"image":     string("docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"),
+							"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 						},
 					},
 				},

--- a/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
@@ -23,6 +23,7 @@ import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/attest"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
 	"github.com/tektoncd/chains/pkg/chains/objects"
@@ -99,7 +100,7 @@ func TestBuildConfig(t *testing.T) {
 						Arguments:  []string(nil),
 						Environment: map[string]interface{}{
 							"container": "step1",
-							"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+							"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 						},
 						Annotations: nil,
 					},
@@ -152,7 +153,7 @@ func TestBuildConfig(t *testing.T) {
 						EntryPoint: "",
 						Arguments:  []string(nil),
 						Environment: map[string]interface{}{
-							"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+							"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 							"container": "step1",
 						},
 						Annotations: nil,
@@ -161,7 +162,7 @@ func TestBuildConfig(t *testing.T) {
 						EntryPoint: "",
 						Arguments:  []string(nil),
 						Environment: map[string]interface{}{
-							"image":     "docker-pullable://gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
+							"image":     artifacts.OCIScheme + "gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
 							"container": "step2",
 						},
 						Annotations: nil,
@@ -170,7 +171,7 @@ func TestBuildConfig(t *testing.T) {
 						EntryPoint: "",
 						Arguments:  []string(nil),
 						Environment: map[string]interface{}{
-							"image":     "docker-pullable://gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
+							"image":     artifacts.OCIScheme + "gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
 							"container": "step3",
 						},
 						Annotations: nil,
@@ -290,7 +291,7 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
 									"container": "step1",
-									"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+									"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 								},
 								Annotations: nil,
 							},
@@ -345,7 +346,7 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 								EntryPoint: "",
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
-									"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+									"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 									"container": "step1",
 								},
 								Annotations: nil,
@@ -354,7 +355,7 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 								EntryPoint: "",
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
-									"image":     "docker-pullable://gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
+									"image":     artifacts.OCIScheme + "gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
 									"container": "step2",
 								},
 								Annotations: nil,
@@ -363,7 +364,7 @@ func TestBuildConfigTaskOrder(t *testing.T) {
 								EntryPoint: "",
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
-									"image":     "docker-pullable://gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
+									"image":     artifacts.OCIScheme + "gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
 									"container": "step3",
 								},
 								Annotations: nil,
@@ -472,21 +473,21 @@ func TestMaterials(t *testing.T) {
 	expected := []common.ProvenanceMaterial{
 		{URI: "github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
 		{
-			URI:    "docker-pullable://gcr.io/test1/test1",
+			URI:    artifacts.OCIScheme + "gcr.io/test1/test1",
 			Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 		},
 		{URI: "github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
 		{
-			URI:    "docker-pullable://gcr.io/test2/test2",
+			URI:    artifacts.OCIScheme + "gcr.io/test2/test2",
 			Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 		},
 		{
-			URI:    "docker-pullable://gcr.io/test3/test3",
+			URI:    artifacts.OCIScheme + "gcr.io/test3/test3",
 			Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 		},
 		{URI: "github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
 		{URI: "abc", Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
-		{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
+		{URI: artifacts.GitSchemePrefix + "https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
 	}
 	ctx := logtesting.TestContextWithLogger(t)
 	got, err := materials(ctx, pro)
@@ -502,16 +503,16 @@ func TestStructuredResultMaterials(t *testing.T) {
 	want := []common.ProvenanceMaterial{
 		{URI: "github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
 		{
-			URI:    "docker-pullable://gcr.io/test1/test1",
+			URI:    artifacts.OCIScheme + "gcr.io/test1/test1",
 			Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 		},
 		{URI: "github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
 		{
-			URI:    "docker-pullable://gcr.io/test2/test2",
+			URI:    artifacts.OCIScheme + "gcr.io/test2/test2",
 			Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 		},
 		{
-			URI:    "docker-pullable://gcr.io/test3/test3",
+			URI:    artifacts.OCIScheme + "gcr.io/test3/test3",
 			Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 		},
 		{URI: "github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},

--- a/pkg/chains/formats/slsa/v1/taskrun/buildconfig_test.go
+++ b/pkg/chains/formats/slsa/v1/taskrun/buildconfig_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/attest"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -68,13 +69,13 @@ status:
 			{
 				EntryPoint: "",
 				Environment: map[string]interface{}{
-					"image":     "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
+					"image":     artifacts.OCIScheme + "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
 					"container": "git-source-repo-jwqcl",
 				},
 				Arguments: interface{}([]string(nil)),
 			}, {
 				Environment: map[string]interface{}{
-					"image":     "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
+					"image":     artifacts.OCIScheme + "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
 					"container": "build",
 				},
 				EntryPoint: "myscript\n",

--- a/pkg/chains/formats/slsa/v2/README.md
+++ b/pkg/chains/formats/slsa/v2/README.md
@@ -34,7 +34,7 @@ The following output was generated. Notice the following below:
 2. `Invocation.Parameters` contains `workspaces and podTemplate` from above spec correctly populated.
 3. `Invocation.Environment` contains `tekton-pipelines-feature-flags` to indicate which feature flags were enabled during the taskrun.
 4. `BuildConfig` contains the resolved `taskSpec`.
- 
+
 ```json
 {
   "_type": "https://in-toto.io/Statement/v0.1",
@@ -372,7 +372,7 @@ The following output was generated. Notice the following below:
     },
     "materials": [
       {
-        "uri": "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
+        "uri": "oci://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
         "digest": {
           "sha256": "28ff94e63e4058afc3f15b4c11c08cf3b54fa91faa646a4bbac90380cd7158df"
         }

--- a/pkg/chains/formats/slsa/v2/slsav2_test.go
+++ b/pkg/chains/formats/slsa/v2/slsav2_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2/taskrun"
 	"github.com/tektoncd/chains/pkg/chains/objects"
@@ -79,18 +80,18 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 			},
 			Materials: []common.ProvenanceMaterial{
 				{
-					URI:    "docker-pullable://gcr.io/test1/test1",
+					URI:    artifacts.OCIScheme + "gcr.io/test1/test1",
 					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
 				{
-					URI:    "docker-pullable://gcr.io/test2/test2",
+					URI:    artifacts.OCIScheme + "gcr.io/test2/test2",
 					Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
 				},
 				{
-					URI:    "docker-pullable://gcr.io/test3/test3",
+					URI:    artifacts.OCIScheme + "gcr.io/test3/test3",
 					Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
 				},
-				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskrun"}},
+				{URI: artifacts.GitSchemePrefix + "https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskrun"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{
@@ -202,10 +203,10 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 			},
 			Materials: []common.ProvenanceMaterial{
 				{
-					URI:    "docker-pullable://gcr.io/test1/test1",
+					URI:    artifacts.OCIScheme + "gcr.io/test1/test1",
 					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
-				{URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskdefault"}},
+				{URI: artifacts.GitSchemePrefix + "https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskdefault"}},
 			},
 			Invocation: slsa.ProvenanceInvocation{
 				ConfigSource: slsa.ConfigSource{
@@ -315,7 +316,7 @@ func TestMultipleSubjects(t *testing.T) {
 			},
 			Materials: []common.ProvenanceMaterial{
 				{
-					URI:    "docker-pullable://gcr.io/test1/test1",
+					URI:    artifacts.OCIScheme + "gcr.io/test1/test1",
 					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 				},
 			},

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/chains/provenance"
@@ -765,7 +766,7 @@ func TestProvenanceMaterials(t *testing.T) {
 			}
 			want := []provenance.ProvenanceMaterial{
 				{
-					URI: "git+" + url + ".git",
+					URI: artifacts.GitSchemePrefix + url + ".git",
 					Digest: provenance.DigestSet{
 						"sha1": commit,
 					},
@@ -781,7 +782,7 @@ func TestProvenanceMaterials(t *testing.T) {
 					}
 					for _, step := range taskRun.Status.Steps {
 						want = append(want, provenance.ProvenanceMaterial{
-							URI: strings.Split(step.ImageID, "@")[0],
+							URI: artifacts.OCIScheme + "" + strings.Split(step.ImageID, "@")[0],
 							Digest: provenance.DigestSet{
 								"sha256": strings.Split(step.ImageID, ":")[1],
 							},
@@ -792,7 +793,7 @@ func TestProvenanceMaterials(t *testing.T) {
 				tr := signedObj.GetObject().(*v1beta1.TaskRun)
 				for _, step := range tr.Status.Steps {
 					want = append(want, provenance.ProvenanceMaterial{
-						URI: strings.Split(step.ImageID, "@")[0],
+						URI: artifacts.OCIScheme + "" + strings.Split(step.ImageID, "@")[0],
 						Digest: provenance.DigestSet{
 							"sha256": strings.Split(step.ImageID, ":")[1],
 						},

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 
 	"github.com/ghodss/yaml"
+	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/test/tekton"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -246,7 +247,7 @@ func expectedTaskRunProvenance(t *testing.T, example string, obj objects.TektonO
 		stepNames = append(stepNames, step.Name)
 		images = append(images, step.ImageID)
 		// append uri and digest that havent already been appended
-		uri := strings.Split(step.ImageID, "@")[0]
+		uri := artifacts.OCIScheme + strings.Split(step.ImageID, "@")[0]
 		digest := strings.Split(step.ImageID, ":")[1]
 		uriDigest := fmt.Sprintf("%s %s", uri, digest)
 		if _, ok := uriDigestSet[uriDigest]; !ok {
@@ -285,7 +286,7 @@ func expectedPipelineRunProvenance(t *testing.T, ctx context.Context, example st
 		buildFinishedTimes = append(buildFinishedTimes, taskRun.Status.CompletionTime.Time.UTC().Format(time.RFC3339))
 		for _, step := range taskRun.Status.Steps {
 			// append uri and digest that havent already been appended
-			uri := strings.Split(step.ImageID, "@")[0]
+			uri := artifacts.OCIScheme + strings.Split(step.ImageID, "@")[0]
 			digest := strings.Split(step.ImageID, ":")[1]
 			uriDigest := fmt.Sprintf("%s %s", uri, digest)
 			if _, ok := uriDigestSet[uriDigest]; !ok {
@@ -295,7 +296,7 @@ func expectedPipelineRunProvenance(t *testing.T, ctx context.Context, example st
 		}
 		for _, sidecar := range taskRun.Status.Sidecars {
 			// append uri and digest that havent already been appended
-			uri := strings.Split(sidecar.ImageID, "@")[0]
+			uri := artifacts.OCIScheme + strings.Split(sidecar.ImageID, "@")[0]
 			digest := strings.Split(sidecar.ImageID, ":")[1]
 			uriDigest := fmt.Sprintf("%s %s", uri, digest)
 			if _, ok := uriDigestSet[uriDigest]; !ok {

--- a/test/testdata/slsa/v1/pipeline-output-image.json
+++ b/test/testdata/slsa/v1/pipeline-output-image.json
@@ -35,7 +35,7 @@
                             "arguments": null,
                             "environment": {
                                 "container": "create-dockerfile",
-                                "image": "distroless.dev/busybox@sha256:186312fcf3f381b5fc1dd80b1afc0d316f3ed39fb4add8ff900d1f0c7c49a92c"
+                                "image": "oci://distroless.dev/busybox@sha256:186312fcf3f381b5fc1dd80b1afc0d316f3ed39fb4add8ff900d1f0c7c49a92c"
                             },
                             "annotations": null
                         }

--- a/test/testdata/slsa/v1/task-output-image.json
+++ b/test/testdata/slsa/v1/task-output-image.json
@@ -25,7 +25,7 @@
                     "arguments": null,
                     "environment": {
                         "container": "{{index .ContainerNames 0}}",
-                        "image": "{{index .StepImages 0}}"
+                        "image": "oci://{{index .StepImages 0}}"
                     },
                     "annotations": null
                 }


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

According to SLSA Provenance v0.2 the `provenance.materials.uri`[1] needs to be a `ResourceURI` which is defined[2] as a _"Uniform Resource Identifier as specified in RFC 3986"_.

The `uri` field of `provenance.materials` is populated with the image reference which does not contain the scheme and therefore is not a valid URI.

This changes that to prepend the `oci://` prefix to Task and sidecar image references.

[1] https://slsa.dev/provenance/v0.2#materials.uri
[2] https://github.com/in-toto/attestation/blob/main/spec/v0.1.0/field_types.md#ResourceURI

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
SLSA Provenance v0.2 provenance.materials.uri field syntax for image references has the `oci://` prefix.
```
