### PR TITLE
fix pipelunerun provenance when multiple tasks have the same name (ca…

### DIFF
--- a/pkg/chains/formats/slsa/internal/material/v1beta1/material.go
+++ b/pkg/chains/formats/slsa/internal/material/v1beta1/material.go
@@ -77,33 +77,38 @@ func PipelineMaterials(ctx context.Context, pro *objects.PipelineRunObjectV1Beta
 		pipelineTasks := pSpec.Tasks
 		pipelineTasks = append(pipelineTasks, pSpec.Finally...)
 		for _, t := range pipelineTasks {
-			tr := pro.GetTaskRunFromTask(t.Name)
-			// Ignore Tasks that did not execute during the PipelineRun.
-			if tr == nil || tr.Status.CompletionTime == nil {
-				logger.Infof("taskrun status not found for task %s", t.Name)
+			taskRuns := pro.GetTaskRunsFromTask(t.Name)
+			if len(taskRuns) == 0 {
+				logger.Infof("no taskruns found for task %s", t.Name)
 				continue
 			}
-
-			stepMaterials, err := FromStepImages(tr)
-			if err != nil {
-				return mats, err
-			}
-			mats = artifact.AppendMaterials(mats, stepMaterials...)
-
-			// add sidecar images
-			sidecarMaterials, err := FromSidecarImages(tr)
-			if err != nil {
-				return nil, err
-			}
-			mats = artifact.AppendMaterials(mats, sidecarMaterials...)
-
-			// add remote task configsource information in materials
-			if tr.Status.Provenance != nil && tr.Status.Provenance.RefSource != nil {
-				m := common.ProvenanceMaterial{
-					URI:    tr.Status.Provenance.RefSource.URI,
-					Digest: tr.Status.Provenance.RefSource.Digest,
+			for _, tr := range taskRuns {
+				// Ignore Tasks that did not execute during the PipelineRun.
+				if tr == nil || tr.Status.CompletionTime == nil {
+					logger.Infof("taskrun status not found for task %s", t.Name)
+					continue
 				}
-				mats = artifact.AppendMaterials(mats, m)
+				stepMaterials, err := FromStepImages(tr)
+				if err != nil {
+					return mats, err
+				}
+				mats = artifact.AppendMaterials(mats, stepMaterials...)
+
+				// add sidecar images
+				sidecarMaterials, err := FromSidecarImages(tr)
+				if err != nil {
+					return nil, err
+				}
+				mats = artifact.AppendMaterials(mats, sidecarMaterials...)
+
+				// add remote task configsource information in materials
+				if tr.Status.Provenance != nil && tr.Status.Provenance.RefSource != nil {
+					m := common.ProvenanceMaterial{
+						URI:    tr.Status.Provenance.RefSource.URI,
+						Digest: tr.Status.Provenance.RefSource.Digest,
+					}
+					mats = artifact.AppendMaterials(mats, m)
+				}
 			}
 		}
 	}
@@ -273,14 +278,20 @@ func FromPipelineParamsAndResults(ctx context.Context, pro *objects.PipelineRunO
 			pipelineTasks := pSpec.Tasks
 			pipelineTasks = append(pipelineTasks, pSpec.Finally...)
 			for _, t := range pipelineTasks {
-				tr := pro.GetTaskRunFromTask(t.Name)
-				// Ignore Tasks that did not execute during the PipelineRun.
-				if tr == nil || tr.Status.CompletionTime == nil {
-					logger.Infof("taskrun is not found or not completed for the task %s", t.Name)
+				taskRuns := pro.GetTaskRunsFromTask(t.Name)
+				if len(taskRuns) == 0 {
+					logger.Infof("no taskruns found for task %s", t.Name)
 					continue
 				}
-				materialsFromTasks := FromTaskParamsAndResults(ctx, tr)
-				mats = artifact.AppendMaterials(mats, materialsFromTasks...)
+				for _, tr := range taskRuns {
+					// Ignore Tasks that did not execute during the PipelineRun.
+					if tr == nil || tr.Status.CompletionTime == nil {
+						logger.Infof("taskrun is not found or not completed for the task %s", t.Name)
+						continue
+					}
+					materialsFromTasks := FromTaskParamsAndResults(ctx, tr)
+					mats = artifact.AppendMaterials(mats, materialsFromTasks...)
+				}
 			}
 		}
 

--- a/pkg/chains/formats/slsa/testdata/pipeline-v1beta1/pipelinerun-childrefs.json
+++ b/pkg/chains/formats/slsa/testdata/pipeline-v1beta1/pipelinerun-childrefs.json
@@ -121,7 +121,7 @@
             {
                 "apiVersion": "tekton.dev/v1beta1",
                 "kind": "TaskRun",
-                "name": "taskrun-build",
+                "name": "taskrun-build-0",
                 "pipelineTaskName": "build"
             }
         ]

--- a/pkg/chains/formats/slsa/testdata/pipeline-v1beta1/pipelinerun1.json
+++ b/pkg/chains/formats/slsa/testdata/pipeline-v1beta1/pipelinerun1.json
@@ -210,7 +210,89 @@
                   }
                 }
               },
-            "taskrun-build": {
+            "taskrun-build-0": {
+                "pipelineTaskName": "build",
+                "status": {
+                    "completionTime": "2021-03-29T09:50:15Z",
+                    "conditions": [
+                        {
+                            "lastTransitionTime": "2021-03-29T09:50:15Z",
+                            "message": "All Steps have completed executing",
+                            "reason": "Succeeded",
+                            "status": "True",
+                            "type": "Succeeded"
+                        }
+                    ],
+                    "podName": "build-pod",
+                    "startTime": "2021-03-29T09:50:00Z",
+                    "steps": [
+                        {
+                            "container": "step-build",
+                            "imageID": "test.io/test/build-image",
+                            "name": "build",
+                            "terminated": {
+                                "exitCode": 0,
+                                "finishedAt": "2022-05-31T19:17:30Z",
+                                "reason": "Completed",
+                                "startedAt": "2021-03-29T09:50:00Z"
+                            }
+                        }
+                    ],
+                    "taskResults": [
+                        {
+                            "name": "IMAGE_DIGEST",
+                            "value": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+                        },
+                        {
+                            "name": "IMAGE_URL",
+                            "value": "test.io/test/image\n"
+                        }
+                    ],
+                    "taskSpec": {
+                        "params": [
+                            {
+                                "description": "Git CHAINS URL",
+                                "name": "CHAINS-GIT_URL",
+                                "type": "string"
+                            },
+                            {
+                                "description": "Git CHAINS Commit",
+                                "name": "CHAINS-GIT_COMMIT",
+                                "type": "string"
+                            }
+                        ],
+                        "results": [
+                            {
+                                "description": "Digest of the image just built.",
+                                "name": "IMAGE_DIGEST"
+                            },
+                            {
+                                "description": "URL of the image just built.",
+                                "name": "IMAGE_URL"
+                            }
+                        ],
+                        "steps": [
+                            {
+                                "command": [
+                                    "buildah",
+                                    "build"
+                                ],
+                                "image": "test.io/test/build-image",
+                                "name": "generate"
+                            },
+                            {
+                                "command": [
+                                    "buildah",
+                                    "push"
+                                ],
+                                "image": "test.io/test/build-image",
+                                "name": "push"
+                            }
+                        ]
+                    }
+                }
+            },
+            "taskrun-build-1": {
                 "pipelineTaskName": "build",
                 "status": {
                     "completionTime": "2021-03-29T09:50:15Z",

--- a/pkg/chains/formats/slsa/testdata/pipeline-v1beta1/taskrun3.json
+++ b/pkg/chains/formats/slsa/testdata/pipeline-v1beta1/taskrun3.json
@@ -1,6 +1,6 @@
 {
     "metadata": {
-        "name": "taskrun-build-0",
+        "name": "taskrun-build-1",
         "labels": {
             "tekton.dev/pipelineTask": "build"
         }
@@ -43,17 +43,17 @@
             {
                 "name": "step1",
                 "container": "step-step1",
-                "imageID": "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+                "imageID": "docker-pullable://gcr.io/test4/test4@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
             },
             {
                 "name": "step2",
                 "container": "step-step2",
-                "imageID": "docker-pullable://gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"
+                "imageID": "docker-pullable://gcr.io/test5/test5@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"
             },
             {
                 "name": "step3",
                 "container": "step-step3",
-                "imageID": "docker-pullable://gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"
+                "imageID": "docker-pullable://gcr.io/test6/test6@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"
             }
         ],
         "taskResults": [

--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -315,14 +315,15 @@ func (pro *PipelineRunObjectV1) GetTaskRuns() []*v1.TaskRun {
 }
 
 // Get the associated TaskRun via the Task name
-func (pro *PipelineRunObjectV1) GetTaskRunFromTask(taskName string) *TaskRunObjectV1 {
+func (pro *PipelineRunObjectV1) GetTaskRunsFromTask(taskName string) []*TaskRunObjectV1 {
+	var taskRuns []*TaskRunObjectV1
 	for _, tr := range pro.taskRuns {
 		val, ok := tr.Labels[PipelineTaskLabel]
 		if ok && val == taskName {
-			return NewTaskRunObjectV1(tr)
+			taskRuns = append(taskRuns, NewTaskRunObjectV1(tr))
 		}
 	}
-	return nil
+	return taskRuns
 }
 
 // Get the imgPullSecrets from the pod template
@@ -388,13 +389,17 @@ func (pro *PipelineRunObjectV1) GetExecutedTasks() (tro []*TaskRunObjectV1) {
 	tasks := pSpec.Tasks
 	tasks = append(tasks, pSpec.Finally...)
 	for _, task := range tasks {
-		tr := pro.GetTaskRunFromTask(task.Name)
-
-		if tr == nil || tr.Status.CompletionTime == nil {
+		taskRuns := pro.GetTaskRunsFromTask(task.Name)
+		if len(taskRuns) == 0 {
 			continue
 		}
+		for _, tr := range taskRuns {
+			if tr == nil || tr.Status.CompletionTime == nil {
+				continue
+			}
 
-		tro = append(tro, tr)
+			tro = append(tro, tr)
+		}
 	}
 
 	return
@@ -514,14 +519,15 @@ func (pro *PipelineRunObjectV1Beta1) AppendTaskRun(tr *v1beta1.TaskRun) { //noli
 }
 
 // Get the associated TaskRun via the Task name
-func (pro *PipelineRunObjectV1Beta1) GetTaskRunFromTask(taskName string) *TaskRunObjectV1Beta1 {
+func (pro *PipelineRunObjectV1Beta1) GetTaskRunsFromTask(taskName string) []*TaskRunObjectV1Beta1 {
+	var taskRuns []*TaskRunObjectV1Beta1
 	for _, tr := range pro.taskRuns {
 		val, ok := tr.Labels[PipelineTaskLabel]
 		if ok && val == taskName {
-			return NewTaskRunObjectV1Beta1(tr)
+			taskRuns = append(taskRuns, NewTaskRunObjectV1Beta1(tr))
 		}
 	}
-	return nil
+	return taskRuns
 }
 
 // Get the imgPullSecrets from the pod template

--- a/pkg/chains/objects/objects_test.go
+++ b/pkg/chains/objects/objects_test.go
@@ -358,16 +358,17 @@ func TestNewTektonObject(t *testing.T) {
 	assert.ErrorContains(t, err, "unrecognized type")
 }
 
-func TestPipelineRun_GetTaskRunFromTask(t *testing.T) {
+func TestPipelineRun_GetTaskRunsFromTask(t *testing.T) {
 	pro := NewPipelineRunObjectV1(getPipelineRun())
 
-	assert.Nil(t, pro.GetTaskRunFromTask("missing"))
-	assert.Nil(t, pro.GetTaskRunFromTask("foo-task"))
+	assert.Nil(t, pro.GetTaskRunsFromTask("missing"))
+	assert.Nil(t, pro.GetTaskRunsFromTask("foo-task"))
 
 	pro.AppendTaskRun(getTaskRun())
-	assert.Nil(t, pro.GetTaskRunFromTask("missing"))
-	tr := pro.GetTaskRunFromTask("foo-task")
-	assert.Equal(t, "foo", tr.Name)
+	assert.Nil(t, pro.GetTaskRunsFromTask("missing"))
+	taskRuns := pro.GetTaskRunsFromTask("foo-task")
+	assert.NotEmpty(t, taskRuns)
+	assert.Equal(t, "foo", taskRuns[0].Name)
 }
 
 func TestProvenanceExists(t *testing.T) {


### PR DESCRIPTION
…se of use of matrix to fan out tasks on a pipeline)

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
Chains only generates provenance attestations for the first image in a matrix of TaskRuns, while all images are signed. The issue is rooted in the assumption that PipelineTaskRuns have unique names within a Pipeline, which isn't true when a matrix is used. The PR aims to address this by ensuring that provenance attestations are generated for all images in the matrix.

- Updated the provenance generation logic to handle multiple TaskRuns with the same task name.
- Ensured that provenance attestations are created for all images referenced in matrixed TaskRuns. 

fixes https://github.com/tektoncd/chains/issues/1164
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
