### PR TITLE
Deep inspection for materials

### DIFF
--- a/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
@@ -50,7 +50,7 @@ type TaskAttestation struct {
 func GenerateAttestation(ctx context.Context, pro *objects.PipelineRunObject, slsaConfig *slsaconfig.SlsaConfig) (interface{}, error) {
 	subjects := extract.SubjectDigests(ctx, pro, slsaConfig)
 
-	mat, err := material.PipelineMaterials(ctx, pro)
+	mat, err := material.PipelineMaterials(ctx, pro, slsaConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/pipelinerun/pipelinerun.go
@@ -34,7 +34,7 @@ const (
 
 // GenerateAttestation generates a provenance statement with SLSA v1.0 predicate for a pipeline run.
 func GenerateAttestation(ctx context.Context, pro *objects.PipelineRunObject, slsaconfig *slsaconfig.SlsaConfig) (interface{}, error) {
-	rd, err := resolveddependencies.PipelineRun(ctx, pro)
+	rd, err := resolveddependencies.PipelineRun(ctx, pro, slsaconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies/resolved_dependencies_test.go
+++ b/pkg/chains/formats/slsa/v2alpha2/internal/resolved_dependencies/resolved_dependencies_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tektoncd/chains/internal/backport"
 	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/compare"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/internal/objectloader"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -504,7 +505,7 @@ func TestPipelineRun(t *testing.T) {
 		{Name: "inputs/result", URI: "git+https://git.test.com.git", Digest: common.DigestSet{"sha1": "abcd"}},
 	}
 	ctx := logtesting.TestContextWithLogger(t)
-	got, err := PipelineRun(ctx, pro)
+	got, err := PipelineRun(ctx, pro, &slsaconfig.SlsaConfig{DeepInspectionEnabled: false})
 	if err != nil {
 		t.Error(err)
 	}
@@ -532,14 +533,21 @@ func TestPipelineRunStructuredResult(t *testing.T) {
 		},
 		{
 			Name: "inputs/result",
-			URI:  "abcd",
+			URI:  "abc",
 			Digest: common.DigestSet{
 				"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 			},
 		},
+		{
+			Name: "inputs/result",
+			URI:  "git+https://git.test.com.git",
+			Digest: common.DigestSet{
+				"sha1": "abcd",
+			},
+		},
 	}
 	ctx := logtesting.TestContextWithLogger(t)
-	got, err := PipelineRun(ctx, proStructuredResults)
+	got, err := PipelineRun(ctx, pro, &slsaconfig.SlsaConfig{DeepInspectionEnabled: false})
 	if err != nil {
 		t.Errorf("error while extracting resolvedDependencies: %v", err)
 	}


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

/kind feature 

Step 2/2 of https://github.com/tektoncd/chains/issues/850. Step 1 is available [here](https://github.com/tektoncd/chains/pull/866) 

Add deep inspection for materials, which will be applied to both slsa v0.2 and slsa v1.0 provenance.



# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note

Enable deep inspection for materials/resolvedDependencies (check each taskrun params/results besides pipeline params/results for pipeline level provenance)
action required: set flag `artifacts.pipelinerun.enable-deep-inspection` to be true.

```
