### PR TITLE
 Make e2e tests faster 

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -37,7 +37,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -248,7 +247,6 @@ func setupSecret(ctx context.Context, t *testing.T, c kubernetes.Interface, opts
 	if _, err := c.CoreV1().Secrets(namespace).Update(ctx, &s, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(time.Minute) // https://github.com/tektoncd/chains/issues/664
 
 	return secret{
 		cosignPriv: cosignPriv,

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -138,7 +138,6 @@ func TestExamples(t *testing.T) {
 			ctx := context.Background()
 			c, ns, cleanup := setup(ctx, t, setupOpts{})
 			t.Cleanup(cleanup)
-
 			cleanUpInTotoFormatter := setConfigMap(ctx, t, c, test.cm)
 			runInTotoFormatterTests(ctx, t, ns, c, test)
 			cleanUpInTotoFormatter()


### PR DESCRIPTION
Instead of waiting for the secrets and configmap to propagate to the pod which could take [~2 mins](https://ahmet.im/blog/kubernetes-secret-volumes-delay/), we restart the pod and force this update since the pod restart takes only a few seconds. This in turn, reduces the time per test from ~1.5 mins down to a few seconds.

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
/kind cleanup
