### PR TITLE
Fix field names in generated json statement

### DIFF
--- a/test/testdata/slsa/v1/pipeline-output-image.json
+++ b/test/testdata/slsa/v1/pipeline-output-image.json
@@ -1,6 +1,6 @@
 {
-    "type": "https://in-toto.io/Statement/v0.1",
-    "predicate_type": "https://slsa.dev/provenance/v0.2",
+    "_type": "https://in-toto.io/Statement/v0.1",
+    "predicateType": "https://slsa.dev/provenance/v0.2",
     "subject": [
         {
             "name": "gcr.io/foo/bar",

--- a/test/testdata/slsa/v1/task-output-image.json
+++ b/test/testdata/slsa/v1/task-output-image.json
@@ -1,6 +1,6 @@
 {
-    "type": "https://in-toto.io/Statement/v0.1",
-    "predicate_type": "https://slsa.dev/provenance/v0.2",
+    "_type": "https://in-toto.io/Statement/v0.1",
+    "predicateType": "https://slsa.dev/provenance/v0.2",
     "subject": [
         {
             "name": "gcr.io/foo/bar",

--- a/test/testdata/slsa/v2/task-output-image.json
+++ b/test/testdata/slsa/v2/task-output-image.json
@@ -1,6 +1,6 @@
 {
-    "type": "https://in-toto.io/Statement/v0.1",
-    "predicate_type": "https://slsa.dev/provenance/v0.2",
+    "_type": "https://in-toto.io/Statement/v0.1",
+    "predicateType": "https://slsa.dev/provenance/v0.2",
     "subject": [
         {
             "name": "gcr.io/foo/bar",

--- a/test/testdata/slsa/v2alpha3/pipeline-output-image.json
+++ b/test/testdata/slsa/v2alpha3/pipeline-output-image.json
@@ -1,6 +1,6 @@
 {
-    "type": "https://in-toto.io/Statement/v1",
-    "predicate_type": "https://slsa.dev/provenance/v1",
+    "_type": "https://in-toto.io/Statement/v1",
+    "predicateType": "https://slsa.dev/provenance/v1",
     "subject": [
         {
             "name": "gcr.io/foo/bar",

--- a/test/testdata/slsa/v2alpha3/task-output-image.json
+++ b/test/testdata/slsa/v2alpha3/task-output-image.json
@@ -1,6 +1,6 @@
 {
-    "type": "https://in-toto.io/Statement/v1",
-    "predicate_type": "https://slsa.dev/provenance/v1",
+    "_type": "https://in-toto.io/Statement/v1",
+    "predicateType": "https://slsa.dev/provenance/v1",
     "subject": [
         {
             "name": "gcr.io/foo/bar",

--- a/test/testdata/slsa/v2alpha4/pipeline-output-image.json
+++ b/test/testdata/slsa/v2alpha4/pipeline-output-image.json
@@ -1,6 +1,6 @@
 {
-    "type": "https://in-toto.io/Statement/v1",
-    "predicate_type": "https://slsa.dev/provenance/v1",
+    "_type": "https://in-toto.io/Statement/v1",
+    "predicateType": "https://slsa.dev/provenance/v1",
     "subject": [
         {
             "name": "gcr.io/foo/bar",

--- a/test/testdata/slsa/v2alpha4/pipeline-with-object-type-hinting.json
+++ b/test/testdata/slsa/v2alpha4/pipeline-with-object-type-hinting.json
@@ -1,6 +1,6 @@
 {
-    "type": "https://in-toto.io/Statement/v1",
-    "predicate_type": "https://slsa.dev/provenance/v1",
+    "_type": "https://in-toto.io/Statement/v1",
+    "predicateType": "https://slsa.dev/provenance/v1",
     "subject": [
         {
             "name": "gcr.io/foo/img1",

--- a/test/testdata/slsa/v2alpha4/task-output-image.json
+++ b/test/testdata/slsa/v2alpha4/task-output-image.json
@@ -1,6 +1,6 @@
 {
-    "type": "https://in-toto.io/Statement/v1",
-    "predicate_type": "https://slsa.dev/provenance/v1",
+    "_type": "https://in-toto.io/Statement/v1",
+    "predicateType": "https://slsa.dev/provenance/v1",
     "subject": [
         {
             "name": "gcr.io/foo/bar",

--- a/test/testdata/slsa/v2alpha4/task-with-object-type-hinting.json
+++ b/test/testdata/slsa/v2alpha4/task-with-object-type-hinting.json
@@ -1,6 +1,6 @@
 {
-    "type": "https://in-toto.io/Statement/v1",
-    "predicate_type": "https://slsa.dev/provenance/v1",
+    "_type": "https://in-toto.io/Statement/v1",
+    "predicateType": "https://slsa.dev/provenance/v1",
     "subject": [
         {
             "name": "gcr.io/foo/img2",


### PR DESCRIPTION
Fixes: #1128

To keep backwards compatibility with previous struct versions (e.g, github.com/in-toto/in-toto-golang/in_toto) we have to use protojson.Marshal function to transform the struct to its json representation so the tags defined in the intoto.Statement are follow and applied to the resulting string.

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

When getting the payload object we check if it is an instance of proto.Message to use the proper Marshall function.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release
