### PR TITLE
Create new buildType for tekton specific verifiers

### DIFF
--- a/pkg/chains/formats/slsa/v2alpha2/internal/build_types/build_types.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/build_types/build_types.go
@@ -1,10 +1,11 @@
 /*
 Copyright 2023 The Tekton Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,14 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package slsaconfig
 
-// SlsaConfig carries common information that is needed across different SLSA formatters.
-type SlsaConfig struct {
-	// BuilderID is the URI of the trusted build platform.
-	BuilderID string
-	// DeepInspectionEnabled configures whether to dive into child taskruns in a pipelinerun
-	DeepInspectionEnabled bool
-	// The buildType for the build definition
-	BuildType string
-}
+package buildtypes
+
+const (
+	SlsaBuildType   = "https://tekton.dev/chains/v2/slsa"
+	TektonBuildType = "https://tekton.dev/chains/v2/slsa-tekton"
+)

--- a/pkg/chains/formats/slsa/v2alpha2/internal/external_parameters/external_parameters.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/external_parameters/external_parameters.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externalparameters
+
+import (
+	"fmt"
+
+	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+func buildConfigSource(provenance *v1beta1.Provenance) map[string]string {
+	ref := ""
+	for alg, hex := range provenance.RefSource.Digest {
+		ref = fmt.Sprintf("%s:%s", alg, hex)
+		break
+	}
+	buildConfigSource := map[string]string{
+		"ref":        ref,
+		"repository": provenance.RefSource.URI,
+		"path":       provenance.RefSource.EntryPoint,
+	}
+	return buildConfigSource
+}
+
+// PipelineRun adds the pipeline run spec and provenance if available
+func PipelineRun(pro *objects.PipelineRunObject) map[string]any {
+	externalParams := make(map[string]any)
+
+	if provenance := pro.GetRemoteProvenance(); provenance != nil {
+		externalParams["buildConfigSource"] = buildConfigSource(provenance)
+	}
+	externalParams["runSpec"] = pro.Spec
+	return externalParams
+}
+
+// TaskRun adds the task run spec and provenance if available
+func TaskRun(tro *objects.TaskRunObject) map[string]any {
+	externalParams := make(map[string]any)
+
+	if provenance := tro.GetRemoteProvenance(); provenance != nil {
+		externalParams["buildConfigSource"] = buildConfigSource(provenance)
+	}
+	externalParams["runSpec"] = tro.Spec
+	return externalParams
+}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/external_parameters/external_parameters_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/external_parameters/external_parameters_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externalparameters
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/chains/pkg/internal/objectloader"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+func TestBuildConfigSource(t *testing.T) {
+	provenance := &v1beta1.Provenance{
+		RefSource: &v1beta1.RefSource{
+			Digest:     map[string]string{"alg1": "hex1", "alg2": "hex2"},
+			URI:        "https://tekton.com",
+			EntryPoint: "/path/to/entry",
+		},
+	}
+
+	want := map[string]string{
+		"ref":        "alg1:hex1",
+		"repository": "https://tekton.com",
+		"path":       "/path/to/entry",
+	}
+
+	got := buildConfigSource(provenance)
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("buildConfigSource(): -want +got: %s", diff)
+	}
+}
+func createPro(path string) *objects.PipelineRunObject {
+	pr, err := objectloader.PipelineRunFromFile(path)
+	if err != nil {
+		panic(err)
+	}
+	tr1, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun1.json")
+	if err != nil {
+		panic(err)
+	}
+	tr2, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun2.json")
+	if err != nil {
+		panic(err)
+	}
+	p := objects.NewPipelineRunObject(pr)
+	p.AppendTaskRun(tr1)
+	p.AppendTaskRun(tr2)
+	return p
+}
+
+func TestPipelineRun(t *testing.T) {
+	pro := createPro("../../../testdata/v2alpha2/pipelinerun1.json")
+
+	got := PipelineRun(pro)
+
+	want := map[string]any{
+		"runSpec": v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: "test-pipeline"},
+			Params: v1beta1.Params{
+				{
+					Name:  "IMAGE",
+					Value: v1beta1.ParamValue{Type: "string", StringVal: "test.io/test/image"},
+				},
+			},
+			ServiceAccountName: "pipeline",
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("PipelineRun(): -want +got: %s", diff)
+	}
+}
+
+func TestTaskRun(t *testing.T) {
+	tr, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := TaskRun(objects.NewTaskRunObject(tr))
+
+	want := map[string]any{
+		"runSpec": v1beta1.TaskRunSpec{
+			Params: v1beta1.Params{
+				{Name: "IMAGE", Value: v1beta1.ParamValue{Type: "string", StringVal: "test.io/test/image"}},
+				{Name: "CHAINS-GIT_COMMIT", Value: v1beta1.ParamValue{Type: "string", StringVal: "taskrun"}},
+				{Name: "CHAINS-GIT_URL", Value: v1beta1.ParamValue{Type: "string", StringVal: "https://git.test.com"}},
+			},
+			ServiceAccountName: "default",
+			TaskRef:            &v1beta1.TaskRef{Name: "build", Kind: "Task"},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("TaskRun(): -want +got: %s", diff)
+	}
+}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/internal_parameters/internal_parameters.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/internal_parameters/internal_parameters.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internalparameters
+
+import (
+	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+// SLSAInternalParameters provides the chains config as internalparameters
+func SLSAInternalParameters(tko objects.TektonObject) map[string]any {
+	internalParams := make(map[string]any)
+	if provenance := tko.GetProvenance(); provenance != (*v1beta1.Provenance)(nil) && provenance.FeatureFlags != nil {
+		internalParams["tekton-pipelines-feature-flags"] = *provenance.FeatureFlags
+	}
+	return internalParams
+}
+
+// TektonInternalParameters provides the chains config as well as annotations and labels
+func TektonInternalParameters(tko objects.TektonObject) map[string]any {
+	internalParams := make(map[string]any)
+	if provenance := tko.GetProvenance(); provenance != (*v1beta1.Provenance)(nil) && provenance.FeatureFlags != nil {
+		internalParams["tekton-pipelines-feature-flags"] = *provenance.FeatureFlags
+	}
+	internalParams["labels"] = tko.GetLabels()
+	internalParams["annotations"] = tko.GetAnnotations()
+	return internalParams
+}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/internal_parameters/internal_parameters_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/internal_parameters/internal_parameters_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internalparameters
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/chains/pkg/internal/objectloader"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+)
+
+func TestTektonInternalParameters(t *testing.T) {
+	tr, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tro := objects.NewTaskRunObject(tr)
+	got := TektonInternalParameters(tro)
+	want := map[string]any{
+		"labels":                         tro.GetLabels(),
+		"annotations":                    tro.GetAnnotations(),
+		"tekton-pipelines-feature-flags": config.FeatureFlags{EnableAPIFields: "beta", ResultExtractionMethod: "termination-message"},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("TaskRun(): -want +got: %s", diff)
+	}
+}
+
+func TestSLSAInternalParameters(t *testing.T) {
+	tr, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tro := objects.NewTaskRunObject(tr)
+	got := SLSAInternalParameters(tro)
+	want := map[string]any{
+		"tekton-pipelines-feature-flags": config.FeatureFlags{EnableAPIFields: "beta", ResultExtractionMethod: "termination-message"},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("TaskRun(): -want +got: %s", diff)
+	}
+}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies/resolved_dependencies_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies/resolved_dependencies_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package resolveddependencies
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	v1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
+	v1slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 	"github.com/tektoncd/chains/internal/backport"
 	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/compare"
@@ -64,208 +66,30 @@ func createPro(path string) *objects.PipelineRunObject {
 	return p
 }
 
-func TestTaskRun(t *testing.T) {
-	tests := []struct {
-		name    string
-		taskRun *v1beta1.TaskRun
-		want    []v1.ResourceDescriptor
-	}{{
-		name: "resolvedDependencies from pipeline resources",
-		taskRun: &v1beta1.TaskRun{
-			Spec: v1beta1.TaskRunSpec{
-				Resources: &v1beta1.TaskRunResources{ //nolint:all //incompatible with pipelines v0.45
-					Inputs: []v1beta1.TaskResourceBinding{ //nolint:all //incompatible with pipelines v0.45
-						{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{ //nolint:all //incompatible with pipelines v0.45
-								Name: "nil-resource-spec",
-							},
-						}, {
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{ //nolint:all //incompatible with pipelines v0.45
-								Name: "repo",
-								ResourceSpec: &v1alpha1.PipelineResourceSpec{ //nolint:all //incompatible with pipelines v0.45
-									Params: []v1alpha1.ResourceParam{ //nolint:all //incompatible with pipelines v0.45
-										{Name: "url", Value: "https://github.com/GoogleContainerTools/distroless"},
-									},
-									Type: backport.PipelineResourceTypeGit,
-								},
-							},
-						},
-					},
-				},
-			},
-			Status: v1beta1.TaskRunStatus{
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					TaskRunResults: []v1beta1.TaskRunResult{
-						{
-							Name: "img1_input" + "-" + artifacts.ArtifactsInputsResultName,
-							Value: *v1beta1.NewObject(map[string]string{
-								"uri":    "gcr.io/foo/bar",
-								"digest": digest,
-							}),
-						},
-					},
-					ResourcesResult: []v1beta1.PipelineResourceResult{
-						{
-							ResourceName: "repo",
-							Key:          "commit",
-							Value:        "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
-						}, {
-							ResourceName: "repo",
-							Key:          "url",
-							Value:        "https://github.com/GoogleContainerTools/distroless",
-						},
-					},
-				},
-			},
-		},
-		want: []v1.ResourceDescriptor{
-			{
-				Name: "inputs/result",
-				URI:  "gcr.io/foo/bar",
-				Digest: common.DigestSet{
-					"sha256": strings.TrimPrefix(digest, "sha256:"),
-				},
-			},
-			{
-				Name: "pipelineResource",
-				URI:  "git+https://github.com/GoogleContainerTools/distroless.git",
-				Digest: common.DigestSet{
-					"sha1": "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
-				},
-			},
-		},
-	}, {
-		name: "resolvedDependencies from remote task",
-		taskRun: &v1beta1.TaskRun{
-			Status: v1beta1.TaskRunStatus{
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					Provenance: &v1beta1.Provenance{
-						RefSource: &v1beta1.RefSource{
-							URI: "git+github.com/something.git",
-							Digest: map[string]string{
-								"sha1": "abcd1234",
-							},
-						},
-					},
-				},
-			},
-		},
-		want: []v1.ResourceDescriptor{
-			{
-				Name: "task",
-				URI:  "git+github.com/something.git",
-				Digest: common.DigestSet{
-					"sha1": "abcd1234",
-				},
-			},
-		},
-	}, {
-		name: "git resolvedDependencies from taskrun params",
-		taskRun: &v1beta1.TaskRun{
-			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
-					Name:  "CHAINS-GIT_COMMIT",
-					Value: *v1beta1.NewStructuredValues("my-commit"),
-				}, {
-					Name:  "CHAINS-GIT_URL",
-					Value: *v1beta1.NewStructuredValues("github.com/something"),
-				}},
-			},
-		},
-		want: []v1.ResourceDescriptor{
-			{
-				Name: "inputs/result",
-				URI:  "git+github.com/something.git",
-				Digest: common.DigestSet{
-					"sha1": "my-commit",
-				},
-			},
-		},
-	}, {
-		name: "resolvedDependencies from step images",
-		taskRun: &v1beta1.TaskRun{
-			Status: v1beta1.TaskRunStatus{
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					Steps: []v1beta1.StepState{{
-						Name:    "git-source-repo-jwqcl",
-						ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
-					}, {
-						Name:    "git-source-repo-repeat-again-jwqcl",
-						ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
-					}, {
-						Name:    "build",
-						ImageID: "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
-					}},
-				},
-			},
-		},
-		want: []v1.ResourceDescriptor{
-			{
-				URI: "oci://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: common.DigestSet{
-					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
-				},
-			},
-			{
-				URI: "oci://gcr.io/cloud-marketplace-containers/google/bazel",
-				Digest: common.DigestSet{
-					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
-				},
-			},
-		},
-	}, {
-		name: "resolvedDependencies from step and sidecar images",
-		taskRun: &v1beta1.TaskRun{
-			Status: v1beta1.TaskRunStatus{
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					Steps: []v1beta1.StepState{{
-						Name:    "git-source-repo-jwqcl",
-						ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
-					}, {
-						Name:    "git-source-repo-repeat-again-jwqcl",
-						ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
-					}, {
-						Name:    "build",
-						ImageID: "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
-					}},
-					Sidecars: []v1beta1.SidecarState{{
-						Name:    "sidecar-jwqcl",
-						ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/sidecar-git-init@sha256:a1234f6e7a69617db57b685893256f978436277094c21d43b153994acd8a09567",
-					}},
-				},
-			},
-		},
-		want: []v1.ResourceDescriptor{
-			{
-				URI: "oci://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-				Digest: common.DigestSet{
-					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
-				},
-			}, {
-				URI: "oci://gcr.io/cloud-marketplace-containers/google/bazel",
-				Digest: common.DigestSet{
-					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
-				},
-			}, {
-				URI: "oci://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/sidecar-git-init",
-				Digest: common.DigestSet{
-					"sha256": "a1234f6e7a69617db57b685893256f978436277094c21d43b153994acd8a09567",
-				},
-			},
-		},
-	}}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := logtesting.TestContextWithLogger(t)
-			rd, err := TaskRun(ctx, objects.NewTaskRunObject(tc.taskRun))
-			if err != nil {
-				t.Fatalf("Did not expect an error but got %v", err)
-			}
-			if diff := cmp.Diff(tc.want, rd); diff != "" {
-				t.Errorf("ResolvedDependencies(): -want +got: %s", diff)
-			}
-		})
+func tektonTaskRuns() map[string][]byte {
+	trs := make(map[string][]byte)
+	tr1, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun1.json")
+	if err != nil {
+		panic(err)
 	}
+	tr2, err := objectloader.TaskRunFromFile("../../../testdata/v2alpha2/taskrun2.json")
+	if err != nil {
+		panic(err)
+	}
+
+	tr1Desc, err := json.Marshal(tr1)
+	if err != nil {
+		panic(err)
+	}
+	trs[tr1.Name] = tr1Desc
+
+	tr2Desc, err := json.Marshal(tr2)
+	if err != nil {
+		panic(err)
+	}
+	trs[tr2.Name] = tr2Desc
+
+	return trs
 }
 
 func TestRemoveDuplicates(t *testing.T) {
@@ -484,38 +308,281 @@ func TestRemoveDuplicates(t *testing.T) {
 	}
 }
 
+func TestTaskRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		taskRun *v1beta1.TaskRun //nolint:staticcheck
+		want    []v1.ResourceDescriptor
+	}{{
+		name: "resolvedDependencies from pipeline resources",
+		taskRun: &v1beta1.TaskRun{ //nolint:staticcheck
+			Spec: v1beta1.TaskRunSpec{
+				Resources: &v1beta1.TaskRunResources{ //nolint:all //incompatible with pipelines v0.45
+					Inputs: []v1beta1.TaskResourceBinding{ //nolint:all //incompatible with pipelines v0.45
+						{
+							PipelineResourceBinding: v1beta1.PipelineResourceBinding{ //nolint:all //incompatible with pipelines v0.45
+								Name: "nil-resource-spec",
+							},
+						}, {
+							PipelineResourceBinding: v1beta1.PipelineResourceBinding{ //nolint:all //incompatible with pipelines v0.45
+								Name: "repo",
+								ResourceSpec: &v1alpha1.PipelineResourceSpec{ //nolint:all //incompatible with pipelines v0.45
+									Params: []v1alpha1.ResourceParam{ //nolint:all //incompatible with pipelines v0.45
+										{Name: "url", Value: "https://github.com/GoogleContainerTools/distroless"},
+									},
+									Type: backport.PipelineResourceTypeGit,
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					TaskRunResults: []v1beta1.TaskRunResult{
+						{
+							Name: "img1_input" + "-" + artifacts.ArtifactsInputsResultName,
+							Value: *v1beta1.NewObject(map[string]string{
+								"uri":    "gcr.io/foo/bar",
+								"digest": digest,
+							}),
+						},
+					},
+					ResourcesResult: []v1beta1.PipelineResourceResult{
+						{
+							ResourceName: "repo",
+							Key:          "commit",
+							Value:        "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
+						}, {
+							ResourceName: "repo",
+							Key:          "url",
+							Value:        "https://github.com/GoogleContainerTools/distroless",
+						},
+					},
+				},
+			},
+		},
+		want: []v1.ResourceDescriptor{
+			{
+				Name: "inputs/result",
+				URI:  "gcr.io/foo/bar",
+				Digest: common.DigestSet{
+					"sha256": strings.TrimPrefix(digest, "sha256:"),
+				},
+			},
+			{
+				Name: "pipelineResource",
+				URI:  "git+https://github.com/GoogleContainerTools/distroless.git",
+				Digest: common.DigestSet{
+					"sha1": "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
+				},
+			},
+		},
+	}, {
+		name: "resolvedDependencies from remote task",
+		taskRun: &v1beta1.TaskRun{ //nolint:staticcheck
+			Status: v1beta1.TaskRunStatus{
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					Provenance: &v1beta1.Provenance{
+						RefSource: &v1beta1.RefSource{
+							URI: "git+github.com/something.git",
+							Digest: map[string]string{
+								"sha1": "abcd1234",
+							},
+						},
+					},
+				},
+			},
+		},
+		want: []v1.ResourceDescriptor{
+			{
+				Name: "task",
+				URI:  "git+github.com/something.git",
+				Digest: common.DigestSet{
+					"sha1": "abcd1234",
+				},
+			},
+		},
+	}, {
+		name: "git resolvedDependencies from taskrun params",
+		taskRun: &v1beta1.TaskRun{ //nolint:staticcheck
+			Spec: v1beta1.TaskRunSpec{
+				Params: []v1beta1.Param{{
+					Name:  "CHAINS-GIT_COMMIT",
+					Value: *v1beta1.NewStructuredValues("my-commit"),
+				}, {
+					Name:  "CHAINS-GIT_URL",
+					Value: *v1beta1.NewStructuredValues("github.com/something"),
+				}},
+			},
+		},
+		want: []v1.ResourceDescriptor{
+			{
+				Name: "inputs/result",
+				URI:  "git+github.com/something.git",
+				Digest: common.DigestSet{
+					"sha1": "my-commit",
+				},
+			},
+		},
+	}, {
+		name: "resolvedDependencies from step images",
+		taskRun: &v1beta1.TaskRun{ //nolint:staticcheck
+			Status: v1beta1.TaskRunStatus{
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					Steps: []v1beta1.StepState{{
+						Name:    "git-source-repo-jwqcl",
+						ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
+					}, {
+						Name:    "git-source-repo-repeat-again-jwqcl",
+						ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
+					}, {
+						Name:    "build",
+						ImageID: "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
+					}},
+				},
+			},
+		},
+		want: []v1.ResourceDescriptor{
+			{
+				URI: "oci://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
+				Digest: common.DigestSet{
+					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
+				},
+			},
+			{
+				URI: "oci://gcr.io/cloud-marketplace-containers/google/bazel",
+				Digest: common.DigestSet{
+					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
+				},
+			},
+		},
+	}, {
+		name: "resolvedDependencies from step and sidecar images",
+		taskRun: &v1beta1.TaskRun{ //nolint:staticcheck
+			Status: v1beta1.TaskRunStatus{
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					Steps: []v1beta1.StepState{{
+						Name:    "git-source-repo-jwqcl",
+						ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
+					}, {
+						Name:    "git-source-repo-repeat-again-jwqcl",
+						ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
+					}, {
+						Name:    "build",
+						ImageID: "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
+					}},
+					Sidecars: []v1beta1.SidecarState{{
+						Name:    "sidecar-jwqcl",
+						ImageID: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/sidecar-git-init@sha256:a1234f6e7a69617db57b685893256f978436277094c21d43b153994acd8a09567",
+					}},
+				},
+			},
+		},
+		want: []v1.ResourceDescriptor{
+			{
+				URI: "oci://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
+				Digest: common.DigestSet{
+					"sha256": "b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247",
+				},
+			}, {
+				URI: "oci://gcr.io/cloud-marketplace-containers/google/bazel",
+				Digest: common.DigestSet{
+					"sha256": "010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964",
+				},
+			}, {
+				URI: "oci://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/sidecar-git-init",
+				Digest: common.DigestSet{
+					"sha256": "a1234f6e7a69617db57b685893256f978436277094c21d43b153994acd8a09567",
+				},
+			},
+		},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := logtesting.TestContextWithLogger(t)
+			rd, err := TaskRun(ctx, objects.NewTaskRunObject(tc.taskRun))
+			if err != nil {
+				t.Fatalf("Did not expect an error but got %v", err)
+			}
+			if diff := cmp.Diff(tc.want, rd); diff != "" {
+				t.Errorf("ResolvedDependencies(): -want +got: %s", diff)
+			}
+		})
+	}
+}
+
 func TestPipelineRun(t *testing.T) {
-	expected := []v1.ResourceDescriptor{
-		{Name: "pipeline", URI: "git+https://github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
-		{Name: "pipelineTask", URI: "git+https://github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
+	taskRuns := tektonTaskRuns()
+	tests := []struct {
+		name           string
+		taskDescriptor addTaskDescriptorContent
+		want           []v1slsa.ResourceDescriptor
+	}{
 		{
-			URI:    "oci://gcr.io/test1/test1",
-			Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+			name:           "test slsa build type",
+			taskDescriptor: AddSLSATaskDescriptor,
+			want: []v1slsa.ResourceDescriptor{
+				{Name: "pipeline", URI: "git+https://github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
+				{Name: "pipelineTask", URI: "git+https://github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
+				{
+					URI:    "oci://gcr.io/test1/test1",
+					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+				},
+				{Name: "pipelineTask", URI: "git+https://github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
+				{
+					URI:    "oci://gcr.io/test2/test2",
+					Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+				},
+				{
+					URI:    "oci://gcr.io/test3/test3",
+					Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+				},
+				{Name: "inputs/result", URI: "abc", Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
+				{Name: "inputs/result", URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
+			},
 		},
-		{Name: "pipelineTask", URI: "git+https://github.com/test", Digest: common.DigestSet{"sha1": "ab123"}},
 		{
-			URI:    "oci://gcr.io/test2/test2",
-			Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+			name:           "test tekton build type",
+			taskDescriptor: AddTektonTaskDescriptor,
+			want: []v1slsa.ResourceDescriptor{
+				{Name: "pipeline", URI: "git+https://github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
+				{Name: "pipelineTask", URI: "git+https://github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}, Content: taskRuns["git-clone"]},
+				{
+					URI:    "oci://gcr.io/test1/test1",
+					Digest: common.DigestSet{"sha256": "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"},
+				},
+				{Name: "pipelineTask", URI: "git+https://github.com/test", Digest: common.DigestSet{"sha1": "ab123"}, Content: taskRuns["taskrun-build"]},
+				{
+					URI:    "oci://gcr.io/test2/test2",
+					Digest: common.DigestSet{"sha256": "4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"},
+				},
+				{
+					URI:    "oci://gcr.io/test3/test3",
+					Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
+				},
+				{Name: "inputs/result", URI: "abc", Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
+				{Name: "inputs/result", URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
+			},
 		},
-		{
-			URI:    "oci://gcr.io/test3/test3",
-			Digest: common.DigestSet{"sha256": "f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"},
-		},
-		{Name: "inputs/result", URI: "abc", Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
-		{Name: "inputs/result", URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
 	}
+
 	ctx := logtesting.TestContextWithLogger(t)
-	got, err := PipelineRun(ctx, pro, &slsaconfig.SlsaConfig{DeepInspectionEnabled: false})
-	if err != nil {
-		t.Error(err)
-	}
-	if diff := cmp.Diff(expected, got, compare.SLSAV1CompareOptions()...); diff != "" {
-		t.Errorf("PipelineRunResolvedDependencies(): -want +got: %s", diff)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := PipelineRun(ctx, pro, &slsaconfig.SlsaConfig{DeepInspectionEnabled: false}, tc.taskDescriptor)
+			if err != nil {
+				t.Error(err)
+			}
+			if d := cmp.Diff(tc.want, got); d != "" {
+				t.Errorf("PipelineRunResolvedDependencies(): -want +got: %s", got)
+			}
+		})
 	}
 }
 
 func TestPipelineRunStructuredResult(t *testing.T) {
-	want := []v1.ResourceDescriptor{
+	want := []v1slsa.ResourceDescriptor{
 		{Name: "pipeline", URI: "git+https://github.com/test", Digest: common.DigestSet{"sha1": "28b123"}},
 		{Name: "pipelineTask", URI: "git+https://github.com/catalog", Digest: common.DigestSet{"sha1": "x123"}},
 		{
@@ -539,15 +606,13 @@ func TestPipelineRunStructuredResult(t *testing.T) {
 			},
 		},
 		{
-			Name: "inputs/result",
-			URI:  "git+https://git.test.com.git",
-			Digest: common.DigestSet{
-				"sha1": "abcd",
-			},
+			URI:    "git+https://git.test.com.git",
+			Digest: common.DigestSet{"sha1": "abcd"},
+			Name:   "inputs/result",
 		},
 	}
 	ctx := logtesting.TestContextWithLogger(t)
-	got, err := PipelineRun(ctx, pro, &slsaconfig.SlsaConfig{DeepInspectionEnabled: false})
+	got, err := PipelineRun(ctx, pro, &slsaconfig.SlsaConfig{DeepInspectionEnabled: false}, AddSLSATaskDescriptor)
 	if err != nil {
 		t.Errorf("error while extracting resolvedDependencies: %v", err)
 	}

--- a/pkg/chains/formats/slsa/v2alpha2/slsav2.go
+++ b/pkg/chains/formats/slsa/v2alpha2/slsav2.go
@@ -45,6 +45,7 @@ func NewFormatter(cfg config.Config) (formats.Payloader, error) {
 		slsaConfig: &slsaconfig.SlsaConfig{
 			BuilderID:             cfg.Builder.ID,
 			DeepInspectionEnabled: cfg.Artifacts.PipelineRuns.DeepInspectionEnabled,
+			BuildType:             cfg.BuildDefinition.BuildType,
 		},
 	}, nil
 }

--- a/pkg/chains/objects/objects_test.go
+++ b/pkg/chains/objects/objects_test.go
@@ -367,3 +367,68 @@ func TestPipelineRun_GetTaskRunFromTask(t *testing.T) {
 	tr := pro.GetTaskRunFromTask("foo-task")
 	assert.Equal(t, "foo", tr.Name)
 }
+
+func TestProvenanceExists(t *testing.T) {
+	pro := NewPipelineRunObject(getPipelineRun())
+	provenance := &v1beta1.Provenance{
+		RefSource: &v1beta1.RefSource{
+			URI: "tekton.com",
+		},
+	}
+	pro.Status.Provenance = &v1beta1.Provenance{
+		RefSource: &v1beta1.RefSource{
+			URI: "tekton.com",
+		},
+	}
+	assert.Equal(t, provenance, pro.GetProvenance())
+}
+
+func TestPipelineRunRemoteProvenance(t *testing.T) {
+	pro := NewPipelineRunObject(getPipelineRun())
+	provenance := &v1beta1.Provenance{
+		RefSource: &v1beta1.RefSource{
+			URI: "tekton.com",
+		},
+	}
+	pro.Status.Provenance = &v1beta1.Provenance{
+		RefSource: &v1beta1.RefSource{
+			URI: "tekton.com",
+		},
+	}
+	assert.Equal(t, provenance, pro.GetProvenance())
+}
+
+func TestTaskRunRemoteProvenance(t *testing.T) {
+	tro := NewTaskRunObject(getTaskRun())
+	provenance := &v1beta1.Provenance{
+		RefSource: &v1beta1.RefSource{
+			URI: "tekton.com",
+		},
+	}
+	tro.Status.Provenance = &v1beta1.Provenance{
+		RefSource: &v1beta1.RefSource{
+			URI: "tekton.com",
+		},
+	}
+	assert.Equal(t, provenance, tro.GetProvenance())
+}
+
+func TestPipelineRunIsRemote(t *testing.T) {
+	pro := NewPipelineRunObject(getPipelineRun())
+	pro.Spec.PipelineRef = &v1beta1.PipelineRef{
+		ResolverRef: v1beta1.ResolverRef{
+			Resolver: "Bundle",
+		},
+	}
+	assert.Equal(t, true, pro.IsRemote())
+}
+
+func TestTaskRunIsRemote(t *testing.T) {
+	tro := NewTaskRunObject(getTaskRun())
+	tro.Spec.TaskRef = &v1beta1.TaskRef{
+		ResolverRef: v1beta1.ResolverRef{
+			Resolver: "Bundle",
+		},
+	}
+	assert.Equal(t, true, tro.IsRemote())
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,11 +28,12 @@ import (
 )
 
 type Config struct {
-	Artifacts    ArtifactConfigs
-	Storage      StorageConfigs
-	Signers      SignerConfigs
-	Builder      BuilderConfig
-	Transparency TransparencyConfig
+	Artifacts       ArtifactConfigs
+	Storage         StorageConfigs
+	Signers         SignerConfigs
+	Builder         BuilderConfig
+	Transparency    TransparencyConfig
+	BuildDefinition BuildDefinitionConfig
 }
 
 // ArtifactConfigs contains the configuration for how to sign/store/format the signatures for each artifact type
@@ -68,6 +69,10 @@ type SignerConfigs struct {
 
 type BuilderConfig struct {
 	ID string
+}
+
+type BuildDefinitionConfig struct {
+	BuildType string
 }
 
 type X509Signer struct {
@@ -200,6 +205,9 @@ const (
 	transparencyEnabledKey = "transparency.enabled"
 	transparencyURLKey     = "transparency.url"
 
+	// Build type
+	buildTypeKey = "builddefinition.buildtype"
+
 	ChainsConfig = "chains-config"
 )
 
@@ -244,6 +252,9 @@ func defaultConfig() *Config {
 		},
 		Builder: BuilderConfig{
 			ID: "https://tekton.dev/chains/v2",
+		},
+		BuildDefinition: BuildDefinitionConfig{
+			BuildType: "https://tekton.dev/chains/v2/slsa",
 		},
 	}
 }
@@ -308,6 +319,9 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 
 		// Build config
 		asString(builderIDKey, &cfg.Builder.ID),
+
+		// Build type
+		asString(buildTypeKey, &cfg.BuildDefinition.BuildType, "https://tekton.dev/chains/v2/slsa", "https://tekton.dev/chains/v2/slsa-tekton"),
 	); err != nil {
 		return nil, fmt.Errorf("failed to parse data: %w", err)
 	}

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -125,6 +125,10 @@ var defaultTransparency = TransparencyConfig{
 	URL: "https://rekor.sigstore.dev",
 }
 
+var defaultBuildDefinition = BuildDefinitionConfig{
+	BuildType: "https://tekton.dev/chains/v2/slsa",
+}
+
 func TestParse(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -139,11 +143,12 @@ func TestParse(t *testing.T) {
 			taskrunEnabled: true,
 			ociEnbaled:     true,
 			want: Config{
-				Builder:      defaultBuilder,
-				Artifacts:    defaultArtifacts,
-				Signers:      defaultSigners,
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Builder:         defaultBuilder,
+				Artifacts:       defaultArtifacts,
+				Signers:         defaultSigners,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		}, {
 			name: "builder configuration",
@@ -156,10 +161,11 @@ func TestParse(t *testing.T) {
 				Builder: BuilderConfig{
 					"builder-id-test",
 				},
-				Artifacts:    defaultArtifacts,
-				Signers:      defaultSigners,
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Artifacts:       defaultArtifacts,
+				Signers:         defaultSigners,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		}, {
 			name: "storage configuration",
@@ -177,7 +183,8 @@ func TestParse(t *testing.T) {
 						NoteHint: "a test message",
 					},
 				},
-				Transparency: defaultTransparency,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		},
 		{
@@ -205,9 +212,10 @@ func TestParse(t *testing.T) {
 						Signer:         "x509",
 					},
 				},
-				Signers:      defaultSigners,
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Signers:         defaultSigners,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		},
 		{
@@ -235,9 +243,10 @@ func TestParse(t *testing.T) {
 						Signer:         "x509",
 					},
 				},
-				Signers:      defaultSigners,
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Signers:         defaultSigners,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		},
 		{
@@ -265,9 +274,10 @@ func TestParse(t *testing.T) {
 						Signer:         "x509",
 					},
 				},
-				Signers:      defaultSigners,
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Signers:         defaultSigners,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		},
 		{
@@ -295,9 +305,10 @@ func TestParse(t *testing.T) {
 						Signer:         "x509",
 					},
 				},
-				Signers:      defaultSigners,
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Signers:         defaultSigners,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		},
 		{
@@ -325,9 +336,10 @@ func TestParse(t *testing.T) {
 						Signer:         "x509",
 					},
 				},
-				Signers:      defaultSigners,
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Signers:         defaultSigners,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		},
 		{
@@ -358,9 +370,10 @@ func TestParse(t *testing.T) {
 						Signer:         "x509",
 					},
 				},
-				Signers:      defaultSigners,
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Signers:         defaultSigners,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		},
 		{
@@ -391,9 +404,10 @@ func TestParse(t *testing.T) {
 						Signer:         "x509",
 					},
 				},
-				Signers:      defaultSigners,
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Signers:         defaultSigners,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		},
 		{
@@ -421,9 +435,10 @@ func TestParse(t *testing.T) {
 						Signer:         "x509",
 					},
 				},
-				Signers:      defaultSigners,
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Signers:         defaultSigners,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		},
 		{
@@ -441,6 +456,7 @@ func TestParse(t *testing.T) {
 					VerifyAnnotation: true,
 					URL:              "https://rekor.sigstore.dev",
 				},
+				BuildDefinition: defaultBuildDefinition,
 			},
 		},
 		{
@@ -472,9 +488,10 @@ func TestParse(t *testing.T) {
 						Signer:         "x509",
 					},
 				},
-				Signers:      defaultSigners,
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Signers:         defaultSigners,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		}, {
 			name: "fulcio",
@@ -513,8 +530,9 @@ func TestParse(t *testing.T) {
 						TUFMirrorURL:     "https://tuf-repo-cdn.sigstore.dev",
 					},
 				},
-				Storage:      defaultStorage,
-				Transparency: defaultTransparency,
+				Storage:         defaultStorage,
+				Transparency:    defaultTransparency,
+				BuildDefinition: defaultBuildDefinition,
 			},
 		}, {
 			name: "rekor - true",
@@ -538,6 +556,7 @@ func TestParse(t *testing.T) {
 					Enabled: true,
 					URL:     "https://rekor.sigstore.dev",
 				},
+				BuildDefinition: defaultBuildDefinition,
 			},
 		}, {
 			name: "rekor - manual",
@@ -561,6 +580,24 @@ func TestParse(t *testing.T) {
 					Enabled:          true,
 					VerifyAnnotation: true,
 					URL:              "https://rekor.sigstore.dev",
+				},
+				BuildDefinition: defaultBuildDefinition,
+			},
+		}, {
+			name: "buildDefinition - slsa-tekton",
+			data: map[string]string{
+				"builddefinition.buildtype": "https://tekton.dev/chains/v2/slsa-tekton",
+			},
+			taskrunEnabled: true,
+			ociEnbaled:     true,
+			want: Config{
+				Builder:      defaultBuilder,
+				Artifacts:    defaultArtifacts,
+				Signers:      defaultSigners,
+				Storage:      defaultStorage,
+				Transparency: defaultTransparency,
+				BuildDefinition: BuildDefinitionConfig{
+					BuildType: "https://tekton.dev/chains/v2/slsa-tekton",
 				},
 			},
 		},


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

This change introduces a new buildType for pipelineRun and taskRun attestations that produces more verbose output. The buildType is based off of [this design doc](https://docs.google.com/document/d/1ddt9oKXUrhRdHmibsgmaznNlpoEbVgOvjuL6EeRwaqY/edit?resourcekey=0--sS7uiVoXJQqvv5cbIKkcw)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)

# Release Notes

``` release-note
NONE
```
