### PR TITLE
Adds initial Attestor implementation.

### DIFF
--- a/pkg/artifacts/signable_test.go
+++ b/pkg/artifacts/signable_test.go
@@ -331,16 +331,19 @@ func TestExtractOCIImagesFromResults(t *testing.T) {
 		},
 	}
 	obj := objects.NewTaskRunObject(tr)
-	want := []interface{}{
+	want := []name.Digest{
 		createDigest(t, fmt.Sprintf("img1@%s", digest1)),
 		createDigest(t, fmt.Sprintf("img2@%s", digest2)),
 		createDigest(t, fmt.Sprintf("img3@%s", digest1)),
 	}
 	ctx := logtesting.TestContextWithLogger(t)
-	got := ExtractOCIImagesFromResults(ctx, obj)
+	got, err := extractOCIImagesFromResults(ctx, obj)
+	if err != nil {
+		t.Fatal(err)
+	}
 	sort.Slice(got, func(i, j int) bool {
-		a := got[i].(name.Digest)
-		b := got[j].(name.Digest)
+		a := got[i]
+		b := got[j]
 		return a.String() < b.String()
 	})
 	if !cmp.Equal(got, want, ignore...) {

--- a/pkg/chains/formats/format.go
+++ b/pkg/chains/formats/format.go
@@ -21,10 +21,19 @@ import (
 )
 
 // Payloader is an interface to generate a chains Payload from a TaskRun
+// Deprecated: Use Formatter instead.
 type Payloader interface {
 	CreatePayload(ctx context.Context, obj interface{}) (interface{}, error)
 	Type() config.PayloadType
 	Wrap() bool
+}
+
+// Formatter transforms an extracted Input artifact into an Output
+// artifact suitable for signing + storage.
+type Formatter[Input any, Output any] interface {
+	// Effectively the same as CreatePayload, but using a different name so that
+	// this interface can coexist with Payloader.
+	FormatPayload(ctx context.Context, in Input) (Output, error)
 }
 
 const (

--- a/pkg/chains/formats/simple/simple.go
+++ b/pkg/chains/formats/simple/simple.go
@@ -15,6 +15,7 @@ package simple
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/sigstore/sigstore/pkg/signature/payload"
@@ -66,6 +67,20 @@ func (i SimpleContainerImage) ImageName() string {
 	return fmt.Sprintf("%s@%s", i.Critical.Identity.DockerReference, i.Critical.Image.DockerManifestDigest)
 }
 
+func (i SimpleContainerImage) MarshalBinary() ([]byte, error) {
+	return json.Marshal(i)
+}
+
 func (i *SimpleSigning) Type() config.PayloadType {
 	return formats.PayloadTypeSimpleSigning
+}
+
+var (
+	_ formats.Formatter[name.Digest, SimpleContainerImage] = &SimpleSigningPayloader{}
+)
+
+type SimpleSigningPayloader SimpleSigning
+
+func (SimpleSigningPayloader) FormatPayload(_ context.Context, v name.Digest) (SimpleContainerImage, error) {
+	return NewSimpleStruct(v), nil
 }

--- a/pkg/chains/formats/slsa/v1/intotoite6.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6.go
@@ -18,8 +18,10 @@ package v1
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
+	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v1/pipelinerun"
@@ -34,21 +36,57 @@ const (
 )
 
 func init() {
-	formats.RegisterPayloader(PayloadTypeInTotoIte6, NewFormatter)
-	formats.RegisterPayloader(PayloadTypeSlsav1, NewFormatter)
+	formats.RegisterPayloader(PayloadTypeInTotoIte6, NewPayloader)
+	formats.RegisterPayloader(PayloadTypeSlsav1, NewPayloader)
 }
 
 type InTotoIte6 struct {
 	slsaConfig *slsaconfig.SlsaConfig
 }
 
-func NewFormatter(cfg config.Config) (formats.Payloader, error) {
+func NewPayloader(cfg config.Config) (formats.Payloader, error) {
+	return NewPayloaderFromConfig(cfg), nil
+}
+
+func NewPayloaderFromConfig(cfg config.Config) *InTotoIte6 {
+	opts := []Option{
+		WithBuilderID(cfg.Builder.ID),
+		WithDeepInspection(cfg.Artifacts.PipelineRuns.DeepInspectionEnabled),
+	}
+	return NewFormatter(opts...)
+}
+
+type options struct {
+	builderID      string
+	deepInspection bool
+}
+
+type Option func(*options)
+
+func WithDeepInspection(enabled bool) Option {
+	return func(o *options) {
+		o.deepInspection = enabled
+	}
+}
+
+func WithBuilderID(id string) Option {
+	return func(o *options) {
+		o.builderID = id
+	}
+}
+
+func NewFormatter(opts ...Option) *InTotoIte6 {
+	o := &options{}
+	for _, f := range opts {
+		f(o)
+	}
+
 	return &InTotoIte6{
 		slsaConfig: &slsaconfig.SlsaConfig{
-			BuilderID:             cfg.Builder.ID,
-			DeepInspectionEnabled: cfg.Artifacts.PipelineRuns.DeepInspectionEnabled,
+			BuilderID:             o.builderID,
+			DeepInspectionEnabled: o.deepInspection,
 		},
-	}, nil
+	}
 }
 
 func (i *InTotoIte6) Wrap() bool {
@@ -66,6 +104,36 @@ func (i *InTotoIte6) CreatePayload(ctx context.Context, obj interface{}) (interf
 	}
 }
 
+func (i *InTotoIte6) FormatPayload(ctx context.Context, obj objects.TektonObject) (*ProvenanceStatement, error) {
+	var (
+		s   *in_toto.ProvenanceStatement
+		err error
+	)
+
+	switch v := obj.(type) {
+	case *objects.TaskRunObject:
+		s, err = taskrun.GenerateAttestation(ctx, v, i.slsaConfig)
+	case *objects.PipelineRunObject:
+		s, err = pipelinerun.GenerateAttestation(ctx, v, i.slsaConfig)
+	default:
+		return nil, fmt.Errorf("intoto does not support type: %s", v)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	// Wrap output in BinaryMarshaller so we know how to format this.
+	out := ProvenanceStatement(*s)
+	return &out, nil
+
+}
+
 func (i *InTotoIte6) Type() config.PayloadType {
 	return formats.PayloadTypeSlsav1
+}
+
+type ProvenanceStatement in_toto.ProvenanceStatement
+
+func (s ProvenanceStatement) MarshalBinary() ([]byte, error) {
+	return json.Marshal(s)
 }

--- a/pkg/chains/formats/slsa/v1/intotoite6_test.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6_test.go
@@ -54,7 +54,7 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 			ID: "test_builder-1",
 		},
 	}
-	expected := in_toto.ProvenanceStatement{
+	expected := &in_toto.ProvenanceStatement{
 		StatementHeader: in_toto.StatementHeader{
 			Type:          in_toto.StatementInTotoV01,
 			PredicateType: slsa.PredicateSLSAProvenance,
@@ -133,7 +133,7 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 			},
 		},
 	}
-	i, _ := NewFormatter(cfg)
+	i, _ := NewPayloader(cfg)
 
 	got, err := i.CreatePayload(ctx, objects.NewTaskRunObject(tr))
 
@@ -158,7 +158,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 			ID: "test_builder-1",
 		},
 	}
