### PR TITLE
Skips the signing of artifacts when valid configuration is not done

### DIFF
--- a/pkg/chains/annotations.go
+++ b/pkg/chains/annotations.go
@@ -68,6 +68,14 @@ func MarkSigned(ctx context.Context, obj objects.TektonObject, ps versioned.Inte
 	return AddAnnotation(ctx, obj, ps, ChainsAnnotation, "true", annotations)
 }
 
+// MarkSkipped marks a Tekton object as skipped because configurations were not set
+func MarkSkipped(ctx context.Context, obj objects.TektonObject, ps versioned.Interface, annotations map[string]string) error {
+	if _, ok := obj.GetAnnotations()[ChainsAnnotation]; ok {
+		return nil
+	}
+	return AddAnnotation(ctx, obj, ps, ChainsAnnotation, "skipped", annotations)
+}
+
 func MarkFailed(ctx context.Context, obj objects.TektonObject, ps versioned.Interface, annotations map[string]string) error {
 	return AddAnnotation(ctx, obj, ps, ChainsAnnotation, "failed", annotations)
 }

--- a/pkg/chains/verifier.go
+++ b/pkg/chains/verifier.go
@@ -57,7 +57,7 @@ func (tv *TaskRunVerifier) VerifyTaskRun(ctx context.Context, tr *v1beta1.TaskRu
 	if err != nil {
 		return err
 	}
-	signers := allSigners(ctx, tv.SecretPath, cfg)
+	signers, _ := allSigners(ctx, tv.SecretPath, cfg)
 
 	for _, signableType := range enabledSignableTypes {
 		if !signableType.Enabled(cfg) {


### PR DESCRIPTION
Before this patch, if proper configurations where not done, chains used to sign the tekton resources with the default configurations which in turn used to create a impression that tekton resources are signed as it used to add the `chains.tekton.dev/signed=true` annotation

Hence, with this patch, if proper configuration is not done (like for e.g. private keys are not stored using cosign or x509) then in that case tekton resources will be skipped from signing, indicating the user to do proper configurations to sign the resources

Fixes: https://github.com/tektoncd/chains/issues/858

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
