### PR TITLE
Fix SPDX format function

### DIFF
--- a/pkg/chains/formats/slsa/attest/attest.go
+++ b/pkg/chains/formats/slsa/attest/attest.go
@@ -116,11 +116,17 @@ func convertConfigSource(source *v1beta1.RefSource) slsa.ConfigSource {
 }
 
 // supports the SPDX format which is recommended by in-toto
-// ref: https://spdx.dev/spdx-specification-21-web-version/#h.49x2ik5
+// ref: https://spdx.github.io/spdx-spec/v2-draft/package-information/#773-examples
 // ref: https://github.com/in-toto/attestation/blob/849867bee97e33678f61cc6bd5da293097f84c25/spec/field_types.md
 func SPDXGit(url, revision string) string {
-	if revision == "" {
-		return artifacts.GitSchemePrefix + url + ".git"
+	if !strings.HasPrefix(url, artifacts.GitSchemePrefix) {
+		url = artifacts.GitSchemePrefix + url
 	}
-	return artifacts.GitSchemePrefix + url + fmt.Sprintf("@%s", revision)
+	if !strings.HasSuffix(url, ".git") {
+		url = url + ".git"
+	}
+	if revision == "" {
+		return url
+	}
+	return url + fmt.Sprintf("@%s", revision)
 }

--- a/pkg/chains/formats/slsa/internal/material/material_test.go
+++ b/pkg/chains/formats/slsa/internal/material/material_test.go
@@ -161,7 +161,7 @@ func TestTaskMaterials(t *testing.T) {
 				},
 			},
 			{
-				URI: artifacts.GitSchemePrefix + "https://github.com/GoogleContainerTools/distroless@my-revision",
+				URI: artifacts.GitSchemePrefix + "https://github.com/GoogleContainerTools/distroless.git@my-revision",
 				Digest: common.DigestSet{
 					"sha1": "50c56a48cfb3a5a80fa36ed91c739bdac8381cbe",
 				},


### PR DESCRIPTION

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

/kind bug

Prior, the function prepends `git+` and appends `.git` regardless of whether the original url has the prefix or suffix already.

Now, it only prepends & appends if they don't exist.


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
# Release Notes

``` release-note
NONE
```
