### PR TITLE
Adds custom namespace in e2e tests

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -35,6 +35,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -202,7 +203,7 @@ type secret struct {
 
 func setupSecret(ctx context.Context, t *testing.T, c kubernetes.Interface, opts setupOpts) secret {
 	// Only overwrite the secret data if it isn't set.
-	namespace := "tekton-chains"
+	namespace := os.Getenv("namespace")
 	s := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "signing-secrets",

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -64,19 +64,19 @@ function install_chains() {
   ko apply -f config/ || fail_test "Tekton Chains installation failed"
 
   # Wait for pods to be running in the namespaces we are deploying to
-  wait_until_pods_running tekton-chains || fail_test "Tekton Chains did not come up"
+  wait_until_pods_running ${namespace} || fail_test "Tekton Chains did not come up"
 }
 
 function chains_patch_spire() {
-  kubectl patch -n tekton-chains deployment tekton-chains-controller \
+  kubectl patch -n ${namespace} deployment tekton-chains-controller \
     --patch-file "$(dirname $0)/testdata/chains-patch-spire.json"
   # Wait for pods to be running in the namespaces we are deploying to
-  wait_until_pods_running tekton-chains || fail_test "Tekton Chains did not come up after patching"
+  wait_until_pods_running ${namespace} || fail_test "Tekton Chains did not come up after patching"
 }
 
 function dump_logs() {
   echo ">> Tekton Chains Logs"
-  kubectl logs deployment/tekton-chains-controller -n tekton-chains
+  kubectl logs deployment/tekton-chains-controller -n ${namespace}
 }
 
 function spire_apply() {
@@ -108,9 +108,9 @@ function install_spire() {
     -selector k8s_psat:agent_sa:spire-agent \
     -node
   spire_apply \
-    -spiffeID spiffe://example.org/ns/tekton-chains/sa/tekton-chains-controller \
+    -spiffeID spiffe://example.org/ns/${namespace}/sa/tekton-chains-controller \
     -parentID spiffe://example.org/ns/spire/node/example \
-    -selector k8s:ns:tekton-chains \
+    -selector k8s:ns:${namespace} \
     -selector k8s:sa:tekton-chains-controller
 }
 
@@ -159,7 +159,7 @@ EOF
       role_type=jwt \
       user_claim=sub \
       bound_audiences=e2e \
-      bound_subject=spiffe://example.org/ns/tekton-chains/sa/tekton-chains-controller \
+      bound_subject=spiffe://example.org/ns/${namespace}/sa/tekton-chains-controller \
       token_ttl=15m \
       token_policies=spire-transit
   vault_exec read transit/keys/e2e >/dev/null 2>&1 \

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -17,6 +17,9 @@
 # This script calls out to scripts in tektoncd/plumbing to setup a cluster
 # and deploy Tekton Pipelines to it for running integration tests.
 
+export namespace="${NAMESPACE:-tekton-chains}"
+echo "Using namespace: $namespace"
+
 source $(git rev-parse --show-toplevel)/test/e2e-common.sh
 
 # Script entry point.

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -53,11 +53,20 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 )
 
+var namespace string
+
+func init() {
+	namespace = os.Getenv("namespace")
+	if namespace == "" {
+		namespace = "tekton-chains"
+	}
+}
+
 func TestInstall(t *testing.T) {
 	ctx := logtesting.TestContextWithLogger(t)
 	c, _, cleanup := setup(ctx, t, setupOpts{})
 	t.Cleanup(cleanup)
-	dep, err := c.KubeClient.AppsV1().Deployments("tekton-chains").Get(ctx, "tekton-chains-controller", metav1.GetOptions{})
+	dep, err := c.KubeClient.AppsV1().Deployments(namespace).Get(ctx, "tekton-chains-controller", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Error getting chains deployment: %v", err)
 	}


### PR DESCRIPTION
- Previously all namespace was hard coded in e2e tests and also when chains is installed in operator it is not installed in `tekton-chains` ns by default, it is installed in `tekton-pipelines`

- Hence this patch by default uses `tekton-chains` ns in e2e, but if chains is installed in other ns, then we can still run the tests in that particular ns

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
