### PR TITLE
Use mount secrets in OCI backend

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -16,7 +16,7 @@ This doc will cover how to set this up!
 
 ## Authenticating to an OCI Registry
 
-To push to an OCI registry, the Chains controller will look for credentials in two places. The first place is in the pod executing your Task and the second place is in the service account configured to run your Task. 
+To push to an OCI registry, the Chains controller will look for credentials in two places. The first place is in the pod executing your Task and the second place is in the service account configured to run your Task.
 
 ### First we'll cover creating the credentials.
 
@@ -101,10 +101,14 @@ Finally, give the service account access to the secret above:
 
 ```shell
 kubectl patch serviceaccount $SERVICE_ACCOUNT_NAME \
-  -p "{\"imagePullSecrets\": [{\"name\": \"registry-credentials\"}]}" -n $NAMESPACE
+  -p "{\"secrets\": [{\"name\": \"registry-credentials\"}]}" -n $NAMESPACE
 ```
 
 Now, Chains has push permissions for any TaskRuns running under the service account `$SERVICE_ACCOUNT_NAME`.
+
+The secrets in the `imagePullSecrets` attribute of the ServiceAccount are also taken into account.
+However, other Tekton components may not do so. The `secrets` attribute is the
+[recommended](https://tekton.dev/docs/pipelines/auth/) approach.
 
 ## Authenticating to Fulcio for Keyless signing
 
@@ -171,7 +175,7 @@ Last but not least, thanks to [spiffe-csi](https://github.com/spiffe/spiffe-csi)
           - name: spiffe-workload-api
             mountPath: /spiffe-workload-api
             readOnly: true
-     
+
      ...
       volumes:
         - name: spiffe-workload-api

--- a/go.mod
+++ b/go.mod
@@ -205,7 +205,7 @@ require (
 	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 // indirect
 	github.com/google/certificate-transparency-go v1.1.4 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
-	github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20221017135236-9b4fdd506cdd // indirect
+	github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20230208142019-eb7d746c941e // indirect
 	github.com/google/go-github/v50 v50.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1436,8 +1436,8 @@ github.com/google/go-containerregistry v0.14.1-0.20230409045903-ed5c185df419 h1:
 github.com/google/go-containerregistry v0.14.1-0.20230409045903-ed5c185df419/go.mod h1:ETSJmRH9iO4Q0WQILIMkDUiKk+CaxItZW+gEDjyw8Ug=
 github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20221030203717-1711cefd7eec h1:GtokKAIyg0S9Y/60CO+gHUBHwYblbwfaUS3Qr+AejTc=
 github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20221030203717-1711cefd7eec/go.mod h1:7QLaBZxN+nMCx82XO5R7qPHq0m61liEg8yca68zymHo=
-github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20221017135236-9b4fdd506cdd h1:+nq85YWt99EkBpsKV+ABoAzxM7My/uOKHModpV/mwgs=
-github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20221017135236-9b4fdd506cdd/go.mod h1:k/wl/uGzWEl8kLqUOWSnKe9QL/10YKnuwHMNZHnXhfY=
+github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20230208142019-eb7d746c941e h1:s003hnAH+8DoiflostIHcPpCjrsCA/uOO5tHtI6vX7g=
+github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20230208142019-eb7d746c941e/go.mod h1:6pjZpt+0dg+Z0kUEn53qLtD57raiZo/bqWzsuX6dDjo=
 github.com/google/go-github/v50 v50.2.0 h1:j2FyongEHlO9nxXLc+LP3wuBSVU9mVxfpdYUexMpIfk=
 github.com/google/go-github/v50 v50.2.0/go.mod h1:VBY8FB6yPIjrtKhozXv4FQupxKLS6H4m6xFZlT43q8Q=
 github.com/google/go-licenses v0.0.0-20200602185517-f29a4c695c3d/go.mod h1:g1VOUGKZYIqe8lDq2mL7plhAWXqrEaGUs7eIjthN1sk=

--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -60,6 +60,7 @@ func NewStorageBackend(ctx context.Context, client kubernetes.Interface, cfg con
 					Namespace:          obj.GetNamespace(),
 					ServiceAccountName: obj.GetServiceAccountName(),
 					ImagePullSecrets:   obj.GetPullSecrets(),
+					UseMountSecrets:    true,
 				})
 			if err != nil {
 				return nil, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -830,8 +830,8 @@ github.com/google/go-containerregistry/pkg/v1/types
 # github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20221030203717-1711cefd7eec
 ## explicit; go 1.17
 github.com/google/go-containerregistry/pkg/authn/k8schain
-# github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20221017135236-9b4fdd506cdd
-## explicit; go 1.17
+# github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20230208142019-eb7d746c941e
+## explicit; go 1.18
 github.com/google/go-containerregistry/pkg/authn/kubernetes
 # github.com/google/go-github/v50 v50.2.0
 ## explicit; go 1.17


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

This bumps the module `github.com/google/go-containerregistry/pkg/authn/kubernetes` so the new option to use mount secrets can be used in the OCI backend.

See https://github.com/tektoncd/chains/issues/700 for additional context.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
OCI backend uses ServiceAccount's Secrets for authentication in addition to the ServiceAccount's ImagePullSecrets.
```
