### PR TITLE
Corrected logic when token file provided

### DIFF
--- a/pkg/chains/signing/x509/x509.go
+++ b/pkg/chains/signing/x509/x509.go
@@ -68,10 +68,14 @@ func NewSigner(ctx context.Context, secretPath string, cfg config.Config) (*Sign
 
 func fulcioSigner(ctx context.Context, cfg config.X509Signer) (*Signer, error) {
 	logger := logging.FromContext(ctx)
-	if !providers.Enabled(ctx) && cfg.IdentityTokenFile != "" {
+
+	providersEnabled := providers.Enabled(ctx)
+
+	if cfg.IdentityTokenFile != "" {
 		FilesystemTokenPath = cfg.IdentityTokenFile
+		providersEnabled = true
 	}
-	if !providers.Enabled(ctx) {
+	if !providersEnabled {
 		return nil, fmt.Errorf("no auth provider for fulcio is enabled")
 	}
 	var tok string

--- a/pkg/chains/signing/x509/x509_test.go
+++ b/pkg/chains/signing/x509/x509_test.go
@@ -52,6 +52,27 @@ MC4CAQAwBQYDK2VwBCIEIGQn0bJwshjwuVdnd/FylMk3Gvb89aGgH49bQpgzCY0n
 // npx jwtgen -a HS256 -s "my-secret" -c "iss=user123" -e 3600
 const token = `eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2Nzc1NjAyMTgsImV4cCI6MTY3NzU2MzgxOCwiaXNzIjoidXNlcjEyMyJ9.c-sDgCyuZA6VaIGl7Y3-9XxttW1PUkBeNBLE9gCKG8s`
 
+func TestCreateSignerFulcioEnabledDefaultTokenFileMissing(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+	d := t.TempDir()
+
+	data := make(map[string]string)
+	data["signers.x509.fulcio.enabled"] = "true"
+	cfg, err := config.NewConfigFromMap(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cfg.Signers.X509.FulcioEnabled {
+		t.Fatal("fulcio is not enabled, expected to be enabled")
+	}
+	_, _ = NewSigner(ctx, d, *cfg)
+	//  With default file not present, expect the list of providers to be empty
+	if providers.Enabled(ctx) {
+		t.Fatal("Expected providers to be false")
+	}
+}
+
 func TestCreateSignerFulcioEnabled(t *testing.T) {
 	ctx := logtesting.TestContextWithLogger(t)
 	d := t.TempDir()


### PR DESCRIPTION
# Changes

Corrects an issue where the value specified by the `signers.x509.identity.token.file` is not observed when the default filepath is present in `/var/run/sigstore/cosign/oidc-token`

Resolves #1051

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Corrects an issue to observe the path provided by the `signers.x509.identity.token.file` property even when the default filepath at `/var/run/sigstore/cosign/oidc-token` is present
```
