### PR TITLE
Add top-level build config to External Parameters

### DIFF
--- a/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun_test.go
@@ -116,10 +116,33 @@ func TestExternalParameters(t *testing.T) {
 					Value: v1beta1.ResultValue{Type: "array", ArrayVal: []string{}},
 				},
 			},
+			PipelineRef: &v1beta1.PipelineRef{
+				ResolverRef: v1beta1.ResolverRef{
+					Resolver: "git",
+				},
+			},
+		},
+		Status: v1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				Provenance: &v1beta1.Provenance{
+					RefSource: &v1beta1.RefSource{
+						URI: "hello",
+						Digest: map[string]string{
+							"sha1": "abc123",
+						},
+						EntryPoint: "pipeline.yaml",
+					},
+				},
+			},
 		},
 	}
 
 	want := map[string]any{
+		"buildConfigSource": map[string]string{
+			"path":       "pipeline.yaml",
+			"ref":        "sha1:abc123",
+			"repository": "hello",
+		},
 		"runSpec": pr.Spec,
 	}
 	got := externalParameters(objects.NewPipelineRunObject(pr))

--- a/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun_test.go
@@ -117,11 +117,30 @@ func TestExternalParameters(t *testing.T) {
 					Value: v1beta1.ResultValue{Type: "array", ArrayVal: []string{}},
 				},
 			},
+			TaskRef: &v1beta1.TaskRef{
+				ResolverRef: v1beta1.ResolverRef{
+					Resolver: "git",
+				},
+			},
+		},
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				Provenance: &v1beta1.Provenance{
+					RefSource: &v1beta1.RefSource{
+						URI: "hello",
+						Digest: map[string]string{
+							"sha1": "abc123",
+						},
+						EntryPoint: "task.yaml",
+					},
+				},
+			},
 		},
 	}
 
 	want := map[string]any{
-		"runSpec": tr.Spec,
+		"buildConfigSource": map[string]string{"path": "task.yaml", "ref": "sha1:abc123", "repository": "hello"},
+		"runSpec":           tr.Spec,
 	}
 	got := externalParameters(objects.NewTaskRunObject(tr))
 	if d := cmp.Diff(want, got); d != "" {


### PR DESCRIPTION
In the [build type design](https://docs.google.com/document/d/1ewqtPXyg_y3MmU6Tc6l1X8nfzjt0AJHlP6VOnFsGNpQ/edit#heading=h.8hw7rf805u8r), we decided the add the complete runSpec to externalParameters and the resolved top-level task/pipeline yaml to resolved dependencies. This has caused some friction in alignment between the Slsa specification, builders and verifiers.

According to the [SLSA spec](https://slsa.dev/provenance/v1#provenance), the external parameters should capture the inputs to the build interface. In the case where the build config is located remotely (e.g. in version control), one of the key ingredients that must be validated is the repo from where the build config was fetched. This information is available in the runSpec under pipelineRef or the taskRef however, that syntax is very specific to Tekton which makes it very challenging for generic verifiers (that validate provenances from several CI/CD systems) to identify without making the verification policy understand the Tekton API. To make matters worse, the repo uri is not necessarily embedded in the [resolver parameters](https://github.com/tektoncd/pipeline/blob/main/pkg/resolution/resolver/git/params.go). This means that depending on the parameters, verifiers need to add logic to extract the URI for verification.

In Tekton Chains, we have this information completely resolved and accessible. However, we add this to the resolved dependencies section of the provenance. **Note** that this will also make it synchronous with the suggested [migration path from SLSA v0.2 to v1.0](https://slsa.dev/provenance/v1#migrating-from-02) where it says that the externalParameters should also contain the old invocation.ConfigSource.

This PR surfaces this information in `externalParameters` section of the SLSA 1.0 predicate and addresses issue https://github.com/tektoncd/chains/issues/846.

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Add top-level build config to External Parameters
```
