### PR TITLE
Manage consts of ResourceDescriptor in its own pkg

### DIFF
--- a/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun.go
@@ -22,13 +22,8 @@ import (
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
 	resolveddependencies "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies"
+	rd "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/resource_descriptor"
 	"github.com/tektoncd/chains/pkg/chains/objects"
-)
-
-const (
-	pipelineRunResults = "pipelineRunResults/%s"
-	// JsonMediaType is the media type of json encoded content used in resource descriptors
-	JsonMediaType = "application/json"
 )
 
 // GenerateAttestation generates a provenance statement with SLSA v1.0 predicate for a pipeline run.
@@ -130,9 +125,9 @@ func byproducts(pro *objects.PipelineRunObject) ([]slsa.ResourceDescriptor, erro
 			return nil, err
 		}
 		bp := slsa.ResourceDescriptor{
-			Name:      fmt.Sprintf(pipelineRunResults, key.Name),
+			Name:      fmt.Sprintf(string(rd.PipelineRunResults), key.Name),
 			Content:   content,
-			MediaType: JsonMediaType,
+			MediaType: string(rd.JsonMediaType),
 		}
 		byProd = append(byProd, bp)
 	}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 
+	resourcedescriptor "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/resource_descriptor"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/internal/objectloader"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -210,7 +211,7 @@ func TestByProducts(t *testing.T) {
 		{
 			Name:      "pipelineRunResults/result-name",
 			Content:   resultBytes,
-			MediaType: JsonMediaType,
+			MediaType: string(resourcedescriptor.JsonMediaType),
 		},
 	}
 	got, err := byproducts(objects.NewPipelineRunObject(pr))
@@ -318,31 +319,31 @@ func TestGenerateAttestation(t *testing.T) {
 					{
 						Name:      "pipelineRunResults/CHAINS-GIT_COMMIT",
 						Content:   []uint8(`"abcd"`),
-						MediaType: JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/CHAINS-GIT_URL",
 						Content:   []uint8(`"https://git.test.com"`),
-						MediaType: JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/IMAGE_URL",
 						Content:   []uint8(`"test.io/test/image"`),
-						MediaType: JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/IMAGE_DIGEST",
 						Content:   []uint8(`"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"`),
-						MediaType: JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/img-ARTIFACT_INPUTS",
 						Content:   []uint8(`{"digest":"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7","uri":"abc"}`),
-						MediaType: JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/img2-ARTIFACT_OUTPUTS",
 						Content:   []uint8(`{"digest":"sha256:","uri":"def"}`),
-						MediaType: JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/img_no_uri-ARTIFACT_OUTPUTS",
 						Content:   []uint8(`{"digest":"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}`),
-						MediaType: JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					},
 				},
 			},

--- a/pkg/chains/formats/slsa/v2alpha2/internal/resource_descriptor/resource_descriptor.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/resource_descriptor/resource_descriptor.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcedescriptor
+
+// types for fields in ResourceDescriptor
+// https://github.com/in-toto/attestation/blob/main/spec/v1/resource_descriptor.md
+type Name string
+type MediaType string
+
+const (
+	// PipelineConfigName is the name of the resolved dependency of the pipelineRef.
+	PipelineConfigName Name = "pipeline"
+	// TaskConfigName is the name of the resolved dependency of the top level taskRef.
+	TaskConfigName Name = "task"
+	// PipelineTaskConfigName is the name of the resolved dependency of the pipeline task.
+	PipelineTaskConfigName Name = "pipelineTask"
+	// InputResultName is the name of the resolved dependency generated from Type hinted parameters or results.
+	InputResultName Name = "inputs/result"
+	// PipelineResourceName is the name of the resolved dependency of pipeline resource.
+	PipelineResourceName Name = "pipelineResource"
+	// PipelineRunResults is the string used to format the name of a pipelinerun result.
+	PipelineRunResults Name = "pipelineRunResults/%s"
+	// TaskRunResults is the string used to format the name of a taskrun result.
+	TaskRunResults Name = "taskRunResults/%s"
+	// JsonMediaType is the media type of json encoded content used in resource descriptors
+	JsonMediaType MediaType = "application/json"
+)

--- a/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun.go
@@ -21,12 +21,10 @@ import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
-	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun"
 	resolveddependencies "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies"
