### PR TITLE
Make chains QPS and Burst configuration consistent

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -53,6 +53,10 @@ func main() {
 		cfg.Burst = rest.DefaultBurst
 	}
 
+	// Multiply by number of controllers
+	cfg.QPS = 2 * cfg.QPS
+	cfg.Burst = 2 * cfg.Burst
+
 	flag.Parse()
 	ctx := injection.WithNamespaceScope(signals.NewContext(), *namespace)
 


### PR DESCRIPTION
Earlier release of chains multiply default cfg by 2. In pipelines also, we do this. Same in Results. This makes chains behaviour consistent with all other controllers.

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
