### PR TITLE
golangci-lint: only flag new issues

### DIFF
--- a/.golang-ci.yaml
+++ b/.golang-ci.yaml
@@ -63,6 +63,8 @@ linters:
 output:
   uniq-by-line: false
 issues:
+  # Only flag new issues
+  new: true
   exclude-rules:
   - path: _test\.go
     linters:


### PR DESCRIPTION


<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Intoto has deprecated the old Subject types in favor of a new library, and this is getting pulled in via recent cosign updates. This is going to be a significant refactor that we'll need to make to chains. This changes the behavior of the lint tool to only flag/block on new issues for now to give us time to work through this.

```
  Error: SA1019: intoto.Subject is deprecated: This implementation of Subject exists for historical compatibility and should not be used. This implementation has been superseded by a ResourceDescriptor struct generated from the Protobuf definition in https://github.com/in-toto/attestation/tree/main/protos/in_toto_attestation/v1. To generate an ITE-6 v1 Statement subject, use the ResourceDescriptor Go APIs provided in https://github.com/in-toto/attestation/tree/main/go/v1.  (staticcheck)
```

https://github.com/tektoncd/chains/actions/runs/8707835742/job/23883780247?pr=1104

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
