### PR TITLE
fix e2e

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -18,11 +18,10 @@ jobs:
       matrix:
         # Keep in sync with the list of supported releases: https://kubernetes.io/releases/
         k8s-version:
-        - v1.25.x
-        - v1.26.x
         - v1.27.x
-        # Needs https://github.com/sigstore/scaffolding/pull/756
-        # - v1.28.x
+        - v1.28.x
+        - v1.29.x
+        - v1.30.x
     uses: ./.github/workflows/reusable-e2e.yaml
     with:
       k8s-version: ${{ matrix.k8s-version }}
@@ -38,5 +37,5 @@ jobs:
         - v0.51.0
     uses: ./.github/workflows/reusable-e2e.yaml
     with:
-      k8s-version: v1.26.x
+      k8s-version: v1.27.x
       pipelines-release: ${{ matrix.pipelines-release }}

--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -27,7 +27,7 @@ jobs:
       GOFLAGS: -ldflags=-s -ldflags=-w
       KO_DOCKER_REPO: registry.local:5000/knative
       KOCACHE: ~/ko
-      SIGSTORE_SCAFFOLDING_RELEASE_VERSION: "v0.6.6"
+      SIGSTORE_SCAFFOLDING_RELEASE_VERSION: "v0.7.2"
       TEKTON_PIPELINES_RELEASE: "https://storage.googleapis.com/tekton-releases/pipeline/previous/${{ inputs.pipelines-release }}/release.yaml"
       # Note that we do not include the v prefix here so we can use it in all
       # the places this is used.


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
- Update SIGSTORE_SCAFFOLDING_RELEASE_VERSION to v0.7.2
- Update k8s matrix version for e2e, min version now for tests is 1.27

I opened an issue on the scaffloading repo to ask for new tag version with a fix that supports k8s 1.26
https://github.com/sigstore/scaffolding/issues/1145


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
