### PR TITLE
Calculate subjects per formatter

### DIFF
--- a/pkg/chains/formats/format.go
+++ b/pkg/chains/formats/format.go
@@ -25,6 +25,7 @@ type Payloader interface {
 	CreatePayload(ctx context.Context, obj interface{}) (interface{}, error)
 	Type() config.PayloadType
 	Wrap() bool
+	RetrieveAllArtifactURIs(ctx context.Context, obj interface{}) ([]string, error)
 }
 
 const (

--- a/pkg/chains/formats/simple/simple.go
+++ b/pkg/chains/formats/simple/simple.go
@@ -70,6 +70,7 @@ func (i *SimpleSigning) Type() config.PayloadType {
 	return formats.PayloadTypeSimpleSigning
 }
 
-func (i *SimpleSigning) RetrieveAllArtifactURIs(ctx context.Context, obj interface{}) ([]string, error) {
+// RetrieveAllArtifactURIs returns always an error, feature not available for simplesigning formatter.
+func (i *SimpleSigning) RetrieveAllArtifactURIs(_ context.Context, _ interface{}) ([]string, error) {
 	return nil, fmt.Errorf("RetrieveAllArtifactURIs not supported for simeplesining formatter")
 }

--- a/pkg/chains/formats/simple/simple.go
+++ b/pkg/chains/formats/simple/simple.go
@@ -69,3 +69,7 @@ func (i SimpleContainerImage) ImageName() string {
 func (i *SimpleSigning) Type() config.PayloadType {
 	return formats.PayloadTypeSimpleSigning
 }
+
+func (i *SimpleSigning) RetrieveAllArtifactURIs(ctx context.Context, obj interface{}) ([]string, error) {
+	return nil, fmt.Errorf("RetrieveAllArtifactURIs not supported for simeplesining formatter")
+}

--- a/pkg/chains/formats/slsa/v1/intotoite6.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v1/pipelinerun"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v1/taskrun"
@@ -93,4 +94,12 @@ func (i *InTotoIte6) CreatePayload(ctx context.Context, obj interface{}) (interf
 
 func (i *InTotoIte6) Type() config.PayloadType {
 	return formats.PayloadTypeSlsav1
+}
+
+func (i *InTotoIte6) RetrieveAllArtifactURIs(ctx context.Context, obj interface{}) ([]string, error) {
+	tkObj, ok := obj.(objects.TektonObject)
+	if !ok {
+		return nil, fmt.Errorf("intoto does not support type")
+	}
+	return extract.RetrieveAllArtifactURIs(ctx, tkObj, i.slsaConfig.DeepInspectionEnabled), nil
 }

--- a/pkg/chains/formats/slsa/v1/intotoite6.go
+++ b/pkg/chains/formats/slsa/v1/intotoite6.go
@@ -96,6 +96,7 @@ func (i *InTotoIte6) Type() config.PayloadType {
 	return formats.PayloadTypeSlsav1
 }
 
+// RetrieveAllArtifactURIs returns the full URI of all artifacts detected as subjects.
 func (i *InTotoIte6) RetrieveAllArtifactURIs(ctx context.Context, obj interface{}) ([]string, error) {
 	tkObj, ok := obj.(objects.TektonObject)
 	if !ok {

--- a/pkg/chains/formats/slsa/v2alpha3/slsav2.go
+++ b/pkg/chains/formats/slsa/v2alpha3/slsav2.go
@@ -70,6 +70,7 @@ func (s *Slsa) Type() config.PayloadType {
 	return formats.PayloadTypeSlsav2alpha3
 }
 
+// RetrieveAllArtifactURIs returns the full URI of all artifacts detected as subjects.
 func (s *Slsa) RetrieveAllArtifactURIs(ctx context.Context, obj interface{}) ([]string, error) {
 	tkObj, ok := obj.(objects.TektonObject)
 	if !ok {

--- a/pkg/chains/formats/slsa/v2alpha3/slsav2.go
+++ b/pkg/chains/formats/slsa/v2alpha3/slsav2.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha3/internal/pipelinerun"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha3/internal/taskrun"
@@ -67,4 +68,12 @@ func (s *Slsa) CreatePayload(ctx context.Context, obj interface{}) (interface{},
 
 func (s *Slsa) Type() config.PayloadType {
 	return formats.PayloadTypeSlsav2alpha3
+}
+
+func (s *Slsa) RetrieveAllArtifactURIs(ctx context.Context, obj interface{}) ([]string, error) {
+	tkObj, ok := obj.(objects.TektonObject)
+	if !ok {
+		return nil, fmt.Errorf("intoto does not support type")
+	}
+	return extract.RetrieveAllArtifactURIs(ctx, tkObj, s.slsaConfig.DeepInspectionEnabled), nil
 }

--- a/pkg/chains/formats/slsa/v2alpha4/internal/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v2alpha4/internal/pipelinerun/pipelinerun.go
@@ -74,6 +74,7 @@ func byproducts(pro *objects.PipelineRunObjectV1, slsaconfig *slsaconfig.SlsaCon
 	return byProd, nil
 }
 
+// SubjectDigests calculates the subjects associated with the given PipelineRun.
 func SubjectDigests(ctx context.Context, pro *objects.PipelineRunObjectV1, slsaconfig *slsaconfig.SlsaConfig) []*intoto.ResourceDescriptor {
 	subjects := extract.SubjectsFromBuildArtifact(ctx, pro.GetResults())
 

--- a/pkg/chains/formats/slsa/v2alpha4/internal/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v2alpha4/internal/pipelinerun/pipelinerun.go
@@ -47,7 +47,7 @@ func GenerateAttestation(ctx context.Context, pro *objects.PipelineRunObjectV1, 
 		return nil, err
 	}
 
-	sub := subjectDigests(ctx, pro, slsaconfig)
+	sub := SubjectDigests(ctx, pro, slsaconfig)
 
 	return provenance.GetSLSA1Statement(pro, sub, &bd, bp, slsaconfig)
 }
@@ -74,7 +74,7 @@ func byproducts(pro *objects.PipelineRunObjectV1, slsaconfig *slsaconfig.SlsaCon
 	return byProd, nil
 }
 
-func subjectDigests(ctx context.Context, pro *objects.PipelineRunObjectV1, slsaconfig *slsaconfig.SlsaConfig) []*intoto.ResourceDescriptor {
+func SubjectDigests(ctx context.Context, pro *objects.PipelineRunObjectV1, slsaconfig *slsaconfig.SlsaConfig) []*intoto.ResourceDescriptor {
 	subjects := extract.SubjectsFromBuildArtifact(ctx, pro.GetResults())
 
 	if !slsaconfig.DeepInspectionEnabled {

--- a/pkg/chains/formats/slsa/v2alpha4/slsav2.go
+++ b/pkg/chains/formats/slsa/v2alpha4/slsav2.go
@@ -76,6 +76,7 @@ func (s *Slsa) Type() config.PayloadType {
 	return payloadTypeSlsav2alpha4
 }
 
+// RetrieveAllArtifactURIs returns the full URI of all artifacts detected as subjects.
 func (s *Slsa) RetrieveAllArtifactURIs(ctx context.Context, obj interface{}) ([]string, error) {
 	var subjects []*intoto.ResourceDescriptor
 	var fullURIs []string

--- a/pkg/chains/formats/slsa/v2alpha4/slsav2.go
+++ b/pkg/chains/formats/slsa/v2alpha4/slsav2.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	intoto "github.com/in-toto/attestation/go/v1"
 	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/v2alpha4/internal/pipelinerun"
@@ -73,4 +74,25 @@ func (s *Slsa) CreatePayload(ctx context.Context, obj interface{}) (interface{},
 // Type returns the version of this payloader.
 func (s *Slsa) Type() config.PayloadType {
 	return payloadTypeSlsav2alpha4
+}
+
+func (s *Slsa) RetrieveAllArtifactURIs(ctx context.Context, obj interface{}) ([]string, error) {
+	var subjects []*intoto.ResourceDescriptor
+	var fullURIs []string
+
+	switch v := obj.(type) {
+	case *objects.TaskRunObjectV1:
+		subjects = taskrun.SubjectDigests(ctx, v)
+	case *objects.PipelineRunObjectV1:
+		subjects = pipelinerun.SubjectDigests(ctx, v, s.slsaConfig)
+	default:
+		return nil, fmt.Errorf("intoto does not support type: %s", v)
+	}
+
+	for _, s := range subjects {
+		for algo, digest := range s.Digest {
+			fullURIs = append(fullURIs, fmt.Sprintf("%s@%s:%s", s.Name, algo, digest))
+		}
+	}
+	return fullURIs, nil
 }


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

Fixes: #1133

# Changes
The way v2alpha3 and v2alpha4 calculate the subjects are different; calling `extract.RetrieveAllArtifactURIs` to generate the subjects is wrong if using v2alpha4. This PR add a new method to the payload formatter that returns the subjects according to the logic of each version. It also changes grafeas backend to generate the subject through the payloader and not calling the `extract.RetrieveAllArtifactURIs` directly.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release