### PR TITLE
Support multinamespace informer filtering

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -4,9 +4,7 @@ linkTitle: "Chains Configuration"
 weight: 20
 ---
 -->
-
 # Chains Configuration
-
 `Chains` works by observing `TaskRun` and `PipelineRun` executions, capturing relevant information, and storing it in a cryptographically-signed format.
 
 `TaskRuns` and `PipelineRuns` can indicate inputs and outputs which are then captured and surfaced in the `Chains` payload formats, where relevant.
@@ -159,3 +157,16 @@ chains.tekton.dev/transparency-upload: "true"
 
 > [!IMPORTANT]
 > To project the latest token values without needing to recreate the pod, avoid using `subPath` in volume mount.
+
+## Namespaces Restrictions in Chains Controller
+This feature allows you to specify a list of namespaces for the controller to monitor, providing granular control over its operation. If no namespaces are specified, the controller defaults to monitoring all namespaces.
+
+### Usage
+To restrict the Chains Controller to specific namespaces, pass a comma-separated list of namespaces as an argument to the controller using the --namespace flag.
+
+### Example
+To restrict the controller to the dev and test namespaces, you would start the controller with the following argument:
+```shell
+--namespace=dev,test
+```
+In this example, the controller will only monitor resources (pipelinesruns and taskruns) within the dev and test namespaces.

--- a/pkg/reconciler/filter.go
+++ b/pkg/reconciler/filter.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"knative.dev/pkg/controller"
+)
+
+// PipelineRunInformerFilterFunc returns a filter function
+// for PipelineRuns ensuring PipelineRuns are filtered by list of namespaces membership
+func PipelineRunInformerFilterFunc(namespaces []string) func(obj interface{}) bool {
+	return func(obj interface{}) bool {
+		// Namespace filter
+		if len(namespaces) == 0 {
+			return true
+		}
+		if pr, ok := obj.(*v1.PipelineRun); ok {
+			for _, ns := range namespaces {
+				if pr.Namespace == ns {
+					return true
+				}
+			}
+		}
+		return false
+	}
+}
+
+// TaskRunInformerFilterFunc returns a filter function
+// for TaskRuns ensuring TaskRuns are filtered by list of namespaces membership
+func TaskRunInformerFilterFunc(namespaces []string) func(obj interface{}) bool {
+	return func(obj interface{}) bool {
+		// Namespace filter
+		if len(namespaces) == 0 {
+			return true
+		}
+		if tr, ok := obj.(*v1.TaskRun); ok {
+			for _, ns := range namespaces {
+				if tr.Namespace == ns {
+					return true
+				}
+			}
+		}
+		return false
+	}
+}
+
+// TaskRunInformerFilterFuncWithOwnership returns a filter function
+// for TaskRuns ensuring Ownership by a PipelineRun and filtered by list of namespaces membership and
+func TaskRunInformerFilterFuncWithOwnership(namespaces []string) func(obj interface{}) bool {
+	return func(obj interface{}) bool {
+		// Ownership filter
+		if !controller.FilterController(&v1.PipelineRun{})(obj) {
+			return false
+		}
+		// Namespace filter
+		if len(namespaces) == 0 {
+			return true
+		}
+		if tr, ok := obj.(*v1.TaskRun); ok {
+			for _, ns := range namespaces {
+				if tr.Namespace == ns {
+					return true
+				}
+			}
+		}
+		return false
+	}
+}

