### PR TITLE
Add TektonObject.GetKindName to abstract more

### DIFF
--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -52,6 +53,7 @@ type Result struct {
 type TektonObject interface {
 	Object
 	GetGVK() string
+	GetKindName() string
 	GetObject() interface{}
 	GetLatestAnnotations(ctx context.Context, clientSet versioned.Interface) (map[string]string, error)
 	Patch(ctx context.Context, clientSet versioned.Interface, patchBytes []byte) error
@@ -89,6 +91,10 @@ func NewTaskRunObject(tr *v1beta1.TaskRun) *TaskRunObject {
 // Get the TaskRun GroupVersionKind
 func (tro *TaskRunObject) GetGVK() string {
 	return fmt.Sprintf("%s/%s", tro.GetGroupVersionKind().GroupVersion().String(), tro.GetGroupVersionKind().Kind)
+}
+
+func (tro *TaskRunObject) GetKindName() string {
+	return strings.ToLower(tro.GetGroupVersionKind().Kind)
 }
 
 // Get the latest annotations on the TaskRun
@@ -150,6 +156,10 @@ func NewPipelineRunObject(pr *v1beta1.PipelineRun) *PipelineRunObject {
 // Get the PipelineRun GroupVersionKind
 func (pro *PipelineRunObject) GetGVK() string {
 	return fmt.Sprintf("%s/%s", pro.GetGroupVersionKind().GroupVersion().String(), pro.GetGroupVersionKind().Kind)
+}
+
+func (pro *PipelineRunObject) GetKindName() string {
+	return strings.ToLower(pro.GetGroupVersionKind().Kind)
 }
 
 // Request the current annotations on the PipelineRun object


### PR DESCRIPTION
# Changes

This commit removes certain parts of the code that switch on the underlying TektonObject type to determine if either the string `taskrun` or `pipelinerun` should be used. Instead, a new method on TektonObject is used.

Relates to https://github.com/tektoncd/chains/issues/875

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
