### PR TITLE
Slsa1.0 params, builderID, buildType, subjects, metadata, byProducts

### DIFF
--- a/pkg/chains/formats/all/all.go
+++ b/pkg/chains/formats/all/all.go
@@ -18,4 +18,5 @@ import (
 	_ "github.com/tektoncd/chains/pkg/chains/formats/simple"
 	_ "github.com/tektoncd/chains/pkg/chains/formats/slsa/v1"
 	_ "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2"
+	_ "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2"
 )

--- a/pkg/chains/formats/format.go
+++ b/pkg/chains/formats/format.go
@@ -33,6 +33,7 @@ const (
 	PayloadTypeInTotoIte6    config.PayloadType = "in-toto"
 	PayloadTypeSlsav1        config.PayloadType = "slsa/v1"
 	PayloadTypeSlsav2        config.PayloadType = "slsa/v2alpha1"
+	PayloadTypeSlsav2alpha2  config.PayloadType = "slsa/v2alpha2"
 )
 
 var (

--- a/pkg/chains/formats/slsa/testdata/v2alpha2/pipelinerun1.json
+++ b/pkg/chains/formats/slsa/testdata/v2alpha2/pipelinerun1.json
@@ -1,0 +1,310 @@
+{
+    "metadata": {
+        "name": "pipelinerun-build",
+	"uid": "abhhf-12354-asjsdbjs23-3435353n"
+    },
+    "spec": {
+        "params": [
+            {
+                "name": "IMAGE",
+                "value": "test.io/test/image"
+            }
+        ],
+        "pipelineRef": {
+            "name": "test-pipeline"
+        },
+        "serviceAccountName": "pipeline"
+    },
+    "status": {
+        "startTime": "2021-03-29T09:50:00Z",
+        "completionTime": "2021-03-29T09:50:15Z",
+        "conditions": [
+            {
+                "lastTransitionTime": "2021-03-29T09:50:15Z",
+                "message": "Tasks Completed: 2 (Failed: 0, Cancelled 0), Skipped: 0",
+                "reason": "Succeeded",
+                "status": "True",
+                "type": "Succeeded"
+            }
+        ],
+        "pipelineResults": [
+            {
+                "name": "CHAINS-GIT_COMMIT",
+                "value": "abcd"
+            },
+            {
+                "name": "CHAINS-GIT_URL",
+                "value": "https://git.test.com"
+            },
+            {
+                "name": "IMAGE_URL",
+                "value": "test.io/test/image"
+            },
+            {
+                "name": "IMAGE_DIGEST",
+                "value": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+            },
+            {
+                "name": "img-ARTIFACT_INPUTS",
+                "value": {
+                    "uri": "abc","digest": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+                }
+            },
+            {
+                "name": "img2-ARTIFACT_OUTPUTS",
+                "value": {
+                    "uri": "def","digest": "sha256:"
+                }
+            },
+            {
+                "name": "img_no_uri-ARTIFACT_OUTPUTS",
+                "value": {
+                    "digest": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+                }
+            }
+        ],
+        "pipelineSpec": {
+            "params": [
+                {
+                    "description": "Image path on registry",
+                    "name": "IMAGE",
+                    "type": "string"
+                }
+            ],
+            "results": [
+                {
+                    "description": "",
+                    "name": "CHAINS-GIT_COMMIT",
+                    "value": "$(tasks.git-clone.results.commit)"
+                },
+                {
+                    "description": "",
+                    "name": "CHAINS-GIT_URL",
+                    "value": "$(tasks.git-clone.results.url)"
+                },
+                {
+                    "description": "",
+                    "name": "IMAGE_URL",
+                    "value": "$(tasks.build.results.IMAGE_URL)"
+                },
+                {
+                    "description": "",
+                    "name": "IMAGE_DIGEST",
+                    "value": "$(tasks.build.results.IMAGE_DIGEST)"
+                }
+            ],
+            "tasks": [
+                {
+                    "name": "git-clone",
+                    "params": [
+                        {
+                            "name": "url",
+                            "value": "https://git.test.com"
+                        },
+                        {
+                            "name": "revision",
+                            "value": ""
+                        }
+                    ],
+                    "taskRef": {
+                        "kind": "ClusterTask",
+                        "name": "git-clone"
+                    }
+                },
+                {
+                    "name": "build",
+                    "params": [
+                        {
+                            "name": "CHAINS-GIT_COMMIT",
+                            "value": "$(tasks.git-clone.results.commit)"
+                        },
+                        {
+                            "name": "CHAINS-GIT_URL",
+                            "value": "$(tasks.git-clone.results.url)"
+                        }
+                    ],
+                    "taskRef": {
+                        "kind": "ClusterTask",
+                        "name": "build"
+                    }
+                }
+            ]
+        },
+        "taskRuns": {
+            "git-clone": {
+                "pipelineTaskName": "git-clone",
+                "status": {
+                  "completionTime": "2021-03-29T09:50:15Z",
+                  "conditions": [
+                    {
+                      "lastTransitionTime": "2021-03-29T09:50:15Z",
+                      "message": "All Steps have completed executing",
+                      "reason": "Succeeded",
+                      "status": "True",
+                      "type": "Succeeded"
+                    }
+                  ],
+                  "podName": "git-clone-pod",
+                  "startTime": "2021-03-29T09:50:00Z",
+                  "steps": [
+                    {
+                      "container": "step-clone",
+                      "imageID": "test.io/test/clone-image",
+                      "name": "clone",
+                      "terminated": {
+                        "exitCode": 0,
+                        "finishedAt": "2021-03-29T09:50:15Z",
+                        "reason": "Completed",
+                        "startedAt": "2022-05-31T19:13:27Z"
+                      }
+                    }
+                  ],
+                  "taskResults": [
+                    {
+                      "name": "commit",
+                      "value": "abcd"
+                    },
+                    {
+                      "name": "url",
+                      "value": "https://git.test.com"
+                    }
+                  ],
+                  "taskSpec": {
+                    "params": [
+                      {
+                        "description": "Repository URL to clone from.",
+                        "name": "url",
+                        "type": "string"
+                      },
+                      {
+                        "default": "",
+                        "description": "Revision to checkout. (branch, tag, sha, ref, etc...)",
+                        "name": "revision",
+                        "type": "string"
+                      }
+                    ],
+                    "results": [
+                      {
+                        "description": "The precise commit SHA that was fetched by this Task.",
+                        "name": "commit"
+                      },
+                      {
+                        "description": "The precise URL that was fetched by this Task.",
+                        "name": "url"
+                      }
+                    ],
+                    "steps": [
+                      {
+                        "env": [
+                          {
+                            "name": "HOME",
+                            "value": "$(params.userHome)"
+                          },
+                          {
+                            "name": "PARAM_URL",
+                            "value": "$(params.url)"
+                          }
+                        ],
+                        "image": "$(params.gitInitImage)",
+                        "name": "clone",
+                        "resources": {},
+                        "script": "git clone"
+                      }
+                    ]
+                  }
+                }
+              },
+            "taskrun-build": {
+                "pipelineTaskName": "build",
+                "status": {
+                    "completionTime": "2021-03-29T09:50:15Z",
+                    "conditions": [
+                        {
+                            "lastTransitionTime": "2021-03-29T09:50:15Z",
+                            "message": "All Steps have completed executing",
+                            "reason": "Succeeded",
+                            "status": "True",
+                            "type": "Succeeded"
+                        }
+                    ],
+                    "podName": "build-pod",
+                    "startTime": "2021-03-29T09:50:00Z",
+                    "steps": [
+                        {
+                            "container": "step-build",
+                            "imageID": "test.io/test/build-image",
+                            "name": "build",
+                            "terminated": {
+                                "exitCode": 0,
+                                "finishedAt": "2022-05-31T19:17:30Z",
+                                "reason": "Completed",
+                                "startedAt": "2021-03-29T09:50:00Z"
+                            }
+                        }
+                    ],
+                    "taskResults": [
+                        {
+                            "name": "IMAGE_DIGEST",
+                            "value": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+                        },
+                        {
+                            "name": "IMAGE_URL",
+                            "value": "test.io/test/image\n"
+                        }
+                    ],
+                    "taskSpec": {
+                        "params": [
+                            {
+                                "description": "Git CHAINS URL",
+                                "name": "CHAINS-GIT_URL",
+                                "type": "string"
+                            },
+                            {
+                                "description": "Git CHAINS Commit",
+                                "name": "CHAINS-GIT_COMMIT",
+                                "type": "string"
+                            }
+                        ],
+                        "results": [
+                            {
+                                "description": "Digest of the image just built.",
+                                "name": "IMAGE_DIGEST"
+                            },
+                            {
+                                "description": "URL of the image just built.",
+                                "name": "IMAGE_URL"
+                            }
+                        ],
+                        "steps": [
+                            {
+                                "command": [
+                                    "buildah",
+                                    "build"
+                                ],
+                                "image": "test.io/test/build-image",
+                                "name": "generate"
+                            },
+                            {
+                                "command": [
+                                    "buildah",
+                                    "push"
+                                ],
+                                "image": "test.io/test/build-image",
+                                "name": "push"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "provenance": {
+          "refSource": {
+            "uri": "git+https://github.com/test",
+            "digest": {
+              "sha1": "28b123"
+            },
+            "entryPoint": "pipeline.yaml"
+          }
+        }
+    }
+}

--- a/pkg/chains/formats/slsa/testdata/v2alpha2/pipelinerun_structured_results.json
+++ b/pkg/chains/formats/slsa/testdata/v2alpha2/pipelinerun_structured_results.json
@@ -1,0 +1,268 @@
+{
+    "metadata": {
+        "name": "pipelinerun-build",
+	"uid": "abhhf-12354-asjsdbjs23-3435353n"
+    },
+    "spec": {
+        "params": [
+            {
+                "name": "IMAGE",
+                "value": "test.io/test/image"
+            }
+        ],
+        "pipelineRef": {
+            "name": "test-pipeline"
+        },
+        "serviceAccountName": "pipeline"
+    },
+    "status": {
+        "startTime": "2021-03-29T09:50:00Z",
+        "completionTime": "2021-03-29T09:50:15Z",
+        "conditions": [
+            {
+                "lastTransitionTime": "2021-03-29T09:50:15Z",
+                "message": "Tasks Completed: 2 (Failed: 0, Cancelled 0), Skipped: 0",
+                "reason": "Succeeded",
+                "status": "True",
+                "type": "Succeeded"
+            }
+        ],
+        "pipelineResults": [
+            {
+                "name": "image-ARTIFACT_INPUTS",
+                "value": {
+                    "uri": "abcd",
+                    "digest": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+                }
+            },
+            {
+                "name": "image-ARTIFACT_OUTPUTS",
+                "value": {
+                    "uri": "hello_world",
+                    "sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+                }
+            }
+        ],
+        "pipelineSpec": {
+            "params": [
+                {
+                    "description": "Image path on registry",
+                    "name": "IMAGE",
+                    "type": "string"
+                }
+            ],
+            "tasks": [
+                {
+                    "name": "git-clone",
+                    "params": [
+                        {
+                            "name": "url",
+                            "value": "https://git.test.com"
+                        },
+                        {
+                            "name": "revision",
+                            "value": ""
+                        }
+                    ],
+                    "taskRef": {
+                        "kind": "ClusterTask",
+                        "name": "git-clone"
+                    }
+                },
+                {
+                    "name": "build",
+                    "params": [
+                        {
+                            "name": "CHAINS-GIT_COMMIT",
+                            "value": "$(tasks.git-clone.results.commit)"
+                        },
+                        {
+                            "name": "CHAINS-GIT_URL",
+                            "value": "$(tasks.git-clone.results.url)"
+                        }
+                    ],
+                    "taskRef": {
+                        "kind": "ClusterTask",
+                        "name": "build"
+                    }
+                }
+            ]
+        },
+        "taskRuns": {
+            "git-clone": {
+                "pipelineTaskName": "git-clone",
+                "status": {
+                  "completionTime": "2021-03-29T09:50:15Z",
+                  "conditions": [
+                    {
+                      "lastTransitionTime": "2021-03-29T09:50:15Z",
+                      "message": "All Steps have completed executing",
+                      "reason": "Succeeded",
+                      "status": "True",
+                      "type": "Succeeded"
+                    }
+                  ],
+                  "podName": "git-clone-pod",
+                  "startTime": "2021-03-29T09:50:00Z",
+                  "steps": [
+                    {
+                      "container": "step-clone",
+                      "imageID": "test.io/test/clone-image",
+                      "name": "clone",
+                      "terminated": {
+                        "exitCode": 0,
+                        "finishedAt": "2021-03-29T09:50:15Z",
+                        "reason": "Completed",
+                        "startedAt": "2022-05-31T19:13:27Z"
+                      }
+                    }
+                  ],
+                  "taskResults": [
+                    {
+                      "name": "commit",
+                      "value": "abcd"
+                    },
+                    {
+                      "name": "url",
+                      "value": "https://git.test.com"
+                    }
+                  ],
+                  "taskSpec": {
+                    "params": [
+                      {
+                        "description": "Repository URL to clone from.",
+                        "name": "url",
+                        "type": "string"
+                      },
+                      {
+                        "default": "",
+                        "description": "Revision to checkout. (branch, tag, sha, ref, etc...)",
+                        "name": "revision",
+                        "type": "string"
+                      }
+                    ],
+                    "results": [
+                      {
+                        "description": "The precise commit SHA that was fetched by this Task.",
+                        "name": "commit"
+                      },
+                      {
+                        "description": "The precise URL that was fetched by this Task.",
+                        "name": "url"
+                      }
+                    ],
+                    "steps": [
+                      {
+                        "env": [
+                          {
+                            "name": "HOME",
+                            "value": "$(params.userHome)"
+                          },
+                          {
+                            "name": "PARAM_URL",
+                            "value": "$(params.url)"
+                          }
+                        ],
+                        "image": "$(params.gitInitImage)",
+                        "name": "clone",
+                        "resources": {},
+                        "script": "git clone"
+                      }
+                    ]
+                  }
+                }
+              },
+            "taskrun-build": {
+                "pipelineTaskName": "build",
+                "status": {
+                    "completionTime": "2021-03-29T09:50:15Z",
+                    "conditions": [
+                        {
+                            "lastTransitionTime": "2021-03-29T09:50:15Z",
+                            "message": "All Steps have completed executing",
+                            "reason": "Succeeded",
+                            "status": "True",
+                            "type": "Succeeded"
+                        }
+                    ],
+                    "podName": "build-pod",
+                    "startTime": "2021-03-29T09:50:00Z",
+                    "steps": [
+                        {
+                            "container": "step-build",
+                            "imageID": "test.io/test/build-image",
+                            "name": "build",
+                            "terminated": {
+                                "exitCode": 0,
+                                "finishedAt": "2022-05-31T19:17:30Z",
+                                "reason": "Completed",
+                                "startedAt": "2021-03-29T09:50:00Z"
+                            }
+                        }
+                    ],
+                    "taskResults": [
+                        {
+                            "name": "IMAGE_DIGEST",
+                            "value": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+                        },
+                        {
+                            "name": "IMAGE_URL",
+                            "value": "test.io/test/image\n"
+                        }
+                    ],
+                    "taskSpec": {
+                        "params": [
+                            {
+                                "description": "Git CHAINS URL",
+                                "name": "CHAINS-GIT_URL",
+                                "type": "string"
+                            },
+                            {
+                                "description": "Git CHAINS Commit",
+                                "name": "CHAINS-GIT_COMMIT",
+                                "type": "string"
+                            }
+                        ],
+                        "results": [
+                            {
+                                "description": "Digest of the image just built.",
+                                "name": "IMAGE_DIGEST"
+                            },
+                            {
+                                "description": "URL of the image just built.",
+                                "name": "IMAGE_URL"
+                            }
+                        ],
+                        "steps": [
+                            {
+                                "command": [
+                                    "buildah",
+                                    "build"
+                                ],
+                                "image": "test.io/test/build-image",
+                                "name": "generate"
+                            },
+                            {
+                                "command": [
+                                    "buildah",
+                                    "push"
+                                ],
+                                "image": "test.io/test/build-image",
+                                "name": "push"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "provenance": {
+          "refSource": {
+            "uri": "git+https://github.com/test",
+            "digest": {
+              "sha1": "28b123"
+            },
+            "entryPoint": "pipeline.yaml"
+          }
+        }
+    }
+}

--- a/pkg/chains/formats/slsa/testdata/v2alpha2/taskrun-multiple-subjects.json
+++ b/pkg/chains/formats/slsa/testdata/v2alpha2/taskrun-multiple-subjects.json
@@ -1,0 +1,56 @@
+{
+    "spec": {
+        "params": [],
+        "taskRef": {
+            "name": "test-task",
+            "kind": "Task"
+        },
+        "serviceAccountName": "default"
+    },
+    "status": {
+        "conditions": [
+            {
+                "type": "Succeeded",
+                "status": "True",
+                "lastTransitionTime": "2021-03-29T09:50:15Z",
+                "reason": "Succeeded",
+                "message": "All Steps have completed executing"
+            }
+        ],
+        "podName": "test-pod-name",
+        "steps": [
+            {
+                "name": "step1",
+                "container": "step-step1",
+                "imageID": "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+            }
+        ],
+        "taskResults": [
+            {
+                "name": "IMAGES",
+                "value": "gcr.io/myimage@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6,gcr.io/myimage@sha256:daa1a56e13c85cf164e7d9e595006649e3a04c47fe4a8261320e18a0bf3b0367"
+            }
+        ],
+        "taskSpec": {
+            "params": [],
+            "results": [
+                {
+                    "name": "file1_DIGEST",
+                    "description": "Digest of a file to push."
+                },
+                {
+                    "name": "file1",
+                    "description": "some assembled file"
+                },
+                {
+                    "name": "file2_DIGEST",
+                    "description": "Digest of a file to push."
+                },
+                {
+                    "name": "file2",
+                    "description": "some assembled file"
+                }
+            ]
+        }
+    }
+}

--- a/pkg/chains/formats/slsa/testdata/v2alpha2/taskrun1.json
+++ b/pkg/chains/formats/slsa/testdata/v2alpha2/taskrun1.json
@@ -1,0 +1,143 @@
+{
+    "metadata": {
+        "name": "taskrun-build",
+        "labels": {
+            "tekton.dev/pipelineTask": "build"
+        },
+	"uid": "abhhf-12354-asjsdbjs23-3435353n"
+    },
+    "spec": {
+        "params": [
+            {
+                "name": "IMAGE",
+                "value": "test.io/test/image"
+            },
+            {
+                "name": "CHAINS-GIT_COMMIT",
+                "value": "taskrun"
+            },
+            {
+                "name": "CHAINS-GIT_URL",
+                "value": "https://git.test.com"
+            }
+        ],
+        "taskRef": {
+            "name": "build",
+            "kind": "Task"
+        },
+        "serviceAccountName": "default"
+    },
+    "status": {
+        "startTime": "2021-03-29T09:50:00Z",
+        "completionTime": "2021-03-29T09:50:15Z",
+        "conditions": [
+            {
+                "type": "Succeeded",
+                "status": "True",
+                "lastTransitionTime": "2021-03-29T09:50:15Z",
+                "reason": "Succeeded",
+                "message": "All Steps have completed executing"
+            }
+        ],
+	"provenance": {
+	    "featureFlags": {
+                "EnableAPIFields": "beta",
+                "ResultExtractionMethod": "termination-message"
+	    }
+	},
+        "podName": "test-pod-name",
+        "steps": [
+            {
+                "name": "step1",
+                "container": "step-step1",
+                "imageID": "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+            },
+            {
+                "name": "step2",
+                "container": "step-step2",
+                "imageID": "docker-pullable://gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"
+            },
+            {
+                "name": "step3",
+                "container": "step-step3",
+                "imageID": "docker-pullable://gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"
+            }
+        ],
+        "taskResults": [
+            {
+                "name": "IMAGE_DIGEST",
+                "value": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+            },
+            {
+                "name": "IMAGE_URL",
+                "value": "gcr.io/my/image"
+            }
+        ],
+        "taskSpec": {
+            "params": [
+                {
+                    "name": "IMAGE",
+                    "type": "string"
+                },
+                {
+                    "name": "filename",
+                    "type": "string"
+                },
+                {
+                    "name": "DOCKERFILE",
+                    "type": "string"
+                },
+                {
+                    "name": "CONTEXT",
+                    "type": "string"
+                },
+                {
+                    "name": "EXTRA_ARGS",
+                    "type": "string"
+                },
+                {
+                    "name": "BUILDER_IMAGE",
+                    "type": "string"
+                }, {
+                    "name": "CHAINS-GIT_COMMIT",
+                    "type": "string",
+                    "default": "task"
+                }, {
+                    "name": "CHAINS-GIT_URL",
+                    "type": "string",
+                    "default": "https://defaultgit.test.com"
+                }
+            ],
+            "steps": [
+                {
+                    "name": "step1"
+                },
+                {
+                    "name": "step2"
+                },
+                {
+                    "name": "step3"
+                }
+            ],
+            "results": [
+                {
+                    "name": "IMAGE_DIGEST",
+                    "description": "Digest of the image just built."
+                },
+                {
+                    "name": "filename_DIGEST",
+                    "description": "Digest of the file just built."
+                }
+            ]
+        },
+      "provenance": {
+          "refSource": {
+            "uri": "git+https://github.com/test",
+            "digest": {
+              "sha1": "ab123"
+            },
+            "entryPoint": "build.yaml"
+          }
+        }
+    }
+}

--- a/pkg/chains/formats/slsa/testdata/v2alpha2/taskrun2.json
+++ b/pkg/chains/formats/slsa/testdata/v2alpha2/taskrun2.json
@@ -1,0 +1,106 @@
+{
+    "metadata": {
+        "name": "git-clone",
+        "labels": {
+            "tekton.dev/pipelineTask": "git-clone"
+        },
+	"uid": "abhhf-12354-asjsdbjs23-3435353n"
+    },
+    "spec": {
+        "params": [
+            {
+                "name": "url",
+                "value": "https://git.test.com"
+            },
+            {
+                "name": "revision",
+                "value": ""
+            }
+        ],
+        "taskRef": {
+            "name": "git-clone",
+            "kind": "Task"
+        },
+        "serviceAccountName": "default"
+    },
+    "status": {
+        "startTime": "2021-03-29T09:50:00Z",
+        "completionTime": "2021-03-29T09:50:15Z",
+        "conditions": [
+            {
+                "type": "Succeeded",
+                "status": "True",
+                "lastTransitionTime": "2021-03-29T09:50:15Z",
+                "reason": "Succeeded",
+                "message": "All Steps have completed executing"
+            }
+        ],
+        "podName": "test-pod-name",
+        "steps": [
+            {
+                "name": "step1",
+                "container": "step-step1",
+                "imageID": "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+            }
+        ],
+        "taskResults": [
+            {
+                "name": "some-uri_DIGEST",
+                "value": "sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+            },
+            {
+                "name": "some-uri",
+                "value": "pkg:deb/debian/curl@7.50.3-1"
+            }
+        ],
+        "taskSpec": {
+            "steps": [
+                {
+                    "env": [
+                    {
+                      "name": "HOME",
+                      "value": "$(params.userHome)"
+                    },
+                    {
+                      "name": "PARAM_URL",
+                      "value": "$(params.url)"
+                    }
+                  ],
+                    "name": "step1",
+                    "script": "git clone"
+                }
+            ],
+            "params": [
+                {
+                    "name": "CHAINS-GIT_COMMIT",
+                    "type": "string",
+                    "default": "sha:taskdefault"
+                },
+                {
+                    "name": "CHAINS-GIT_URL",
+                    "type": "string",
+                    "default": "https://git.test.com"
+                }
+            ],
+            "results": [
+                {
+                    "name": "some-uri_DIGEST",
+                    "description": "Digest of a file to push."
+                },
+                {
+                    "name": "some-uri",
+                    "description": "some calculated uri"
+                }
+            ]
+        },
+        "provenance": {
+          "refSource": {
+            "uri": "git+https://github.com/catalog",
+            "digest": {
+              "sha1": "x123"
+            },
+            "entryPoint": "git-clone.yaml"
+          }
+        }
+    }
+}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2023 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
+	resolveddependencies "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies"
+	"github.com/tektoncd/chains/pkg/chains/objects"
+)
+
+const (
+	pipelineRunResults = "pipelineRunResults/%s"
+	// JsonMediaType is the media type of json encoded content used in resource descriptors
+	JsonMediaType = "application/json"
+)
+
+// GenerateAttestation generates a provenance statement with SLSA v1.0 predicate for a pipeline run.
+func GenerateAttestation(ctx context.Context, builderID string, pro *objects.PipelineRunObject) (interface{}, error) {
+	rd, err := resolveddependencies.PipelineRun(ctx, pro)
+	if err != nil {
+		return nil, err
+	}
+	bp, err := byproducts(pro)
+	if err != nil {
+		return nil, err
+	}
+	att := intoto.ProvenanceStatementSLSA1{
+		StatementHeader: intoto.StatementHeader{
+			Type:          intoto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject:       extract.SubjectDigests(ctx, pro),
+		},
+		Predicate: slsa.ProvenancePredicate{
+			BuildDefinition: slsa.ProvenanceBuildDefinition{
+				BuildType:            "https://tekton.dev/chains/v2/slsa",
+				ExternalParameters:   externalParameters(pro),
+				InternalParameters:   internalParameters(pro),
+				ResolvedDependencies: rd,
+			},
+			RunDetails: slsa.ProvenanceRunDetails{
+				Builder: slsa.Builder{
+					ID: builderID,
+				},
+				BuildMetadata: metadata(pro),
+				Byproducts:    bp,
+			},
+		},
+	}
+	return att, nil
+}
+
+func metadata(pro *objects.PipelineRunObject) slsa.BuildMetadata {
+	m := slsa.BuildMetadata{
+		InvocationID: string(pro.ObjectMeta.UID),
+	}
+	if pro.Status.StartTime != nil {
+		utc := pro.Status.StartTime.Time.UTC()
+		m.StartedOn = &utc
+	}
+	if pro.Status.CompletionTime != nil {
+		utc := pro.Status.CompletionTime.Time.UTC()
+		m.FinishedOn = &utc
+	}
+	return m
+}
+
+// internalParameters adds the tekton feature flags that were enabled
+// for the pipelinerun.
+func internalParameters(pro *objects.PipelineRunObject) map[string]any {
+	internalParams := make(map[string]any)
+	if pro.Status.Provenance != nil && pro.Status.Provenance.FeatureFlags != nil {
+		internalParams["tekton-pipelines-feature-flags"] = *pro.Status.Provenance.FeatureFlags
+	}
+	return internalParams
+}
+
+// externalParameters adds the pipeline run spec
+func externalParameters(pro *objects.PipelineRunObject) map[string]any {
+	externalParams := make(map[string]any)
+	externalParams["runSpec"] = pro.Spec
+	return externalParams
+}
+
+// byproducts contains the pipelineRunResults
+func byproducts(pro *objects.PipelineRunObject) ([]slsa.ResourceDescriptor, error) {
+	byProd := []slsa.ResourceDescriptor{}
+	for _, key := range pro.Status.PipelineResults {
+		content, err := json.Marshal(key.Value)
+		if err != nil {
+			return nil, err
+		}
+		bp := slsa.ResourceDescriptor{
+			Name:      fmt.Sprintf(pipelineRunResults, key.Name),
+			Content:   content,
+			MediaType: JsonMediaType,
+		}
+		byProd = append(byProd, bp)
+	}
+	return byProd, nil
+}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun_test.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
+
+	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/chains/pkg/internal/objectloader"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestMetadata(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "my-taskrun",
+			Namespace: "my-namespace",
+			Annotations: map[string]string{
+				"chains.tekton.dev/reproducible": "true",
+			},
+			UID: "abhhf-12354-asjsdbjs23-3435353n",
+		},
+		Status: v1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				StartTime:      &v1.Time{Time: time.Date(1995, time.December, 24, 6, 12, 12, 12, time.UTC)},
+				CompletionTime: &v1.Time{Time: time.Date(1995, time.December, 24, 6, 12, 12, 24, time.UTC)},
+			},
+		},
+	}
+	start := time.Date(1995, time.December, 24, 6, 12, 12, 12, time.UTC)
+	end := time.Date(1995, time.December, 24, 6, 12, 12, 24, time.UTC)
+	want := slsa.BuildMetadata{
+		InvocationID: "abhhf-12354-asjsdbjs23-3435353n",
+		StartedOn:    &start,
+		FinishedOn:   &end,
+	}
+	got := metadata(objects.NewPipelineRunObject(pr))
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("metadata (-want, +got):\n%s", d)
+	}
+}
+
+func TestMetadataInTimeZone(t *testing.T) {
+	tz := time.FixedZone("Test Time", int((12 * time.Hour).Seconds()))
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "my-taskrun",
+			Namespace: "my-namespace",
+			Annotations: map[string]string{
+				"chains.tekton.dev/reproducible": "true",
+			},
+			UID: "abhhf-12354-asjsdbjs23-3435353n",
+		},
+		Status: v1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				StartTime:      &v1.Time{Time: time.Date(1995, time.December, 24, 6, 12, 12, 12, tz)},
+				CompletionTime: &v1.Time{Time: time.Date(1995, time.December, 24, 6, 12, 12, 24, tz)},
+			},
+		},
+	}
+	start := time.Date(1995, time.December, 24, 6, 12, 12, 12, tz).UTC()
+	end := time.Date(1995, time.December, 24, 6, 12, 12, 24, tz).UTC()
+	want := slsa.BuildMetadata{
+		InvocationID: "abhhf-12354-asjsdbjs23-3435353n",
+		StartedOn:    &start,
+		FinishedOn:   &end,
+	}
+	got := metadata(objects.NewPipelineRunObject(pr))
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("metadata (-want, +got):\n%s", d)
+	}
+}
+
+func TestExternalParameters(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		Spec: v1beta1.PipelineRunSpec{
+			Params: v1beta1.Params{
+				{
+					Name:  "my-param",
+					Value: v1beta1.ResultValue{Type: "string", StringVal: "string-param"},
+				},
+				{
+					Name:  "my-array-param",
+					Value: v1beta1.ResultValue{Type: "array", ArrayVal: []string{"my", "array"}},
+				},
+				{
+					Name:  "my-empty-string-param",
+					Value: v1beta1.ResultValue{Type: "string"},
+				},
+				{
+					Name:  "my-empty-array-param",
+					Value: v1beta1.ResultValue{Type: "array", ArrayVal: []string{}},
+				},
+			},
+		},
+	}
+
+	want := map[string]any{
+		"runSpec": pr.Spec,
+	}
+	got := externalParameters(objects.NewPipelineRunObject(pr))
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("externalParameters (-want, +got):\n%s", d)
+	}
+}
+
+func TestInternalParameters(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		Status: v1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				Provenance: &v1beta1.Provenance{
+					FeatureFlags: &config.FeatureFlags{
+						RunningInEnvWithInjectedSidecars: true,
+						EnableAPIFields:                  "stable",
+						AwaitSidecarReadiness:            true,
+						VerificationNoMatchPolicy:        "skip",
+						EnableProvenanceInStatus:         true,
+						ResultExtractionMethod:           "termination-message",
+						MaxResultSize:                    4096,
+					},
+				},
+			},
+		},
+	}
+
+	want := map[string]any{
+		"tekton-pipelines-feature-flags": config.FeatureFlags{
+			RunningInEnvWithInjectedSidecars: true,
+			EnableAPIFields:                  "stable",
+			AwaitSidecarReadiness:            true,
+			VerificationNoMatchPolicy:        "skip",
+			EnableProvenanceInStatus:         true,
+			ResultExtractionMethod:           "termination-message",
+			MaxResultSize:                    4096,
+		},
+	}
+	got := internalParameters(objects.NewPipelineRunObject(pr))
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("internalParameters (-want, +got):\n%s", d)
+	}
+}
+
+func TestByProducts(t *testing.T) {
+	resultValue := v1beta1.ResultValue{Type: "string", StringVal: "result-value"}
+	pr := &v1beta1.PipelineRun{
+		Status: v1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				PipelineResults: []v1beta1.PipelineRunResult{
+					{
+						Name:  "result-name",
+						Value: resultValue,
+					},
+				},
+			},
+		},
+	}
+
+	resultBytes, err := json.Marshal(resultValue)
+	if err != nil {
+		t.Fatalf("Could not marshal results: %s", err)
+	}
+	want := []slsa.ResourceDescriptor{
+		{
+			Name:      "pipelineRunResults/result-name",
+			Content:   resultBytes,
+			MediaType: JsonMediaType,
+		},
+	}
+	got, err := byproducts(objects.NewPipelineRunObject(pr))
+	if err != nil {
+		t.Fatalf("Could not extract byproducts: %s", err)
+	}
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("byproducts (-want, +got):\n%s", d)
+	}
+}
+
+func createPro(path string) *objects.PipelineRunObject {
+	pr, err := objectloader.PipelineRunFromFile(path)
+	if err != nil {
+		panic(err)
+	}
+	tr1, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun1.json")
+	if err != nil {
+		panic(err)
+	}
+	tr2, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun2.json")
+	if err != nil {
+		panic(err)
+	}
+	p := objects.NewPipelineRunObject(pr)
+	p.AppendTaskRun(tr1)
+	p.AppendTaskRun(tr2)
+	return p
+}
+
+func TestGenerateAttestation(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+
+	pr := createPro("../../../testdata/v2alpha2/pipelinerun1.json")
+
+	e1BuildStart := time.Unix(1617011400, 0)
+	e1BuildFinished := time.Unix(1617011415, 0)
+
+	want := in_toto.ProvenanceStatementSLSA1{
+		StatementHeader: in_toto.StatementHeader{
+			Type:          in_toto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject: []in_toto.Subject{
+				{
+					Name: "test.io/test/image",
+					Digest: common.DigestSet{
+						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+					},
+				},
+			},
+		},
+		Predicate: slsa.ProvenancePredicate{
+			BuildDefinition: slsa.ProvenanceBuildDefinition{
+				BuildType: "https://tekton.dev/chains/v2/slsa",
+				ExternalParameters: map[string]any{
+					"runSpec": pr.Spec,
+				},
+				InternalParameters: map[string]any{},
+				ResolvedDependencies: []slsa.ResourceDescriptor{
+					{
+						URI:    "git+https://github.com/test",
+						Digest: common.DigestSet{"sha1": "28b123"},
+						Name:   "pipeline",
+					},
+					{
+						URI:    "git+https://github.com/catalog",
+						Digest: common.DigestSet{"sha1": "x123"},
+						Name:   "pipelineTask",
+					},
+					{
+						URI:    "oci://gcr.io/test1/test1",
+						Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					},
+					{
+						URI:    "git+https://github.com/test",
+						Digest: common.DigestSet{"sha1": "ab123"},
+						Name:   "pipelineTask",
+					},
+					{
+						URI:    "oci://gcr.io/test2/test2",
+						Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+					},
+					{
+						URI:    "oci://gcr.io/test3/test3",
+						Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+					},
+					{
+						URI:    "abc",
+						Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"},
+						Name:   "inputs/result",
+					},
+					{Name: "inputs/result", URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
+				},
+			},
+			RunDetails: slsa.ProvenanceRunDetails{
+				Builder: slsa.Builder{
+					ID: "test_builder-1",
+				},
+				BuildMetadata: slsa.BuildMetadata{
+					InvocationID: "abhhf-12354-asjsdbjs23-3435353n",
+					StartedOn:    &e1BuildStart,
+					FinishedOn:   &e1BuildFinished,
+				},
+				Byproducts: []slsa.ResourceDescriptor{
+					{
+						Name:      "pipelineRunResults/CHAINS-GIT_COMMIT",
+						Content:   []uint8(`"abcd"`),
+						MediaType: JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/CHAINS-GIT_URL",
+						Content:   []uint8(`"https://git.test.com"`),
+						MediaType: JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/IMAGE_URL",
+						Content:   []uint8(`"test.io/test/image"`),
+						MediaType: JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/IMAGE_DIGEST",
+						Content:   []uint8(`"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"`),
+						MediaType: JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/img-ARTIFACT_INPUTS",
+						Content:   []uint8(`{"digest":"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7","uri":"abc"}`),
+						MediaType: JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/img2-ARTIFACT_OUTPUTS",
+						Content:   []uint8(`{"digest":"sha256:","uri":"def"}`),
+						MediaType: JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/img_no_uri-ARTIFACT_OUTPUTS",
+						Content:   []uint8(`{"digest":"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}`),
+						MediaType: JsonMediaType,
+					},
+				},
+			},
+		},
+	}
+
+	got, err := GenerateAttestation(ctx, "test_builder-1", pr)
+
+	if err != nil {
+		t.Errorf("unwant error: %s", err.Error())
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("GenerateAttestation(): -want +got: %s", diff)
+	}
+}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies/resolved_dependencies_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies/resolved_dependencies_test.go
@@ -38,8 +38,8 @@ var pro *objects.PipelineRunObject
 var proStructuredResults *objects.PipelineRunObject
 
 func init() {
-	pro = createPro("../../../testdata/pipelinerun1.json")
-	proStructuredResults = createPro("../../../testdata/pipelinerun_structured_results.json")
+	pro = createPro("../../../testdata/v2alpha2/pipelinerun1.json")
+	proStructuredResults = createPro("../../../testdata/v2alpha2/pipelinerun_structured_results.json")
 }
 
 func createPro(path string) *objects.PipelineRunObject {
@@ -48,11 +48,11 @@ func createPro(path string) *objects.PipelineRunObject {
 	if err != nil {
 		panic(err)
 	}
-	tr1, err := objectloader.TaskRunFromFile("../../../testdata/taskrun1.json")
+	tr1, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun1.json")
 	if err != nil {
 		panic(err)
 	}
-	tr2, err := objectloader.TaskRunFromFile("../../../testdata/taskrun2.json")
+	tr2, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun2.json")
 	if err != nil {
 		panic(err)
 	}
@@ -484,13 +484,13 @@ func TestRemoveDuplicates(t *testing.T) {
 
 func TestPipelineRun(t *testing.T) {
 	expected := []v1.ResourceDescriptor{
-		{Name: "pipeline", URI: "github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
-		{Name: "pipelineTask", URI: "github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
+		{Name: "pipeline", URI: "git+https://github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
+		{Name: "pipelineTask", URI: "git+https://github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
 		{
 			URI:    "oci://gcr.io/test1/test1",
 			Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 		},
-		{Name: "pipelineTask", URI: "github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
+		{Name: "pipelineTask", URI: "git+https://github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
 		{
 			URI:    "oci://gcr.io/test2/test2",
 			Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
@@ -514,13 +514,13 @@ func TestPipelineRun(t *testing.T) {
 
 func TestPipelineRunStructuredResult(t *testing.T) {
 	want := []v1.ResourceDescriptor{
-		{Name: "pipeline", URI: "github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
-		{Name: "pipelineTask", URI: "github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
+		{Name: "pipeline", URI: "git+https://github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
+		{Name: "pipelineTask", URI: "git+https://github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
 		{
 			URI:    "oci://gcr.io/test1/test1",
 			Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
 		},
-		{Name: "pipelineTask", URI: "github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
+		{Name: "pipelineTask", URI: "git+https://github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
 		{
 			URI:    "oci://gcr.io/test2/test2",
 			Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},

--- a/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2023 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun"
+	resolveddependencies "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies"
+	"github.com/tektoncd/chains/pkg/chains/objects"
+)
+
+const taskRunResults = "taskRunResults/%s"
+
+// GenerateAttestation generates a provenance statement with SLSA v1.0 predicate for a task run.
+func GenerateAttestation(ctx context.Context, builderID string, tro *objects.TaskRunObject) (interface{}, error) {
+	rd, err := resolveddependencies.TaskRun(ctx, tro)
+	if err != nil {
+		return nil, err
+	}
+	bp, err := byproducts(tro)
+	if err != nil {
+		return nil, err
+	}
+	att := intoto.ProvenanceStatementSLSA1{
+		StatementHeader: intoto.StatementHeader{
+			Type:          intoto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject:       extract.SubjectDigests(ctx, tro),
+		},
+		Predicate: slsa.ProvenancePredicate{
+			BuildDefinition: slsa.ProvenanceBuildDefinition{
+				BuildType:            "https://tekton.dev/chains/v2/slsa",
+				ExternalParameters:   externalParameters(tro),
+				InternalParameters:   internalParameters(tro),
+				ResolvedDependencies: rd,
+			},
+			RunDetails: slsa.ProvenanceRunDetails{
+				Builder: slsa.Builder{
+					ID: builderID,
+				},
+				BuildMetadata: metadata(tro),
+				Byproducts:    bp,
+			},
+		},
+	}
+	return att, nil
+}
+
+func metadata(tro *objects.TaskRunObject) slsa.BuildMetadata {
+	m := slsa.BuildMetadata{
+		InvocationID: string(tro.ObjectMeta.UID),
+	}
+	if tro.Status.StartTime != nil {
+		utc := tro.Status.StartTime.Time.UTC()
+		m.StartedOn = &utc
+	}
+	if tro.Status.CompletionTime != nil {
+		utc := tro.Status.CompletionTime.Time.UTC()
+		m.FinishedOn = &utc
+	}
+	return m
+}
+
+// internalParameters adds the tekton feature flags that were enabled
+// for the taskrun.
+func internalParameters(tro *objects.TaskRunObject) map[string]any {
+	internalParams := make(map[string]any)
+	if tro.Status.Provenance != nil && tro.Status.Provenance.FeatureFlags != nil {
+		internalParams["tekton-pipelines-feature-flags"] = *tro.Status.Provenance.FeatureFlags
+	}
+	return internalParams
+}
+
+// externalParameters adds the task run spec
+func externalParameters(tro *objects.TaskRunObject) map[string]any {
+	externalParams := make(map[string]any)
+	externalParams["runSpec"] = tro.Spec
+	return externalParams
+}
+
+// byproducts contains the taskRunResults
+func byproducts(tro *objects.TaskRunObject) ([]slsa.ResourceDescriptor, error) {
+	byProd := []slsa.ResourceDescriptor{}
+	for _, key := range tro.Status.TaskRunResults {
+		content, err := json.Marshal(key.Value)
+		if err != nil {
+			return nil, err
+		}
+		bp := slsa.ResourceDescriptor{
+			Name:      fmt.Sprintf(taskRunResults, key.Name),
+			Content:   content,
+			MediaType: pipelinerun.JsonMediaType,
+		}
+		byProd = append(byProd, bp)
+	}
+	return byProd, nil
+}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
+
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun"
+	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/chains/pkg/internal/objectloader"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestMetadata(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "my-taskrun",
+			Namespace: "my-namespace",
+			Annotations: map[string]string{
+				"chains.tekton.dev/reproducible": "true",
+			},
+			UID: "abhhf-12354-asjsdbjs23-3435353n",
+		},
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				StartTime:      &v1.Time{Time: time.Date(1995, time.December, 24, 6, 12, 12, 12, time.UTC)},
+				CompletionTime: &v1.Time{Time: time.Date(1995, time.December, 24, 6, 12, 12, 24, time.UTC)},
+			},
+		},
+	}
+	start := time.Date(1995, time.December, 24, 6, 12, 12, 12, time.UTC)
+	end := time.Date(1995, time.December, 24, 6, 12, 12, 24, time.UTC)
+	want := slsa.BuildMetadata{
+		InvocationID: "abhhf-12354-asjsdbjs23-3435353n",
+		StartedOn:    &start,
+		FinishedOn:   &end,
+	}
+	got := metadata(objects.NewTaskRunObject(tr))
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("metadata (-want, +got):\n%s", d)
+	}
+}
+
+func TestMetadataInTimeZone(t *testing.T) {
+	tz := time.FixedZone("Test Time", int((12 * time.Hour).Seconds()))
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "my-taskrun",
+			Namespace: "my-namespace",
+			Annotations: map[string]string{
+				"chains.tekton.dev/reproducible": "true",
+			},
+			UID: "abhhf-12354-asjsdbjs23-3435353n",
+		},
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				StartTime:      &v1.Time{Time: time.Date(1995, time.December, 24, 6, 12, 12, 12, tz)},
+				CompletionTime: &v1.Time{Time: time.Date(1995, time.December, 24, 6, 12, 12, 24, tz)},
+			},
+		},
+	}
+	start := time.Date(1995, time.December, 24, 6, 12, 12, 12, tz).UTC()
+	end := time.Date(1995, time.December, 24, 6, 12, 12, 24, tz).UTC()
+	want := slsa.BuildMetadata{
+		InvocationID: "abhhf-12354-asjsdbjs23-3435353n",
+		StartedOn:    &start,
+		FinishedOn:   &end,
+	}
+	got := metadata(objects.NewTaskRunObject(tr))
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("metadata (-want, +got):\n%s", d)
+	}
+}
+
+func TestExternalParameters(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		Spec: v1beta1.TaskRunSpec{
+			Params: v1beta1.Params{
+				{
+					Name:  "my-param",
+					Value: v1beta1.ResultValue{Type: "string", StringVal: "string-param"},
+				},
+				{
+					Name:  "my-array-param",
+					Value: v1beta1.ResultValue{Type: "array", ArrayVal: []string{"my", "array"}},
+				},
+				{
+					Name:  "my-empty-string-param",
+					Value: v1beta1.ResultValue{Type: "string"},
+				},
+				{
+					Name:  "my-empty-array-param",
+					Value: v1beta1.ResultValue{Type: "array", ArrayVal: []string{}},
+				},
+			},
+		},
+	}
+
+	want := map[string]any{
+		"runSpec": tr.Spec,
+	}
+	got := externalParameters(objects.NewTaskRunObject(tr))
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("externalParameters (-want, +got):\n%s", d)
+	}
+}
+
+func TestInternalParameters(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				Provenance: &v1beta1.Provenance{
+					FeatureFlags: &config.FeatureFlags{
+						RunningInEnvWithInjectedSidecars: true,
+						EnableAPIFields:                  "stable",
+						AwaitSidecarReadiness:            true,
+						VerificationNoMatchPolicy:        "skip",
+						EnableProvenanceInStatus:         true,
+						ResultExtractionMethod:           "termination-message",
+						MaxResultSize:                    4096,
+					},
+				},
+			},
+		},
+	}
+
+	want := map[string]any{
+		"tekton-pipelines-feature-flags": config.FeatureFlags{
+			RunningInEnvWithInjectedSidecars: true,
+			EnableAPIFields:                  "stable",
+			AwaitSidecarReadiness:            true,
+			VerificationNoMatchPolicy:        "skip",
+			EnableProvenanceInStatus:         true,
+			ResultExtractionMethod:           "termination-message",
+			MaxResultSize:                    4096,
+		},
+	}
+	got := internalParameters(objects.NewTaskRunObject(tr))
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("internalParameters (-want, +got):\n%s", d)
+	}
+}
+
+func TestByProducts(t *testing.T) {
+	resultValue := v1beta1.ResultValue{Type: "string", StringVal: "result-value"}
+	tr := &v1beta1.TaskRun{
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunResults: []v1beta1.TaskRunResult{
+					{
+						Name:  "result-name",
+						Value: resultValue,
+					},
+				},
+			},
+		},
+	}
+
+	resultBytes, err := json.Marshal(resultValue)
+	if err != nil {
+		t.Fatalf("Could not marshal results: %s", err)
+	}
+	want := []slsa.ResourceDescriptor{
+		{
+			Name:      "taskRunResults/result-name",
+			Content:   resultBytes,
+			MediaType: pipelinerun.JsonMediaType,
+		},
+	}
+	got, err := byproducts(objects.NewTaskRunObject(tr))
+	if err != nil {
+		t.Fatalf("Could not extract byproducts: %s", err)
+	}
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("byproducts (-want, +got):\n%s", d)
+	}
+}
+
+func TestTaskRunGenerateAttestation(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+
+	tr, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e1BuildStart := time.Unix(1617011400, 0)
+	e1BuildFinished := time.Unix(1617011415, 0)
+
+	resultValue := v1beta1.ResultValue{Type: "string", StringVal: "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}
+	resultBytesDigest, err := json.Marshal(resultValue)
+	if err != nil {
+		t.Fatalf("Could not marshal results: %s", err)
+	}
+	resultValue = v1beta1.ResultValue{Type: "string", StringVal: "gcr.io/my/image"}
+	resultBytesUri, err := json.Marshal(resultValue)
+	if err != nil {
+		t.Fatalf("Could not marshal results: %s", err)
+	}
+
+	want := in_toto.ProvenanceStatementSLSA1{
+		StatementHeader: in_toto.StatementHeader{
+			Type:          in_toto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject: []in_toto.Subject{
+				{
+					Name: "gcr.io/my/image",
+					Digest: common.DigestSet{
+						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+					},
+				},
+			},
+		},
+		Predicate: slsa.ProvenancePredicate{
+			BuildDefinition: slsa.ProvenanceBuildDefinition{
+				BuildType: "https://tekton.dev/chains/v2/slsa",
+				ExternalParameters: map[string]any{
+					"runSpec": tr.Spec,
+				},
+				InternalParameters: map[string]any{
+					"tekton-pipelines-feature-flags": config.FeatureFlags{EnableAPIFields: "beta", ResultExtractionMethod: "termination-message"},
+				},
+				ResolvedDependencies: []slsa.ResourceDescriptor{
+					{
+						URI:    "git+https://github.com/test",
+						Digest: common.DigestSet{"sha1": "ab123"},
+						Name:   "task",
+					},
+					{
+						URI:    "oci://gcr.io/test1/test1",
+						Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					},
+					{
+						URI:    "oci://gcr.io/test2/test2",
+						Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+					},
+					{
+						URI:    "oci://gcr.io/test3/test3",
+						Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+					},
+					{Name: "inputs/result", URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "taskrun"}},
+				},
+			},
+			RunDetails: slsa.ProvenanceRunDetails{
+				Builder: slsa.Builder{
+					ID: "test_builder-1",
+				},
+				BuildMetadata: slsa.BuildMetadata{
+					InvocationID: "abhhf-12354-asjsdbjs23-3435353n",
+					StartedOn:    &e1BuildStart,
+					FinishedOn:   &e1BuildFinished,
+				},
+				Byproducts: []slsa.ResourceDescriptor{
+					{
+						Name:      "taskRunResults/IMAGE_DIGEST",
+						Content:   resultBytesDigest,
+						MediaType: pipelinerun.JsonMediaType,
+					},
+					{
+						Name:      "taskRunResults/IMAGE_URL",
+						Content:   resultBytesUri,
+						MediaType: pipelinerun.JsonMediaType,
+					},
+				},
+			},
+		},
+	}
+
+	got, err := GenerateAttestation(ctx, "test_builder-1", objects.NewTaskRunObject(tr))
+
+	if err != nil {
+		t.Errorf("unwant error: %s", err.Error())
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("GenerateAttestation(): -want +got: %s", diff)
+	}
+}

--- a/pkg/chains/formats/slsa/v2alpha2/slsav2.go
+++ b/pkg/chains/formats/slsa/v2alpha2/slsav2.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/taskrun"
+	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/chains/pkg/config"
+)
+
+const (
+	PayloadTypeSlsav2alpha2 = formats.PayloadTypeSlsav2alpha2
+)
+
+func init() {
+	formats.RegisterPayloader(PayloadTypeSlsav2alpha2, NewFormatter)
+}
+
+type Slsa struct {
+	builderID string
+}
+
+func NewFormatter(cfg config.Config) (formats.Payloader, error) {
+	return &Slsa{
+		builderID: cfg.Builder.ID,
+	}, nil
+}
+
+func (s *Slsa) Wrap() bool {
+	return true
+}
+
+func (s *Slsa) CreatePayload(ctx context.Context, obj interface{}) (interface{}, error) {
+	switch v := obj.(type) {
+	case *objects.TaskRunObject:
+		return taskrun.GenerateAttestation(ctx, s.builderID, v)
+	case *objects.PipelineRunObject:
+		return pipelinerun.GenerateAttestation(ctx, s.builderID, v)
+	default:
+		return nil, fmt.Errorf("intoto does not support type: %s", v)
+	}
+}
+
+func (s *Slsa) Type() config.PayloadType {
+	return formats.PayloadTypeSlsav2alpha2
+}

