### PR TITLE
Enable `docdb` for `artifacts.pipelinerun.storage`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -258,7 +258,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 
 		// PipelineRuns
 		asString(pipelinerunFormatKey, &cfg.Artifacts.PipelineRuns.Format, "in-toto", "slsa/v1", "slsa/v2alpha2"),
-		asStringSet(pipelinerunStorageKey, &cfg.Artifacts.PipelineRuns.StorageBackend, sets.New[string]("tekton", "oci", "grafeas")),
+		asStringSet(pipelinerunStorageKey, &cfg.Artifacts.PipelineRuns.StorageBackend, sets.New[string]("tekton", "oci", "docdb", "grafeas")),
 		asString(pipelinerunSignerKey, &cfg.Artifacts.PipelineRuns.Signer, "x509", "kms"),
 
 		// OCI

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -209,6 +209,35 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:           "pipelineRun multi backend with docdb",
+			data:           map[string]string{pipelinerunStorageKey: "tekton,docdb"},
+			taskrunEnabled: true,
+			ociEnbaled:     true,
+			want: Config{
+				Builder: defaultBuilder,
+				Artifacts: ArtifactConfigs{
+					TaskRuns: Artifact{
+						Format:         "in-toto",
+						StorageBackend: sets.New[string]("tekton"),
+						Signer:         "x509",
+					},
+					PipelineRuns: Artifact{
+						Format:         "in-toto",
+						Signer:         "x509",
+						StorageBackend: sets.New[string]("tekton", "docdb"),
+					},
+					OCI: Artifact{
+						Format:         "simplesigning",
+						StorageBackend: sets.New[string]("oci"),
+						Signer:         "x509",
+					},
+				},
+				Signers:      defaultSigners,
+				Storage:      defaultStorage,
+				Transparency: defaultTransparency,
+			},
+		},
+		{
 			name:           "taskrun multi backend disabled",
 			data:           map[string]string{taskrunStorageKey: ""},
 			taskrunEnabled: false,


### PR DESCRIPTION
Fixes https://github.com/tektoncd/chains/issues/869

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Enables `docdb` as storage option for `PipelineRun`'s via `artifacts.pipelinerun.storage`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
