### PR TITLE
docs: Ensure the storage backend to store OCI signatures is set to oci

### DIFF
--- a/docs/tutorials/signed-provenance-tutorial.md
+++ b/docs/tutorials/signed-provenance-tutorial.md
@@ -57,6 +57,7 @@ You'll need to make these changes to the Tekton Chains Config:
 
 * `artifacts.taskrun.format=slsa/v1`
 * `artifacts.taskrun.storage=oci`
+* `artifacts.oci.storage=oci`
 * `transparency.enabled=true`
 
 You can set these fields by running
@@ -64,6 +65,7 @@ You can set these fields by running
 ```shell
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.taskrun.format": "slsa/v1"}}'
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.taskrun.storage": "oci"}}'
+kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"artifacts.oci.storage": "oci"}}'
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"transparency.enabled": "true"}}'
 ```
 
@@ -124,7 +126,7 @@ You should see verification output for both!
 ## Finding Provenance in Rekor
 
 To find provenance for the image in Rekor, first get the digest of the `$REGISTRY/kaniko-chains` image you just built.
-You can look this up in the TaskRun, or pull the image to get the digest. 
+You can look this up in the TaskRun, or pull the image to get the digest.
 
 You can then search rekor to find all entries that match the sha256 digest of the image you just built with the [rekor-cli](https://github.com/sigstore/rekor/releases/) tool:
 


### PR DESCRIPTION
We need to ensure that the storage backend to store OCI signatures is enabled and is set to `oci`. This is especially true when we come to this tutorial after passing the Getting started one[1]. Otherwise, the command:
   `cosign verify --key cosign.pub $REGISTRY/kaniko-chains`
returns nothing

[1]. https://tekton.dev/docs/chains/getting-started-tutorial/

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