--- a/pkg/chains/formats/slsa/v2alpha2/slsav2_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/slsav2_test.go
@@ -1,0 +1,502 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha2
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun"
+	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/chains/pkg/config"
+	"github.com/tektoncd/chains/pkg/internal/objectloader"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
+	pipelineConfig "github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+var (
+	e1BuildStart    = time.Unix(1617011400, 0)
+	e1BuildFinished = time.Unix(1617011415, 0)
+)
+
+func TestNewFormatter(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		cfg := config.Config{
+			Builder: config.BuilderConfig{
+				ID: "testid",
+			},
+		}
+		f, err := NewFormatter(cfg)
+		if err != nil {
+			t.Errorf("Error creating formatter: %s", err)
+		}
+		if f == nil {
+			t.Error("Failed to create formatter")
+		}
+	})
+}
+
+func TestCreatePayloadError(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+
+	cfg := config.Config{
+		Builder: config.BuilderConfig{
+			ID: "testid",
+		},
+	}
+	f, _ := NewFormatter(cfg)
+
+	t.Run("Invalid type", func(t *testing.T) {
+		p, err := f.CreatePayload(ctx, "not a task ref")
+
+		if p != nil {
+			t.Errorf("Unexpected payload")
+		}
+		if err == nil {
+			t.Errorf("Expected error")
+		} else {
+			if err.Error() != "intoto does not support type: not a task ref" {
+				t.Errorf("wrong error returned: '%s'", err.Error())
+			}
+		}
+	})
+
+}
+
+func TestCorrectPayloadType(t *testing.T) {
+	var i Slsa
+	if i.Type() != formats.PayloadTypeSlsav2alpha2 {
+		t.Errorf("Invalid type returned: %s", i.Type())
+	}
+}
+
+func TestTaskRunCreatePayload1(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+
+	tr, err := objectloader.TaskRunFromFile("../testdata/v2alpha2/taskrun1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resultValue := v1beta1.ParamValue{Type: "string", StringVal: "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}
+	resultBytesDigest, err := json.Marshal(resultValue)
+	if err != nil {
+		t.Fatalf("Could not marshal results: %s", err)
+	}
+	resultValue = v1beta1.ParamValue{Type: "string", StringVal: "gcr.io/my/image"}
+	resultBytesUri, err := json.Marshal(resultValue)
+	if err != nil {
+		t.Fatalf("Could not marshal results: %s", err)
+	}
+
+	cfg := config.Config{
+		Builder: config.BuilderConfig{
+			ID: "test_builder-1",
+		},
+	}
+	expected := in_toto.ProvenanceStatementSLSA1{
+		StatementHeader: in_toto.StatementHeader{
+			Type:          in_toto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject: []in_toto.Subject{
+				{
+					Name: "gcr.io/my/image",
+					Digest: common.DigestSet{
+						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+					},
+				},
+			},
+		},
+		Predicate: slsa.ProvenancePredicate{
+			BuildDefinition: slsa.ProvenanceBuildDefinition{
+				BuildType: "https://tekton.dev/chains/v2/slsa",
+				ExternalParameters: map[string]any{
+					"runSpec": tr.Spec,
+				},
+				InternalParameters: map[string]any{
+					"tekton-pipelines-feature-flags": pipelineConfig.FeatureFlags{EnableAPIFields: "beta", ResultExtractionMethod: "termination-message"},
+				},
+				ResolvedDependencies: []slsa.ResourceDescriptor{
+					{
+						URI:    "git+https://github.com/test",
+						Digest: common.DigestSet{"sha1": "ab123"},
+						Name:   "task",
+					},
+					{
+						URI:    "oci://gcr.io/test1/test1",
+						Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					},
+					{
+						URI:    "oci://gcr.io/test2/test2",
+						Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+					},
+					{
+						URI:    "oci://gcr.io/test3/test3",
+						Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+					},
+					{Name: "inputs/result", URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "taskrun"}},
+				},
+			},
+			RunDetails: slsa.ProvenanceRunDetails{
+				Builder: slsa.Builder{
+					ID: "test_builder-1",
+				},
+				BuildMetadata: slsa.BuildMetadata{
+					InvocationID: "abhhf-12354-asjsdbjs23-3435353n",
+					StartedOn:    &e1BuildStart,
+					FinishedOn:   &e1BuildFinished,
+				},
+				Byproducts: []slsa.ResourceDescriptor{
+					{
+						Name:      "taskRunResults/IMAGE_DIGEST",
+						Content:   resultBytesDigest,
+						MediaType: pipelinerun.JsonMediaType,
+					},
+					{
+						Name:      "taskRunResults/IMAGE_URL",
+						Content:   resultBytesUri,
+						MediaType: pipelinerun.JsonMediaType,
+					},
+				},
+			},
+		},
+	}
+
+	i, _ := NewFormatter(cfg)
+
+	got, err := i.CreatePayload(ctx, objects.NewTaskRunObject(tr))
+
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("Slsa.CreatePayload(): -want +got: %s", diff)
+	}
+}
+
+func TestTaskRunCreatePayload2(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+	tr, err := objectloader.TaskRunFromFile("../testdata/v2alpha2/taskrun2.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resultValue := v1beta1.ParamValue{Type: "string", StringVal: "sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"}
+	resultBytesDigest, err := json.Marshal(resultValue)
+	if err != nil {
+		t.Fatalf("Could not marshal results: %s", err)
+	}
+	resultValue = v1beta1.ParamValue{Type: "string", StringVal: "pkg:deb/debian/curl@7.50.3-1"}
+	resultBytesUri, err := json.Marshal(resultValue)
+	if err != nil {
+		t.Fatalf("Could not marshal results: %s", err)
+	}
+
+	cfg := config.Config{
+		Builder: config.BuilderConfig{
+			ID: "test_builder-2",
+		},
+	}
+	expected := in_toto.ProvenanceStatementSLSA1{
+		StatementHeader: in_toto.StatementHeader{
+			Type:          in_toto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject:       nil,
+		},
+		Predicate: slsa.ProvenancePredicate{
+			BuildDefinition: slsa.ProvenanceBuildDefinition{
+				BuildType: "https://tekton.dev/chains/v2/slsa",
+				ExternalParameters: map[string]any{
+					"runSpec": tr.Spec,
+				},
+				InternalParameters: map[string]any{},
+				ResolvedDependencies: []slsa.ResourceDescriptor{
+					{
+						URI:    "git+https://github.com/catalog",
+						Digest: common.DigestSet{"sha1": "x123"},
+						Name:   "task",
+					},
+					{
+						URI:    "oci://gcr.io/test1/test1",
+						Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					},
+					{Name: "inputs/result", URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "sha:taskdefault"}},
+				},
+			},
+			RunDetails: slsa.ProvenanceRunDetails{
+				Builder: slsa.Builder{
+					ID: "test_builder-2",
+				},
+				BuildMetadata: slsa.BuildMetadata{
+					InvocationID: "abhhf-12354-asjsdbjs23-3435353n",
+					StartedOn:    &e1BuildStart,
+					FinishedOn:   &e1BuildFinished,
+				},
+				Byproducts: []slsa.ResourceDescriptor{
+					{
+						Name:      "taskRunResults/some-uri_DIGEST",
+						Content:   resultBytesDigest,
+						MediaType: pipelinerun.JsonMediaType,
+					},
+					{
+						Name:      "taskRunResults/some-uri",
+						Content:   resultBytesUri,
+						MediaType: pipelinerun.JsonMediaType,
+					},
+				},
+			},
+		},
+	}
+
+	i, _ := NewFormatter(cfg)
+	got, err := i.CreatePayload(ctx, objects.NewTaskRunObject(tr))
+
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("Slsa.CreatePayload(): -want +got: %s", diff)
+	}
+}
+
+func TestMultipleSubjects(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+
+	tr, err := objectloader.TaskRunFromFile("../testdata/v2alpha2/taskrun-multiple-subjects.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resultValue := v1beta1.ParamValue{
+		Type:      "string",
+		StringVal: "gcr.io/myimage@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6,gcr.io/myimage@sha256:daa1a56e13c85cf164e7d9e595006649e3a04c47fe4a8261320e18a0bf3b0367",
+	}
+	resultBytes, err := json.Marshal(resultValue)
+	if err != nil {
+		t.Fatalf("Could not marshal results: %s", err)
+	}
+	cfg := config.Config{
+		Builder: config.BuilderConfig{
+			ID: "test_builder-multiple",
+		},
+	}
+	expected := in_toto.ProvenanceStatementSLSA1{
+		StatementHeader: in_toto.StatementHeader{
+			Type:          in_toto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject: []in_toto.Subject{
+				{
+					Name: "gcr.io/myimage",
+					Digest: common.DigestSet{
+						"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+					},
+				}, {
+					Name: "gcr.io/myimage",
+					Digest: common.DigestSet{
+						"sha256": "daa1a56e13c85cf164e7d9e595006649e3a04c47fe4a8261320e18a0bf3b0367",
+					},
+				},
+			},
+		},
+		Predicate: slsa.ProvenancePredicate{
+			BuildDefinition: slsa.ProvenanceBuildDefinition{
+				BuildType: "https://tekton.dev/chains/v2/slsa",
+				ExternalParameters: map[string]any{
+					"runSpec": tr.Spec,
+				},
+				InternalParameters: map[string]any{},
+				ResolvedDependencies: []slsa.ResourceDescriptor{
+					{
+						URI:    "oci://gcr.io/test1/test1",
+						Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					},
+				},
+			},
+			RunDetails: slsa.ProvenanceRunDetails{
+				Builder: slsa.Builder{
+					ID: "test_builder-multiple",
+				},
+				BuildMetadata: slsa.BuildMetadata{},
+				Byproducts: []slsa.ResourceDescriptor{
+					{
+						Name:      "taskRunResults/IMAGES",
+						Content:   resultBytes,
+						MediaType: pipelinerun.JsonMediaType,
+					},
+				},
+			},
+		},
+	}
+
+	i, _ := NewFormatter(cfg)
+	got, err := i.CreatePayload(ctx, objects.NewTaskRunObject(tr))
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("Slsa.CreatePayload(): -want +got: %s", diff)
+	}
+}
+
+func createPro(path string) *objects.PipelineRunObject {
+	pr, err := objectloader.PipelineRunFromFile(path)
+	if err != nil {
+		panic(err)
+	}
+	tr1, err := objectloader.TaskRunFromFile("../testdata/v2alpha2/taskrun1.json")
+	if err != nil {
+		panic(err)
+	}
+	tr2, err := objectloader.TaskRunFromFile("../testdata/v2alpha2/taskrun2.json")
+	if err != nil {
+		panic(err)
+	}
+	p := objects.NewPipelineRunObject(pr)
+	p.AppendTaskRun(tr1)
+	p.AppendTaskRun(tr2)
+	return p
+}
+
+func TestPipelineRunCreatePayload1(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+
+	pr := createPro("../testdata/v2alpha2/pipelinerun1.json")
+
+	cfg := config.Config{
+		Builder: config.BuilderConfig{
+			ID: "test_builder-1",
+		},
+	}
+	expected := in_toto.ProvenanceStatementSLSA1{
+		StatementHeader: in_toto.StatementHeader{
+			Type:          in_toto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject: []in_toto.Subject{
+				{
+					Name: "test.io/test/image",
+					Digest: common.DigestSet{
+						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+					},
+				},
+			},
+		},
+		Predicate: slsa.ProvenancePredicate{
+			BuildDefinition: slsa.ProvenanceBuildDefinition{
+				BuildType: "https://tekton.dev/chains/v2/slsa",
+				ExternalParameters: map[string]any{
+					"runSpec": pr.Spec,
+				},
+				InternalParameters: map[string]any{},
+				ResolvedDependencies: []slsa.ResourceDescriptor{
+					{
+						URI:    "git+https://github.com/test",
+						Digest: common.DigestSet{"sha1": "28b123"},
+						Name:   "pipeline",
+					},
+					{
+						URI:    "git+https://github.com/catalog",
+						Digest: common.DigestSet{"sha1": "x123"},
+						Name:   "pipelineTask",
+					},
+					{
+						URI:    "oci://gcr.io/test1/test1",
+						Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+					},
+					{
+						URI:    "git+https://github.com/test",
+						Digest: common.DigestSet{"sha1": "ab123"},
+						Name:   "pipelineTask",
+					},
+					{
+						URI:    "oci://gcr.io/test2/test2",
+						Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+					},
+					{
+						URI:    "oci://gcr.io/test3/test3",
+						Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+					},
+					{
+						URI:    "abc",
+						Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"},
+						Name:   "inputs/result",
+					},
+					{Name: "inputs/result", URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
+				},
+			},
+			RunDetails: slsa.ProvenanceRunDetails{
+				Builder: slsa.Builder{
+					ID: "test_builder-1",
+				},
+				BuildMetadata: slsa.BuildMetadata{
+					InvocationID: "abhhf-12354-asjsdbjs23-3435353n",
+					StartedOn:    &e1BuildStart,
+					FinishedOn:   &e1BuildFinished,
+				},
+				Byproducts: []slsa.ResourceDescriptor{
+					{
+						Name:      "pipelineRunResults/CHAINS-GIT_COMMIT",
+						Content:   []uint8(`"abcd"`),
+						MediaType: pipelinerun.JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/CHAINS-GIT_URL",
+						Content:   []uint8(`"https://git.test.com"`),
+						MediaType: pipelinerun.JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/IMAGE_URL",
+						Content:   []uint8(`"test.io/test/image"`),
+						MediaType: pipelinerun.JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/IMAGE_DIGEST",
+						Content:   []uint8(`"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"`),
+						MediaType: pipelinerun.JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/img-ARTIFACT_INPUTS",
+						Content:   []uint8(`{"digest":"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7","uri":"abc"}`),
+						MediaType: pipelinerun.JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/img2-ARTIFACT_OUTPUTS",
+						Content:   []uint8(`{"digest":"sha256:","uri":"def"}`),
+						MediaType: pipelinerun.JsonMediaType,
+					}, {
+						Name:      "pipelineRunResults/img_no_uri-ARTIFACT_OUTPUTS",
+						Content:   []uint8(`{"digest":"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}`),
+						MediaType: pipelinerun.JsonMediaType,
+					},
+				},
+			},
+		},
+	}
+
+	i, _ := NewFormatter(cfg)
+
+	got, err := i.CreatePayload(ctx, pr)
+
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("Slsa.CreatePayload(): -want +got: %s", diff)
+	}
+}


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
This PR adds support for adding external and internal parameters, builder information and run details like build metadata to the slsa 1.0 predicate for pipelineruns and taskruns. This is a follow up to PR https://github.com/tektoncd/chains/pull/798.

The next PR will wire everything up and implement e2e tests and docs.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Add external and internal parameters, builderID, buildType, subjects, metadata and byProducts to slsa1.0 predicate.
```
/kind feature