### PR TITLE
Configure depguard with "lax" mode

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -42,6 +42,13 @@ linters:
     - unused
     - usestdlibvars
     - whitespace
+linters-settings:
+  depguard:
+    rules:
+      main:
+        list-mode: lax
+        allow:
+          - $gostd
 output:
   uniq-by-line: false
 issues:


### PR DESCRIPTION
# Changes

Configure depguard with "lax" mode. See docs at https://golangci-lint.run/usage/linters/#depguard

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
