### PR TITLE
Pass slsa-related config via explicit struct instead of separate args

### DIFF
--- a/pkg/chains/formats/slsa/internal/slsaconfig/slsaconfig.go
+++ b/pkg/chains/formats/slsa/internal/slsaconfig/slsaconfig.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2023 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package slsaconfig
+
+// SlsaConfig carries common information that is needed across different SLSA formatters.
+type SlsaConfig struct {
+	// BuilderID is the URI of the trusted build platform.
+	BuilderID string
+}

--- a/pkg/chains/formats/slsa/v1/intotoite6.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v1/pipelinerun"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v1/taskrun"
 	"github.com/tektoncd/chains/pkg/chains/objects"
@@ -38,12 +39,14 @@ func init() {
 }
 
 type InTotoIte6 struct {
-	builderID string
+	slsaConfig *slsaconfig.SlsaConfig
 }
 
 func NewFormatter(cfg config.Config) (formats.Payloader, error) {
 	return &InTotoIte6{
-		builderID: cfg.Builder.ID,
+		slsaConfig: &slsaconfig.SlsaConfig{
+			BuilderID: cfg.Builder.ID,
+		},
 	}, nil
 }
 
@@ -54,9 +57,9 @@ func (i *InTotoIte6) Wrap() bool {
 func (i *InTotoIte6) CreatePayload(ctx context.Context, obj interface{}) (interface{}, error) {
 	switch v := obj.(type) {
 	case *objects.TaskRunObject:
-		return taskrun.GenerateAttestation(ctx, i.builderID, v)
+		return taskrun.GenerateAttestation(ctx, v, i.slsaConfig)
 	case *objects.PipelineRunObject:
-		return pipelinerun.GenerateAttestation(ctx, i.builderID, v)
+		return pipelinerun.GenerateAttestation(ctx, v, i.slsaConfig)
 	default:
 		return nil, fmt.Errorf("intoto does not support type: %s", v)
 	}

--- a/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/attest"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/material"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -46,7 +47,7 @@ type TaskAttestation struct {
 	Results    []v1beta1.TaskRunResult   `json:"results,omitempty"`
 }
 
-func GenerateAttestation(ctx context.Context, builderID string, pro *objects.PipelineRunObject) (interface{}, error) {
+func GenerateAttestation(ctx context.Context, pro *objects.PipelineRunObject, slsaConfig *slsaconfig.SlsaConfig) (interface{}, error) {
 	subjects := extract.SubjectDigests(ctx, pro)
 
 	mat, err := material.PipelineMaterials(ctx, pro)
@@ -61,7 +62,7 @@ func GenerateAttestation(ctx context.Context, builderID string, pro *objects.Pip
 		},
 		Predicate: slsa.ProvenancePredicate{
 			Builder: common.ProvenanceBuilder{
-				ID: builderID,
+				ID: slsaConfig.BuilderID,
 			},
 			BuildType:   pro.GetGVK(),
 			Invocation:  invocation(pro),

--- a/pkg/chains/formats/slsa/v1/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v1/taskrun/taskrun.go
@@ -22,11 +22,12 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/attest"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/material"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
-func GenerateAttestation(ctx context.Context, builderID string, tro *objects.TaskRunObject) (interface{}, error) {
+func GenerateAttestation(ctx context.Context, tro *objects.TaskRunObject, slsaConfig *slsaconfig.SlsaConfig) (interface{}, error) {
 	subjects := extract.SubjectDigests(ctx, tro)
 
 	mat, err := material.TaskMaterials(ctx, tro)
@@ -41,7 +42,7 @@ func GenerateAttestation(ctx context.Context, builderID string, tro *objects.Tas
 		},
 		Predicate: slsa.ProvenancePredicate{
 			Builder: common.ProvenanceBuilder{
-				ID: builderID,
+				ID: slsaConfig.BuilderID,
 			},
 			BuildType:   tro.GetGVK(),
 			Invocation:  invocation(tro),

--- a/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun.go
@@ -21,6 +21,7 @@ import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	resolveddependencies "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 )
@@ -32,7 +33,7 @@ const (
 )
 
 // GenerateAttestation generates a provenance statement with SLSA v1.0 predicate for a pipeline run.
-func GenerateAttestation(ctx context.Context, builderID string, pro *objects.PipelineRunObject) (interface{}, error) {
+func GenerateAttestation(ctx context.Context, pro *objects.PipelineRunObject, slsaconfig *slsaconfig.SlsaConfig) (interface{}, error) {
 	rd, err := resolveddependencies.PipelineRun(ctx, pro)
 	if err != nil {
 		return nil, err
@@ -56,7 +57,7 @@ func GenerateAttestation(ctx context.Context, builderID string, pro *objects.Pip
 			},
 			RunDetails: slsa.ProvenanceRunDetails{
 				Builder: slsa.Builder{
-					ID: builderID,
+					ID: slsaconfig.BuilderID,
 				},
 				BuildMetadata: metadata(pro),
 				Byproducts:    bp,

--- a/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/internal/objectloader"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -243,7 +244,6 @@ func createPro(path string) *objects.PipelineRunObject {
 
 func TestGenerateAttestation(t *testing.T) {
 	ctx := logtesting.TestContextWithLogger(t)
-
 	pr := createPro("../../../testdata/v2alpha2/pipelinerun1.json")
 
 	e1BuildStart := time.Unix(1617011400, 0)
@@ -349,7 +349,9 @@ func TestGenerateAttestation(t *testing.T) {
 		},
 	}
 
-	got, err := GenerateAttestation(ctx, "test_builder-1", pr)
+	got, err := GenerateAttestation(ctx, pr, &slsaconfig.SlsaConfig{
+		BuilderID: "test_builder-1",
+	})
 
 	if err != nil {
 		t.Errorf("unwant error: %s", err.Error())

--- a/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun.go
@@ -21,6 +21,7 @@ import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun"
 	resolveddependencies "github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies"
 	"github.com/tektoncd/chains/pkg/chains/objects"
@@ -29,7 +30,7 @@ import (
 const taskRunResults = "taskRunResults/%s"
 
 // GenerateAttestation generates a provenance statement with SLSA v1.0 predicate for a task run.
-func GenerateAttestation(ctx context.Context, builderID string, tro *objects.TaskRunObject) (interface{}, error) {
+func GenerateAttestation(ctx context.Context, tro *objects.TaskRunObject, slsaConfig *slsaconfig.SlsaConfig) (interface{}, error) {
 	rd, err := resolveddependencies.TaskRun(ctx, tro)
 	if err != nil {
 		return nil, err
@@ -53,7 +54,7 @@ func GenerateAttestation(ctx context.Context, builderID string, tro *objects.Tas
 			},
 			RunDetails: slsa.ProvenanceRunDetails{
 				Builder: slsa.Builder{
-					ID: builderID,
+					ID: slsaConfig.BuilderID,
 				},
 				BuildMetadata: metadata(tro),
 				Byproducts:    bp,

--- a/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/taskrun/taskrun_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/internal/objectloader"
@@ -221,7 +222,6 @@ func TestByProducts(t *testing.T) {
 
 func TestTaskRunGenerateAttestation(t *testing.T) {
 	ctx := logtesting.TestContextWithLogger(t)
-
 	tr, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun1.json")
 	if err != nil {
 		t.Fatal(err)
@@ -308,7 +308,9 @@ func TestTaskRunGenerateAttestation(t *testing.T) {
 		},
 	}
 
-	got, err := GenerateAttestation(ctx, "test_builder-1", objects.NewTaskRunObject(tr))
+	got, err := GenerateAttestation(ctx, objects.NewTaskRunObject(tr), &slsaconfig.SlsaConfig{
+		BuilderID: "test_builder-1",
+	})
 
 	if err != nil {
 		t.Errorf("unwant error: %s", err.Error())

--- a/pkg/chains/formats/slsa/v2alpha2/slsav2.go
+++ b/pkg/chains/formats/slsa/v2alpha2/slsav2.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha2/internal/taskrun"
 	"github.com/tektoncd/chains/pkg/chains/objects"
@@ -36,12 +37,14 @@ func init() {
 }
 
 type Slsa struct {
-	builderID string
+	slsaConfig *slsaconfig.SlsaConfig
 }
 
 func NewFormatter(cfg config.Config) (formats.Payloader, error) {
 	return &Slsa{
-		builderID: cfg.Builder.ID,
+		slsaConfig: &slsaconfig.SlsaConfig{
+			BuilderID: cfg.Builder.ID,
+		},
 	}, nil
 }
 
@@ -52,9 +55,9 @@ func (s *Slsa) Wrap() bool {
 func (s *Slsa) CreatePayload(ctx context.Context, obj interface{}) (interface{}, error) {
 	switch v := obj.(type) {
 	case *objects.TaskRunObject:
-		return taskrun.GenerateAttestation(ctx, s.builderID, v)
+		return taskrun.GenerateAttestation(ctx, v, s.slsaConfig)
 	case *objects.PipelineRunObject:
-		return pipelinerun.GenerateAttestation(ctx, s.builderID, v)
+		return pipelinerun.GenerateAttestation(ctx, v, s.slsaConfig)
 	default:
 		return nil, fmt.Errorf("intoto does not support type: %s", v)
 	}


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

/cleanup

Prior, we received slsa-related configs from configmap and passed them
via separate arguments down to GenerateAttestation.

Now, we pass them via a struct as a whole instead of separate args. This
will enable slsa formatters to be extensible to receive more slsa-related
configs without having to change downstream functions' interface i.e.
config option [`ObserveMode`](https://github.com/tektoncd/chains/pull/866#discussion_r1269715883)
which customizes how Chains observes inputs/outputs.

Signed-off-by: Chuang Wang <chuangw@google.com>
@chuangw6

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

# Release Notes

``` release-note
NONE
```
