### PR TITLE
chore: add aaron-prindle to OWNERS reviewers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
 - wlynch
 
 reviewers:
+- aaron-prindle
 - chitrangpatel
 - lcarva
 - wlynch


### PR DESCRIPTION
This PR adds `aaron-prindle` to the OWNERS reviewers list as discussed in the Chains WG meeting today (2/29/2024)