+	rd "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/resource_descriptor"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 )
-
-const taskRunResults = "taskRunResults/%s"
 
 // GenerateAttestation generates a provenance statement with SLSA v1.0 predicate for a task run.
 func GenerateAttestation(ctx context.Context, builderID string, tro *objects.TaskRunObject) (interface{}, error) {
@@ -125,9 +123,9 @@ func byproducts(tro *objects.TaskRunObject) ([]slsa.ResourceDescriptor, error) {
 			return nil, err
 		}
 		bp := slsa.ResourceDescriptor{
-			Name:      fmt.Sprintf(taskRunResults, key.Name),
+			Name:      fmt.Sprintf(string(rd.TaskRunResults), key.Name),
 			Content:   content,
-			MediaType: pipelinerun.JsonMediaType,
+			MediaType: string(rd.JsonMediaType),
 		}
 		byProd = append(byProd, bp)
 	}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 
-	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun"
+	resourcedescriptor "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/resource_descriptor"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/internal/objectloader"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -207,7 +207,7 @@ func TestByProducts(t *testing.T) {
 		{
 			Name:      "taskRunResults/result-name",
 			Content:   resultBytes,
-			MediaType: pipelinerun.JsonMediaType,
+			MediaType: string(resourcedescriptor.JsonMediaType),
 		},
 	}
 	got, err := byproducts(objects.NewTaskRunObject(tr))
@@ -296,12 +296,12 @@ func TestTaskRunGenerateAttestation(t *testing.T) {
 					{
 						Name:      "taskRunResults/IMAGE_DIGEST",
 						Content:   resultBytesDigest,
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					},
 					{
 						Name:      "taskRunResults/IMAGE_URL",
 						Content:   resultBytesUri,
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					},
 				},
 			},

--- a/pkg/chains/formats/slsa/v2alpha2/slsav2_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/slsav2_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/chains/pkg/chains/formats"
-	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun"
+	resourcedescriptor "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/resource_descriptor"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/chains/pkg/internal/objectloader"
@@ -172,12 +172,12 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 					{
 						Name:      "taskRunResults/IMAGE_DIGEST",
 						Content:   resultBytesDigest,
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					},
 					{
 						Name:      "taskRunResults/IMAGE_URL",
 						Content:   resultBytesUri,
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					},
 				},
 			},
@@ -258,12 +258,12 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 					{
 						Name:      "taskRunResults/some-uri_DIGEST",
 						Content:   resultBytesDigest,
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					},
 					{
 						Name:      "taskRunResults/some-uri",
 						Content:   resultBytesUri,
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					},
 				},
 			},
@@ -343,7 +343,7 @@ func TestMultipleSubjects(t *testing.T) {
 					{
 						Name:      "taskRunResults/IMAGES",
 						Content:   resultBytes,
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					},
 				},
 			},
@@ -458,31 +458,31 @@ func TestPipelineRunCreatePayload1(t *testing.T) {
 					{
 						Name:      "pipelineRunResults/CHAINS-GIT_COMMIT",
 						Content:   []uint8(`"abcd"`),
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/CHAINS-GIT_URL",
 						Content:   []uint8(`"https://git.test.com"`),
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/IMAGE_URL",
 						Content:   []uint8(`"test.io/test/image"`),
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/IMAGE_DIGEST",
 						Content:   []uint8(`"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"`),
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/img-ARTIFACT_INPUTS",
 						Content:   []uint8(`{"digest":"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7","uri":"abc"}`),
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/img2-ARTIFACT_OUTPUTS",
 						Content:   []uint8(`{"digest":"sha256:","uri":"def"}`),
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					}, {
 						Name:      "pipelineRunResults/img_no_uri-ARTIFACT_OUTPUTS",
 						Content:   []uint8(`{"digest":"sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}`),
-						MediaType: pipelinerun.JsonMediaType,
+						MediaType: string(resourcedescriptor.JsonMediaType),
 					},
 				},
 			},


### PR DESCRIPTION


<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

/cleanup

Prior, there are a number of consts defined for the ResourceDescriptor across different packages, which introduces dependencies between those packages i.e. taskrun pkg imports pipelinerun pkg just for json media type, which in turn is prone to import cycle in future.

Now, since ResourceDescriptor in SLSA v1 is a standalone type, we organize and manage all the constants for the fields of ResourceDescriptor into its own (internal) package.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

# Release Notes

``` release-note
NONE
```
