### PR TITLE
Fixes value for storage.oci.repository

### DIFF
--- a/pkg/chains/storage/oci/legacy_test.go
+++ b/pkg/chains/storage/oci/legacy_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/chains/pkg/config"
+)
+
+func TestNewRepo(t *testing.T) {
+	t.Run("Use any registry in storage oci repository", func(t *testing.T) {
+		cfg := config.Config{}
+		cfg.Storage.OCI.Repository = "example.com/foo"
+		tests := []struct {
+			imageName        string
+			expectedRepoName string
+		}{
+			{
+				imageName:        "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:bc4f7468f87486e3835b09098c74cd7f54db2cf697cbb9b824271b95a2d0871e",
+				expectedRepoName: "example.com/foo",
+			},
+			{
+				imageName:        "foo.io/bar/kaniko-chains@sha256:bc4f7468f87486e3835b09098c74cd7f54db2cf697cbb9b824271b95a2d0871e",
+				expectedRepoName: "example.com/foo",
+			},
+			{
+				imageName:        "registry.com/spam/spam/spam/spam/spam/spam@sha256:bc4f7468f87486e3835b09098c74cd7f54db2cf697cbb9b824271b95a2d0871e",
+				expectedRepoName: "example.com/foo",
+			},
+		}
+
+		for _, test := range tests {
+			ref, err := name.NewDigest(test.imageName)
+			if err != nil {
+				t.Error(err)
+			}
+			repo, err := newRepo(cfg, ref)
+			if err != nil {
+				t.Error(err)
+			}
+			assert.Equal(t, repo.Name(), test.expectedRepoName)
+		}
+	})
+}


### PR DESCRIPTION
* Previously while providing repo url value for storage oci repository, chains controller was giving an error as
`a digest must contain exactly one '@' separator (e.g. registry/repository@digest)`
because, it was not able to add digest and repo name

* Hence this patch fixes it, by formatting the value provided by the user and thus storing the
attestations/signatures in the provide location

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