--- a/pkg/reconciler/filter_test.go
+++ b/pkg/reconciler/filter_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package reconciler
+
+import (
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestPipelineRunInformerFilterFunc tests the PipelineRunInformerFilterFunc
+func TestPipelineRunInformerFilterFunc(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespaces []string
+		obj        interface{}
+		expected   bool
+	}{
+		{
+			name:       "Empty namespaces, should match",
+			namespaces: []string{},
+			obj:        &v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected:   true,
+		},
+		{
+			name:       "Matching namespace",
+			namespaces: []string{"default", "test"},
+			obj:        &v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected:   true,
+		},
+		{
+			name:       "Non-matching namespace",
+			namespaces: []string{"test"},
+			obj:        &v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected:   false,
+		},
+		{
+			name:       "Non PipelineRun object",
+			namespaces: []string{"default"},
+			obj:        &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filterFunc := PipelineRunInformerFilterFunc(tt.namespaces)
+			result := filterFunc(tt.obj)
+			if result != tt.expected {
+				t.Errorf("Reconciler.PipelineRunInformerFilterFunc() result = %v, wanted %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestTaskRunInformerFilterFunc tests the TaskRunInformerFilterFunc
+func TestTaskRunInformerFilterFunc(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespaces []string
+		obj        interface{}
+		expected   bool
+	}{
+		{
+			name:       "Matching namespace",
+			namespaces: []string{"default", "test"},
+			obj:        &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected:   true,
+		},
+		{
+			name:       "Empty namespaces, should match",
+			namespaces: []string{},
+			obj:        &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected:   true,
+		},
+		{
+			name:       "Non-matching namespace",
+			namespaces: []string{"test"},
+			obj:        &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected:   false,
+		},
+		{
+			name:       "Non TaskRun object",
+			namespaces: []string{"default"},
+			obj:        &v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filterFunc := TaskRunInformerFilterFunc(tt.namespaces)
+			result := filterFunc(tt.obj)
+			if result != tt.expected {
+				t.Errorf("Reconciler.TaskRunInformerFilterFunc() result = %v, wanted %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestTaskRunInformerFilterFuncWithOwnership tests the TaskRunInformerFilterFuncWithOwnership
+func TestTaskRunInformerFilterFuncWithOwnership(t *testing.T) {
+	boolValue := true
+	tests := []struct {
+		name       string
+		namespaces []string
+		obj        interface{}
+		expected   bool
+	}{
+		{
+			name:       "Empty namespaces and ownership, should match",
+			namespaces: []string{},
+			obj: &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: "tekton.dev/v1", Kind: "PipelineRun", Controller: &boolValue},
+				},
+			}},
+			expected: true,
+		},
+		{
+			name:       "Matching namespace and ownership",
+			namespaces: []string{"default", "test"},
+			obj: &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: "tekton.dev/v1", Kind: "PipelineRun", Controller: &boolValue},
+				},
+			}},
+			expected: true,
+		},
+		{
+			name:       "Non-matching namespace and ownership",
+			namespaces: []string{"test"},
+			obj: &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: "tekton.dev/v1", Kind: "PipelineRun", Controller: &boolValue},
+				},
+			}},
+			expected: false,
+		},
+		{
+			name:       "No ownership",
+			namespaces: []string{"default"},
+			obj:        &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filterFunc := TaskRunInformerFilterFuncWithOwnership(tt.namespaces)
+			result := filterFunc(tt.obj)
+			if result != tt.expected {
+				t.Errorf("Reconciler.TaskRunInformerFilterFuncWithOwnership() result = %v, wanted %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -78,7 +78,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 					Name:      config.ChainsConfig,
 				},
 			})