-	expected := in_toto.ProvenanceStatement{
+	expected := &in_toto.ProvenanceStatement{
 		StatementHeader: in_toto.StatementHeader{
 			Type:          in_toto.StatementInTotoV01,
 			PredicateType: slsa.PredicateSLSAProvenance,
@@ -359,7 +359,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 	pro.AppendTaskRun(tr1)
 	pro.AppendTaskRun(tr2)
 
-	i, _ := NewFormatter(cfg)
+	i, _ := NewPayloader(cfg)
 
 	got, err := i.CreatePayload(ctx, pro)
 	if err != nil {
@@ -382,7 +382,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 			ID: "test_builder-1",
 		},
 	}
-	expected := in_toto.ProvenanceStatement{
+	expected := &in_toto.ProvenanceStatement{
 		StatementHeader: in_toto.StatementHeader{
 			Type:          in_toto.StatementInTotoV01,
 			PredicateType: slsa.PredicateSLSAProvenance,
@@ -577,7 +577,7 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 	pro.AppendTaskRun(tr1)
 	pro.AppendTaskRun(tr2)
 
-	i, _ := NewFormatter(cfg)
+	i, _ := NewPayloader(cfg)
 	got, err := i.CreatePayload(ctx, pro)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
@@ -600,7 +600,7 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 			ID: "test_builder-2",
 		},
 	}
-	expected := in_toto.ProvenanceStatement{
+	expected := &in_toto.ProvenanceStatement{
 		StatementHeader: in_toto.StatementHeader{
 			Type:          in_toto.StatementInTotoV01,
 			PredicateType: slsa.PredicateSLSAProvenance,
@@ -652,7 +652,7 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 			},
 		},
 	}
-	i, _ := NewFormatter(cfg)
+	i, _ := NewPayloader(cfg)
 	got, err := i.CreatePayload(ctx, objects.NewTaskRunObject(tr))
 
 	if err != nil {
@@ -676,7 +676,7 @@ func TestMultipleSubjects(t *testing.T) {
 			ID: "test_builder-multiple",
 		},
 	}
-	expected := in_toto.ProvenanceStatement{
+	expected := &in_toto.ProvenanceStatement{
 		StatementHeader: in_toto.StatementHeader{
 			Type:          in_toto.StatementInTotoV01,
 			PredicateType: slsa.PredicateSLSAProvenance,
@@ -723,7 +723,7 @@ func TestMultipleSubjects(t *testing.T) {
 		},
 	}
 
-	i, _ := NewFormatter(cfg)
+	i, _ := NewPayloader(cfg)
 	got, err := i.CreatePayload(ctx, objects.NewTaskRunObject(tr))
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
@@ -740,7 +740,7 @@ func TestNewFormatter(t *testing.T) {
 				ID: "testid",
 			},
 		}
-		f, err := NewFormatter(cfg)
+		f, err := NewPayloader(cfg)
 		if f == nil {
 			t.Error("Failed to create formatter")
 		}
@@ -758,7 +758,7 @@ func TestCreatePayloadError(t *testing.T) {
 			ID: "testid",
 		},
 	}
-	f, _ := NewFormatter(cfg)
+	f, _ := NewPayloader(cfg)
 
 	t.Run("Invalid type", func(t *testing.T) {
 		p, err := f.CreatePayload(ctx, "not a task ref")

--- a/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
@@ -47,14 +47,14 @@ type TaskAttestation struct {
 	Results    []v1beta1.TaskRunResult   `json:"results,omitempty"`
 }
 
-func GenerateAttestation(ctx context.Context, pro *objects.PipelineRunObject, slsaConfig *slsaconfig.SlsaConfig) (interface{}, error) {
+func GenerateAttestation(ctx context.Context, pro *objects.PipelineRunObject, slsaConfig *slsaconfig.SlsaConfig) (*intoto.ProvenanceStatement, error) {
 	subjects := extract.SubjectDigests(ctx, pro, slsaConfig)
 
 	mat, err := material.PipelineMaterials(ctx, pro, slsaConfig)
 	if err != nil {
 		return nil, err
 	}
-	att := intoto.ProvenanceStatement{
+	att := &intoto.ProvenanceStatement{
 		StatementHeader: intoto.StatementHeader{
 			Type:          intoto.StatementInTotoV01,
 			PredicateType: slsa.PredicateSLSAProvenance,

--- a/pkg/chains/formats/slsa/v1/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v1/taskrun/taskrun.go
@@ -27,14 +27,14 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
-func GenerateAttestation(ctx context.Context, tro *objects.TaskRunObject, slsaConfig *slsaconfig.SlsaConfig) (interface{}, error) {
+func GenerateAttestation(ctx context.Context, tro *objects.TaskRunObject, slsaConfig *slsaconfig.SlsaConfig) (*intoto.ProvenanceStatement, error) {
 	subjects := extract.SubjectDigests(ctx, tro, slsaConfig)
 
 	mat, err := material.TaskMaterials(ctx, tro)
 	if err != nil {
 		return nil, err
 	}
-	att := intoto.ProvenanceStatement{
+	att := &intoto.ProvenanceStatement{
 		StatementHeader: intoto.StatementHeader{
 			Type:          intoto.StatementInTotoV01,
 			PredicateType: slsa.PredicateSLSAProvenance,

--- a/pkg/chains/internal/attestors/attestor_test.go
+++ b/pkg/chains/internal/attestors/attestor_test.go
@@ -1,0 +1,137 @@
+package attestors
+
+import (
+	"crypto"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/tektoncd/chains/pkg/chains/formats/simple"
+	v1 "github.com/tektoncd/chains/pkg/chains/formats/slsa/v1"
+	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/chains/pkg/chains/signing"
+	"github.com/tektoncd/chains/pkg/chains/signing/x509"
+	"github.com/tektoncd/chains/pkg/chains/storage/oci"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	logtest "knative.dev/pkg/logging/testing"
+)
+
+func TestOCIAttestor(t *testing.T) {
+	digest := setupRegistry(t)
+
+	// Create local signer using randomly generated key.
+	sv := newSignerVerifier(t)
+	signer := &x509.Signer{SignerVerifier: sv}
+
+	storer, err := oci.NewSimpleStorer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	att := &Attestor[name.Digest, simple.SimpleContainerImage]{
+		payloader: simple.SimpleSigningPayloader{},
+		signer:    signer,
+		storer:    storer,
+	}
+	ctx := logtest.TestContextWithLogger(t)
+	if _, err := att.Attest(ctx, nil, digest); err != nil {
+		t.Error(err)
+	}
+
+	// Verify signature to make sure it was pushed properly.
+	if _, _, err := cosign.VerifyImageSignatures(ctx, digest, &cosign.CheckOpts{
+		SigVerifier: sv,
+		IgnoreTlog:  true,
+	}); err != nil {
+		t.Error(err)
+	}
+}
+
+func setupRegistry(t *testing.T) name.Digest {
+	t.Helper()
+
+	reg := httptest.NewServer(registry.New())
+	t.Cleanup(reg.Close)
+
+	// Push an image to the local registry.
+	ref, err := name.ParseReference(fmt.Sprintf("%s/foo", strings.TrimPrefix(reg.URL, "http://")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.Put(ref, empty.Image); err != nil {
+		t.Fatal(err)
+	}
+	h, err := empty.Image.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ref.Context().Digest(h.String())
+}
+
+func newSignerVerifier(t *testing.T) signature.SignerVerifier {
+	t.Helper()
+
+	priv, err := cosign.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("error generating keypair: %v", err)
+	}
+	sv, err := signature.LoadECDSASignerVerifier(priv, crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sv
+}
+
+func TestSLSAAttestor(t *testing.T) {
+	digest := setupRegistry(t)
+
+	// Create local signer using randomly generated key.
+	sv := newSignerVerifier(t)
+	signer := &x509.Signer{SignerVerifier: sv}
+	wrapped, err := signing.Wrap(signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	storer, err := oci.NewAttestationStorer[*v1.ProvenanceStatement]()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := &v1beta1.TaskRun{
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunResults: []v1beta1.TaskRunResult{{
+					Name:  "IMAGES",
+					Value: *v1beta1.NewArrayOrString(digest.String()),
+				}},
+			},
+		},
+	}
+	obj := objects.NewTaskRunObject(tr)
+
+	att := &Attestor[objects.TektonObject, *v1.ProvenanceStatement]{
+		payloader: v1.NewFormatter(),
+		signer:    wrapped,
+		storer:    storer,
+	}
+	ctx := logtest.TestContextWithLogger(t)
+	if _, err := att.Attest(ctx, obj, obj); err != nil {
+		t.Error(err)
+	}
+
+	// Verify attestation to make sure it was stored properly.
+	if _, _, err := cosign.VerifyImageAttestations(ctx, digest, &cosign.CheckOpts{
+		SigVerifier: sv,
+		IgnoreTlog:  true,
+	}); err != nil {
+		t.Error(err)
+	}
+}

--- a/pkg/chains/internal/attestors/attestors.go
+++ b/pkg/chains/internal/attestors/attestors.go
@@ -1,0 +1,117 @@
+package attestors
+
+import (
+	"bytes"
+	"context"
+	"encoding"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/tektoncd/chains/pkg/chains"
+	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/formats/simple"
+	v1 "github.com/tektoncd/chains/pkg/chains/formats/slsa/v1"
+	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/chains/pkg/chains/signing"
+	"github.com/tektoncd/chains/pkg/chains/storage/api"
+	"github.com/tektoncd/chains/pkg/chains/storage/oci"
+	"github.com/tektoncd/chains/pkg/config"
+)
+
+type AttestorHandler[Input any] interface {
+	Attest(context.Context, objects.TektonObject, Input) error
+}
+
+type Attestor[Input any, Output encoding.BinaryMarshaler] struct {
+	payloader formats.Formatter[Input, Output]
+	signer    signing.Signer
+	storer    api.Storer[Input, Output]
+}
+
+// Handler takes an input object -> creates, signs, and stores its attestation.
+func (a *Attestor[Input, Output]) Attest(ctx context.Context, obj objects.TektonObject, in Input) (*api.StoreResponse, error) {
+	out, err := a.payloader.FormatPayload(ctx, in)
+	if err != nil {
+		return nil, fmt.Errorf("error creating attestation payload: %w", err)
+	}
+
+	b, err := out.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling payload: %w", err)
+	}
+
+	sig, err := a.signer.SignMessage(bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("error signing payload: %w", err)
+	}
+	req := &api.StoreRequest[Input, Output]{
+		Object:   obj,
+		Artifact: in,
+		Payload:  out,
+		Bundle: &signing.Bundle{
+			Content:   b,
+			Signature: sig,
+			Cert:      []byte(a.signer.Cert()),
+			Chain:     []byte(a.signer.Chain()),
+		},
+	}
+	return a.storer.Store(ctx, req)
+}
+
+func NewContainerSigner(ctx context.Context, cfg config.Config) (*Attestor[name.Digest, simple.SimpleContainerImage], error) {
+	signer, err := chains.NewSignerFromConfig(ctx, "", cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var opts []oci.Option
+	if repo := cfg.Storage.OCI.Repository; repo != "" {
+		r, err := name.NewRepository(repo)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing OCI repo name: %w", err)
+		}
+		opts = append(opts, oci.WithTargetRepository(r))
+	}
+
+	storer, err := oci.NewSimpleStorer(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Attestor[name.Digest, simple.SimpleContainerImage]{
+		payloader: simple.SimpleSigningPayloader{},
+		signer:    signer,
+		storer:    storer,
+	}, nil
+}
+
+func NewProvenanceSigner(ctx context.Context, cfg config.Config) (*Attestor[objects.TektonObject, *v1.ProvenanceStatement], error) {
+	signer, err := chains.NewSignerFromConfig(ctx, "", cfg)
+	if err != nil {
+		return nil, err
+	}
+	wrapped, err := signing.Wrap(signer)
+	if err != nil {
+		return nil, err
+	}
+
+	var opts []oci.Option
+	if repo := cfg.Storage.OCI.Repository; repo != "" {
+		r, err := name.NewRepository(repo)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing OCI repo name: %w", err)
+		}
+		opts = append(opts, oci.WithTargetRepository(r))
+	}
+	storer, err := oci.NewAttestationStorer[*v1.ProvenanceStatement](opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Attestor[objects.TektonObject, *v1.ProvenanceStatement]{
+		payloader: v1.NewPayloaderFromConfig(cfg),
+		signer:    wrapped,
+		// TODO: add support for other storage options.
+		storer: storer,
+	}, nil
+}

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -46,6 +46,13 @@ type ObjectSigner struct {
 	Pipelineclientset versioned.Interface
 }
 
+func NewSignerFromConfig(ctx context.Context, sp string, cfg config.Config) (signing.Signer, error) {
+	if cfg.Signers.KMS.KMSRef != "" {
+		return kms.NewSigner(ctx, cfg.Signers.KMS)
+	}
+	return x509.NewSigner(ctx, sp, cfg)
+}
+
 func allSigners(ctx context.Context, sp string, cfg config.Config) map[string]signing.Signer {
 	l := logging.FromContext(ctx)
 	all := map[string]signing.Signer{}

--- a/pkg/chains/signing/x509/x509.go
+++ b/pkg/chains/signing/x509/x509.go
@@ -42,6 +42,9 @@ import (
 
 const (
 	defaultOIDCClientID = "sigstore"
+
+	// SecretPath contains the path to the secrets volume that is mounted in.
+	defaultSecretPath = "/etc/signing-secrets"
 )
 
 // Signer exposes methods to sign payloads.
@@ -53,6 +56,9 @@ type Signer struct {
 
 // NewSigner returns a configured Signer
 func NewSigner(ctx context.Context, secretPath string, cfg config.Config) (*Signer, error) {
+	if secretPath == "" {
+		secretPath = defaultSecretPath
+	}
 	x509PrivateKeyPath := filepath.Join(secretPath, "x509.pem")
 	cosignPrivateKeypath := filepath.Join(secretPath, "cosign.key")
 

--- a/pkg/chains/storage/oci/options.go
+++ b/pkg/chains/storage/oci/options.go
@@ -14,41 +14,22 @@
 
 package oci
 
-import "github.com/google/go-containerregistry/pkg/name"
+import (
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
 
 // Option provides a config option compatible with all OCI storers.
-type Option interface {
-	AttestationStorerOption
-	SimpleStorerOption
-}
+type Option func(o *ociOption)
 
-// AttestationStorerOption provides a config option compatible with AttestationStorer.
-type AttestationStorerOption interface {
-	applyAttestationStorer(s *AttestationStorer) error
-}
-
-// SimpleStorerOption provides a config option compatible with SimpleStorer.
-type SimpleStorerOption interface {
-	applySimpleStorer(s *SimpleStorer) error
+type ociOption struct {
+	repo   *name.Repository
+	remote []remote.Option
 }
 
 // WithTargetRepository configures the target repository where objects will be stored.
 func WithTargetRepository(repo name.Repository) Option {
-	return &targetRepoOption{
-		repo: repo,
+	return func(o *ociOption) {
+		o.repo = &repo
 	}
-}
-
-type targetRepoOption struct {
-	repo name.Repository
-}
-
-func (o *targetRepoOption) applyAttestationStorer(s *AttestationStorer) error {
-	s.repo = &o.repo
-	return nil
-}
-
-func (o *targetRepoOption) applySimpleStorer(s *SimpleStorer) error {
-	s.repo = &o.repo
-	return nil
 }


### PR DESCRIPTION


<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

This is the initial implementation of Attestors, which uses generics to link chains components together with strict typing.

To start, this adds Attestor implementations of OCI signing and v1 SLSA attestations. These Attestors are NOT wired up to the controller yet, since they don't yet support the full range of config options (and there's likely a few tweaks we need to make in order to help reuse components like signers between Attestors).

`attestors.go` is the file to pay most attention to in this PR.

Part of #780 

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
