### PR TITLE
Expose performance options (v0.16)

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -28,7 +28,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         pipelines-release:
-        - v0.41.0
         - v0.44.0
         - v0.46.0
         - v0.47.0

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,27 @@
+# Performance
+
+Tekton Chains exposes a few parameters that can be used to fine tune the controllers execution to
+improve its performance as needed.
+
+The controller accepts the following parameters:
+
+`--threads-per-controller` controls the number of concurrent threads the Chains controller
+processes. The default value is 2.
+
+`--kube-api-burst` controle the maximum burst for throttle. The default value is 10.
+
+`--kube-api-qps` controles the maximum QPS to the server from the client. The default value is 5.
+
+Modify the `Deployment` to use those parameters, for example:
+
+```yaml
+spec:
+    template:
+        spec:
+            containers:
+                - image: gcr.io/tekton-releases/github.com/tektoncd/chains/cmd/controller:v0.20.0
+                  args:
+                    - --threads-per-controller=32
+                    - --kube-api-burst=2
+                    - --kube-api-qps=3
+```


### PR DESCRIPTION
# Changes

This allow admins to specify a few parameters to better suit their use of Chains.

`--threads-per-controller` controls the number of concurrent threads the Chains controller processes. The default value is 2.

`--kube-api-burst` controle the maximum burst for throttle.

`--kube-api-qps` controles the maximum QPS to the server from the client.

The approach taken here is the same one used by the Tekton Pipeline controller for the sake of consistency in the ecosystem.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Expose new performance parameters to control controller's execution. See docs at https://tekton.dev/docs/chains/performance for details.
```