-			ctl := NewController(ctx, configMapWatcher)
+			namespacedScopedController := NewNamespacesScopedController(nil)
+			ctl := namespacedScopedController(ctx, configMapWatcher)
 
 			if la, ok := ctl.Reconciler.(pkgreconciler.LeaderAware); ok {
 				if err := la.Promote(pkgreconciler.UniversalBucket(), func(pkgreconciler.Bucket, types.NamespacedName) {}); err != nil {

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -19,10 +19,12 @@ import (
 	"github.com/tektoncd/chains/pkg/chains"
 	"github.com/tektoncd/chains/pkg/chains/storage"
 	"github.com/tektoncd/chains/pkg/config"
+	"github.com/tektoncd/chains/pkg/reconciler"
 	"github.com/tektoncd/chains/pkg/taskrunmetrics"
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1/taskrun"
 	taskrunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/taskrun"
+	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -31,63 +33,70 @@ import (
 	_ "github.com/tektoncd/chains/pkg/chains/formats/all"
 )
 
-func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	logger := logging.FromContext(ctx)
-	taskRunInformer := taskruninformer.Get(ctx)
+// NewNamespacesScopedController returns a new controller implementation where informer is filtered
+// given a list of namespaces
+func NewNamespacesScopedController(namespaces []string) func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+		logger := logging.FromContext(ctx)
+		taskRunInformer := taskruninformer.Get(ctx)
 
-	kubeClient := kubeclient.Get(ctx)
-	pipelineClient := pipelineclient.Get(ctx)
+		kubeClient := kubeclient.Get(ctx)
+		pipelineClient := pipelineclient.Get(ctx)
 
-	tsSigner := &chains.ObjectSigner{
-		SecretPath:        SecretPath,
-		Pipelineclientset: pipelineClient,
-		Recorder:          taskrunmetrics.Get(ctx),
-	}
+		tsSigner := &chains.ObjectSigner{
+			SecretPath:        SecretPath,
+			Pipelineclientset: pipelineClient,
+			Recorder:          taskrunmetrics.Get(ctx),
+		}
 
-	c := &Reconciler{
-		TaskRunSigner:     tsSigner,
-		Pipelineclientset: pipelineClient,
-	}
-	impl := taskrunreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
-		watcherStop := make(chan bool)
+		c := &Reconciler{
+			TaskRunSigner:     tsSigner,
+			Pipelineclientset: pipelineClient,
+		}
+		impl := taskrunreconciler.NewImpl(ctx, c, func(_ *controller.Impl) controller.Options {
+			watcherStop := make(chan bool)
 
-		cfgStore := config.NewConfigStore(logger, func(name string, value interface{}) {
-			select {
-			case watcherStop <- true:
-				logger.Info("sent close event to WatchBackends()...")
-			default:
-				logger.Info("could not send close event to WatchBackends()...")
-			}
+			cfgStore := config.NewConfigStore(logger, func(_ string, value interface{}) {
+				select {
+				case watcherStop <- true:
+					logger.Info("sent close event to WatchBackends()...")
+				default:
+					logger.Info("could not send close event to WatchBackends()...")
+				}
 
-			// get updated config
-			cfg := *value.(*config.Config)
+				// get updated config
+				cfg := *value.(*config.Config)
 
-			// get all backends for storing provenance
-			backends, err := storage.InitializeBackends(ctx, pipelineClient, kubeClient, cfg)
-			if err != nil {
-				logger.Error(err)
-			}
-			tsSigner.Backends = backends
+				// get all backends for storing provenance
+				backends, err := storage.InitializeBackends(ctx, pipelineClient, kubeClient, cfg)
+				if err != nil {
+					logger.Error(err)
+				}
+				tsSigner.Backends = backends
 
-			if err := storage.WatchBackends(ctx, watcherStop, tsSigner.Backends, cfg); err != nil {
-				logger.Error(err)
+				if err := storage.WatchBackends(ctx, watcherStop, tsSigner.Backends, cfg); err != nil {
+					logger.Error(err)
+				}
+			})
+
+			// setup watches for the config names provided by client
+			cfgStore.WatchConfigs(cmw)
+
+			return controller.Options{
+				// The chains reconciler shouldn't mutate the taskrun's status.
+				SkipStatusUpdates: true,
+				ConfigStore:       cfgStore,
+				FinalizerName:     "chains.tekton.dev",
 			}
 		})
 
-		// setup watches for the config names provided by client
-		cfgStore.WatchConfigs(cmw)
-
-		return controller.Options{
-			// The chains reconciler shouldn't mutate the taskrun's status.
-			SkipStatusUpdates: true,
-			ConfigStore:       cfgStore,
-			FinalizerName:     "chains.tekton.dev",
+		if _, err := taskRunInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+			FilterFunc: reconciler.TaskRunInformerFilterFunc(namespaces),
+			Handler:    controller.HandleAll(impl.Enqueue),
+		}); err != nil {
+			logger.Errorf("adding event handler for taskrun controller's taskrun informer encountered error: %v", err)
 		}
-	})
 
-	if _, err := taskRunInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue)); err != nil {
-		logger.Errorf("adding event handler for taskrun controller's taskrun informer encountered error: %w", err)
+		return impl
 	}
-
-	return impl
 }

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -75,7 +75,9 @@ func TestReconciler_Reconcile(t *testing.T) {
 					Name:      config.ChainsConfig,
 				},
 			})
-			ctl := NewController(ctx, configMapWatcher)
+
+			namespacedScopedController := NewNamespacesScopedController(nil)
+			ctl := namespacedScopedController(ctx, configMapWatcher)
 
 			if la, ok := ctl.Reconciler.(pkgreconciler.LeaderAware); ok {
 				if err := la.Promote(pkgreconciler.UniversalBucket(), func(pkgreconciler.Bucket, types.NamespacedName) {}); err != nil {


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
Support of specifying a list of namespaces to restrict the informer. You can provide a list of namespaces as an argument to the controller, and it will only watch objects (PipelineRuns and TaskRuns) within these specified namespaces. If no list is provided, the controller will default to watching all namespaces.


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
The Chains controller now supports specifying a list of namespaces to restrict the informer. 
You can provide a list of namespaces as an argument to the controller, and it will only watch objects (PipelineRuns and TaskRuns) within these specified namespaces. 
If no list is provided, the controller will default to watching all namespaces.

```
