### PR TITLE
Fixes Hashivault configuration with Chains

### DIFF
--- a/pkg/chains/signing/kms/kms_test.go
+++ b/pkg/chains/signing/kms/kms_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kms creates a signer using a key management server
+
+package kms
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/chains/pkg/config"
+)
+
+func TestInValidVaultAddressTimeout(t *testing.T) {
+	cfg := config.KMSSigner{}
+	cfg.Auth.Address = "http://8.8.8.8:8200"
+
+	_, err := NewSigner(context.TODO(), cfg)
+	expectedErrorMessage := "dial tcp 8.8.8.8:8200: i/o timeout"
+	if err.Error() != expectedErrorMessage {
+		t.Errorf("Expected error message '%s', but got '%s'", expectedErrorMessage, err.Error())
+	}
+}
+
+func TestInValidVaultAddressConnectionRefused(t *testing.T) {
+	cfg := config.KMSSigner{}
+	cfg.Auth.Address = "http://127.0.0.1:8200"
+
+	_, err := NewSigner(context.TODO(), cfg)
+	expectedErrorMessage := "dial tcp 127.0.0.1:8200: connect: connection refused"
+	if err.Error() != expectedErrorMessage {
+		t.Errorf("Expected error message '%s', but got '%s'", expectedErrorMessage, err.Error())
+	}
+}


### PR DESCRIPTION
* Initially when kms was misconfigured, then the chains controller pod was getting panic and ended up getting crashed

* Hence, this patch checks it the vault address is valid and if it is not valid, then returns the error which handles the pod from getting panic and crashed

* Example of Logs of pod getting crashed

```bash=
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1b43574]

goroutine 173 [running]:
github.com/tektoncd/chains/vendor/github.com/jellydator/ttlcache/v3.(*Item[...]).Value(0xc000513a00?)
	github.com/tektoncd/chains/vendor/github.com/jellydator/ttlcache/v3/item.go:110 +0x34
github.com/tektoncd/chains/vendor/github.com/sigstore/sigstore/pkg/signature/kms/hashivault.(*hashivaultClient).public(0xc0003be480)
	github.com/tektoncd/chains/vendor/github.com/sigstore/sigstore/pkg/signature/kms/hashivault/client.go:251 +0xe9
github.com/tektoncd/chains/vendor/github.com/sigstore/sigstore/pkg/signature/kms/hashivault.SignerVerifier.PublicKey(...)
	github.com/tektoncd/chains/vendor/github.com/sigstore/sigstore/pkg/signature/kms/hashivault/signer.go:140
github.com/tektoncd/chains/pkg/chains/signing.Wrap({0x2af1440?, 0xc000578db0?}, {0x37567c8, 0xc001110b90})
	github.com/tektoncd/chains/pkg/chains/signing/wrap.go:32 +0x46
github.com/tektoncd/chains/pkg/chains.(*ObjectSigner).Sign(0xc000d35110, {0x3750aa0, 0xc001032f90}, {0x377ac40, 0xc0010984f8})
	github.com/tektoncd/chains/pkg/chains/signing.go:153 +0x916
github.com/tektoncd/chains/pkg/reconciler/taskrun.(*Reconciler).FinalizeKind(0xc000611f40, {0x3750aa0, 0xc001032f90}, 0xc000af0f00)
	github.com/tektoncd/chains/pkg/reconciler/taskrun/taskrun.go:67 +0x1e2
github.com/tektoncd/chains/pkg/reconciler/taskrun.(*Reconciler).ReconcileKind(0xc000f7ef80?, {0x3750aa0?, 0xc001032f90?}, 0x11?)
	github.com/tektoncd/chains/pkg/reconciler/taskrun/taskrun.go:45 +0x25
github.com/tektoncd/chains/vendor/github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1beta1/taskrun.(*reconcilerImpl).Reconcile(0xc0004c2d20, {0x3750aa0, 0xc001032ed0}, {0xc000632900, 0x28})
	github.com/tektoncd/chains/vendor/github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1beta1/taskrun/reconciler.go:236 +0x582
github.com/tektoncd/chains/vendor/knative.dev/pkg/controller.(*Impl).processNextWorkItem(0xc0002ed9e0)
	github.com/tektoncd/chains/vendor/knative.dev/pkg/controller/controller.go:542 +0x58d
github.com/tektoncd/chains/vendor/knative.dev/pkg/controller.(*Impl).RunContext.func3()
	github.com/tektoncd/chains/vendor/knative.dev/pkg/controller/controller.go:491 +0x68
created by github.com/tektoncd/chains/vendor/knative.dev/pkg/controller.(*Impl).RunContext
	github.com/tektoncd/chains/vendor/knative.dev/pkg/controller/controller.go:489 +0x312
```

Signed-off-by: Puneet Punamiya ppunamiy@redhat.com

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
