### PR TITLE
Read KMS Auth token from filepath

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -147,7 +147,15 @@ chains.tekton.dev/transparency-upload: "true"
 | :-------------------------------- | :------------------------------------------------------------------------------------------ | :--------------- | :------ |
 | `signers.kms.auth.address`        | URI of KMS server (e.g. the value of `VAULT_ADDR`)                                          |                  |
 | `signers.kms.auth.token`          | Auth token KMS server (e.g. the value of `VAULT_TOKEN`)                                     |                  |
+| `signers.kms.auth.token-dir`      | Path to store KMS server Auth token (e.g. `/etc/kms-secrets`)                               |                  |
 | `signers.kms.auth.oidc.path`      | Path used for OIDC authentication (e.g. `jwt` for Vault)                                    |                  |
 | `signers.kms.auth.oidc.role`      | Role used for OIDC authentication                                                           |                  |
 | `signers.kms.auth.spire.sock`     | URI of the Spire socket used for KMS token (e.g. `unix:///tmp/spire-agent/public/api.sock`) |                  |
 | `signers.kms.auth.spire.audience` | Audience for requesting a SVID from Spire                                                   |                  |
+> NOTE:
+>
+> If `signers.kms.auth.token-dir` is set, create a secret with the key `KMS_AUTH_TOKEN` and ensure the Chains deployment mounts this secret to 
+> the path specified by `signers.kms.auth.token-dir`. 
+
+> [!IMPORTANT]
+> To project the latest token values without needing to recreate the pod, avoid using `subPath` in volume mount.

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -73,6 +73,9 @@ For Azure, this should have the structure of `azurekms://[VAULT_NAME][VAULT_URL]
 ### Authentication
 
 Most likely, you will need to set up some additional authentication so that the `chains-controller` deployment has access to your KMS service for signing.
+
+For Vault, if you use Token-based authentication, store the token as a secret with the key name `KMS_AUTH_TOKEN`. Mount this secret to a specific path within the tekton-chains-controller container. Specify the mounted path as the value for the `chains-config` config map key `signers.kms.auth.token-dir`. This approach can also be applied to other KMS providers that support token-based authentication. Note that the existing configuration option `signers.kms.auth.token` will still work. If both values are set, `signers.kms.auth.token-dir` will take precedence.
+
 For GCP/GKE, we suggest enabling [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity), and giving your service account `Cloud KMS Admin` permissions.
 Other Service Account techniques would work as well.
 

--- a/pkg/chains/storage/docdb/docdb_test.go
+++ b/pkg/chains/storage/docdb/docdb_test.go
@@ -380,8 +380,6 @@ func TestWatchBackend(t *testing.T) {
 			// Let's wait for the event to be read by fsnotify
 			time.Sleep(500 * time.Millisecond)
 
-			// Empty the channel now
-			<-backendChan
 			currentEnv = os.Getenv("MONGO_SERVER_URL")
 			if currentEnv != testEnv {
 				t.Errorf("expected MONGO_SERVER_URL: %s, but got %s", testEnv, currentEnv)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,10 +91,11 @@ type KMSSigner struct {
 
 // KMSAuth configures authentication to the KMS server
 type KMSAuth struct {
-	Address string
-	Token   string
-	OIDC    KMSAuthOIDC
-	Spire   KMSAuthSpire
+	Address  string
+	Token    string
+	TokenDir string
+	OIDC     KMSAuthOIDC
+	Spire    KMSAuthSpire
 }
 
 // KMSAuthOIDC configures settings to authenticate with OIDC
@@ -192,6 +193,7 @@ const (
 	kmsAuthAddress       = "signers.kms.auth.address"
 	kmsAuthToken         = "signers.kms.auth.token"
 	kmsAuthOIDCPath      = "signers.kms.auth.oidc.path"
+	kmsAuthTokenDir      = "signers.kms.auth.token-dir" // #nosec G101
 	kmsAuthOIDCRole      = "signers.kms.auth.oidc.role"
 	kmsAuthSpireSock     = "signers.kms.auth.spire.sock"
 	kmsAuthSpireAudience = "signers.kms.auth.spire.audience"
@@ -311,6 +313,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		asString(kmsSignerKMSRef, &cfg.Signers.KMS.KMSRef),
 		asString(kmsAuthAddress, &cfg.Signers.KMS.Auth.Address),
 		asString(kmsAuthToken, &cfg.Signers.KMS.Auth.Token),
+		asString(kmsAuthTokenDir, &cfg.Signers.KMS.Auth.TokenDir),
 		asString(kmsAuthOIDCPath, &cfg.Signers.KMS.Auth.OIDC.Path),
 		asString(kmsAuthOIDCRole, &cfg.Signers.KMS.Auth.OIDC.Role),
 		asString(kmsAuthSpireSock, &cfg.Signers.KMS.Auth.Spire.Sock),


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Support for retrieving KMS provider Auth token from mount path configured with the new key `signers.kms.auth.token-dir` in configMap chains-config.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Chains now supports extracting the KMS provider auth token (e.g., `VAULT_TOKEN`) from a specified filepath. 
Instead of using the configMap key `signers.kms.auth.token`, you can now use `signers.kms.auth.token-dir` pointing to a valid filepath within the container (e.g., `/etc/kms-secrets`).

### Steps to Utilize This Feature:
- Create a secret with the key name `KMS_AUTH_TOKEN`.
- Update the Chains deployment specification to volume mount this secret. 

**Note:** To project the latest token values without needing to recreate the pod, avoid using `subPath`.
```
