### PR TITLE
fix mapping between Status.Steps and Status.TaskSpec.Steps

### DIFF
--- a/pkg/chains/formats/slsa/testdata/pipeline-v1beta1/taskrun4.json
+++ b/pkg/chains/formats/slsa/testdata/pipeline-v1beta1/taskrun4.json
@@ -1,0 +1,136 @@
+{
+    "metadata": {
+        "name": "mismatch Status.Step.Name and Status.TaskSpec.Step.Name",
+        "labels": {
+            "tekton.dev/pipelineTask": "build"
+        }
+    },
+    "spec": {
+        "params": [
+            {
+                "name": "IMAGE",
+                "value": "test.io/test/image"
+            },
+            {
+                "name": "CHAINS-GIT_COMMIT",
+                "value": "sha:taskrun"
+            },
+            {
+                "name": "CHAINS-GIT_URL",
+                "value": "https://git.test.com"
+            }
+        ],
+        "taskRef": {
+            "name": "build",
+            "kind": "Task"
+        },
+        "serviceAccountName": "default"
+    },
+    "status": {
+        "startTime": "2021-03-29T09:50:00Z",
+        "completionTime": "2021-03-29T09:50:15Z",
+        "conditions": [
+            {
+                "type": "Succeeded",
+                "status": "True",
+                "lastTransitionTime": "2021-03-29T09:50:15Z",
+                "reason": "Succeeded",
+                "message": "All Steps have completed executing"
+            }
+        ],
+        "podName": "test-pod-name",
+        "steps": [
+            {
+                "name": "unnamed-",
+                "container": "step-step1",
+                "imageID": "docker-pullable://gcr.io/test7/test7@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+            },
+            {
+                "name": "step2",
+                "container": "step-step2",
+                "imageID": "docker-pullable://gcr.io/test8/test8@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"
+            },
+            {
+                "name": "step3",
+                "container": "step-step3",
+                "imageID": "docker-pullable://gcr.io/test9/test9@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"
+            }
+        ],
+        "taskResults": [
+            {
+                "name": "IMAGE_DIGEST",
+                "value": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+            },
+            {
+                "name": "IMAGE_URL",
+                "value": "gcr.io/my/image"
+            }
+        ],
+        "taskSpec": {
+            "params": [
+                {
+                    "name": "IMAGE",
+                    "type": "string"
+                },
+                {
+                    "name": "filename",
+                    "type": "string"
+                },
+                {
+                    "name": "DOCKERFILE",
+                    "type": "string"
+                },
+                {
+                    "name": "CONTEXT",
+                    "type": "string"
+                },
+                {
+                    "name": "EXTRA_ARGS",
+                    "type": "string"
+                },
+                {
+                    "name": "BUILDER_IMAGE",
+                    "type": "string"
+                }, {
+                    "name": "CHAINS-GIT_COMMIT",
+                    "type": "string",
+                    "default": "sha:task"
+                }, {
+                    "name": "CHAINS-GIT_URL",
+                    "type": "string",
+                    "default": "https://defaultgit.test.com"
+                }
+            ],
+            "steps": [
+                {
+                    "name": "step1"
+                },
+                {
+                    "name": "step2"
+                },
+                {
+                    "name": "step3"
+                }
+            ],
+            "results": [
+                {
+                    "name": "IMAGE_DIGEST",
+                    "description": "Digest of the image just built."
+                },
+                {
+                    "name": "filename_DIGEST",
+                    "description": "Digest of the file just built."
+                }
+            ]
+        },
+      "provenance": {
+          "refSource": {
+            "uri": "github.com/test",
+            "digest": {
+              "sha1": "ab123"
+            },
+            "entryPoint": "build.yaml"
+          }
+        }
+    }
+}

--- a/pkg/chains/formats/slsa/testdata/pipeline-v1beta1/taskrun5.json
+++ b/pkg/chains/formats/slsa/testdata/pipeline-v1beta1/taskrun5.json
@@ -1,0 +1,141 @@
+{
+    "metadata": {
+        "name": "mismatch size between Status.Steps and Status.TaskSpec.Steps",
+        "labels": {
+            "tekton.dev/pipelineTask": "build"
+        }
+    },
+    "spec": {
+        "params": [
+            {
+                "name": "IMAGE",
+                "value": "test.io/test/image"
+            },
+            {
+                "name": "CHAINS-GIT_COMMIT",
+                "value": "sha:taskrun"
+            },
+            {
+                "name": "CHAINS-GIT_URL",
+                "value": "https://git.test.com"
+            }
+        ],
+        "taskRef": {
+            "name": "build",
+            "kind": "Task"
+        },
+        "serviceAccountName": "default"
+    },
+    "status": {
+        "startTime": "2021-03-29T09:50:00Z",
+        "completionTime": "2021-03-29T09:50:15Z",
+        "conditions": [
+            {
+                "type": "Succeeded",
+                "status": "True",
+                "lastTransitionTime": "2021-03-29T09:50:15Z",
+                "reason": "Succeeded",
+                "message": "All Steps have completed executing"
+            }
+        ],
+        "podName": "test-pod-name",
+        "steps": [
+            {
+                "name": "step1",
+                "container": "step-step1",
+                "imageID": "docker-pullable://gcr.io/test10/test10@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+            },
+            {
+                "name": "step2",
+                "container": "step-step2",
+                "imageID": "docker-pullable://gcr.io/test11/test11@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac"
+            },
+            {
+                "name": "step3",
+                "container": "step-step3",
+                "imageID": "docker-pullable://gcr.io/test12/test12@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"
+            },
+            {
+                "name": "step4",
+                "container": "step-step3",
+                "imageID": "docker-pullable://gcr.io/test13/test13@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478"
+            }
+        ],
+        "taskResults": [
+            {
+                "name": "IMAGE_DIGEST",
+                "value": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+            },
+            {
+                "name": "IMAGE_URL",
+                "value": "gcr.io/my/image"
+            }
+        ],
+        "taskSpec": {
+            "params": [
+                {
+                    "name": "IMAGE",
+                    "type": "string"
+                },
+                {
+                    "name": "filename",
+                    "type": "string"
+                },
+                {
+                    "name": "DOCKERFILE",
+                    "type": "string"
+                },
+                {
+                    "name": "CONTEXT",
+                    "type": "string"
+                },
+                {
+                    "name": "EXTRA_ARGS",
+                    "type": "string"
+                },
+                {
+                    "name": "BUILDER_IMAGE",
+                    "type": "string"
+                }, {
+                    "name": "CHAINS-GIT_COMMIT",
+                    "type": "string",
+                    "default": "sha:task"
+                }, {
+                    "name": "CHAINS-GIT_URL",
+                    "type": "string",
+                    "default": "https://defaultgit.test.com"
+                }
+            ],
+            "steps": [
+                {
+                    "name": "step1"
+                },
+                {
+                    "name": "step2"
+                },
+                {
+                    "name": "step3"
+                }
+            ],
+            "results": [
+                {
+                    "name": "IMAGE_DIGEST",
+                    "description": "Digest of the image just built."
+                },
+                {
+                    "name": "filename_DIGEST",
+                    "description": "Digest of the file just built."
+                }
+            ]
+        },
+      "provenance": {
+          "refSource": {
+            "uri": "github.com/test",
+            "digest": {
+              "sha1": "ab123"
+            },
+            "entryPoint": "build.yaml"
+          }
+        }
+    }
+}

--- a/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/provenance_test.go
@@ -90,6 +90,7 @@ func TestInvocation(t *testing.T) {
 }
 
 func TestBuildConfig(t *testing.T) {
+	//nolint:dupl
 	expected := BuildConfig{
 		Tasks: []TaskAttestation{
 			{
@@ -296,6 +297,230 @@ func TestBuildConfig(t *testing.T) {
 		},
 	}
 	ctx := logtesting.TestContextWithLogger(t)
+	got := buildConfig(ctx, pro)
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("buildConfig(): -want +got: %s", diff)
+	}
+}
+
+func TestBuildConfigMismatchStatusStepsAndTaskSpec(t *testing.T) {
+	//nolint:dupl
+	expected := BuildConfig{
+		Tasks: []TaskAttestation{
+			{
+				Name:  "git-clone",
+				After: nil,
+				Ref: v1beta1.TaskRef{
+					Name: "git-clone",
+					Kind: "ClusterTask",
+				},
+				ServiceAccountName: "pipeline",
+				StartedOn:          e1BuildStart,
+				FinishedOn:         e1BuildFinished,
+				Status:             "Succeeded",
+				Steps: []attest.StepAttestation{
+					{
+						EntryPoint: "git clone",
+						Arguments:  []string(nil),
+						Environment: map[string]interface{}{
+							"container": "step1",
+							"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+						},
+						Annotations: nil,
+					},
+				},
+				Invocation: slsa.ProvenanceInvocation{
+					ConfigSource: slsa.ConfigSource{
+						URI:        "github.com/catalog",
+						Digest:     common.DigestSet{"sha1": "x123"},
+						EntryPoint: "git-clone.yaml",
+					},
+					Parameters: map[string]v1beta1.ParamValue{
+						"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskdefault"},
+						"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
+						"revision":          {Type: "string", StringVal: ""},
+						"url":               {Type: "string", StringVal: "https://git.test.com"},
+					},
+					Environment: map[string]map[string]string{
+						"labels": {"tekton.dev/pipelineTask": "git-clone"},
+					},
+				},
+				Results: []v1beta1.TaskRunResult{
+					{
+						Name: "some-uri_DIGEST",
+						Value: v1beta1.ParamValue{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+						},
+					},
+					{
+						Name: "some-uri",
+						Value: v1beta1.ParamValue{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "pkg:deb/debian/curl@7.50.3-1",
+						},
+					},
+				},
+			},
+			//nolint:dupl
+			{
+				Name:  "build",
+				After: []string{"git-clone"},
+				Ref: v1beta1.TaskRef{
+					Name: "build",
+					Kind: "ClusterTask",
+				},
+				StartedOn:          e1BuildStart,
+				FinishedOn:         e1BuildFinished,
+				ServiceAccountName: "pipeline",
+				Status:             "Succeeded",
+				Steps: []attest.StepAttestation{
+					{
+						EntryPoint: "",
+						Arguments:  []string(nil),
+						Environment: map[string]interface{}{
+							"image":     artifacts.OCIScheme + "gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+							"container": "step1",
+						},
+						Annotations: nil,
+					},
+					{
+						EntryPoint: "",
+						Arguments:  []string(nil),
+						Environment: map[string]interface{}{
+							"image":     artifacts.OCIScheme + "gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
+							"container": "step2",
+						},
+						Annotations: nil,
+					},
+					{
+						EntryPoint: "",
+						Arguments:  []string(nil),
+						Environment: map[string]interface{}{
+							"image":     artifacts.OCIScheme + "gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
+							"container": "step3",
+						},
+						Annotations: nil,
+					},
+				},
+				Invocation: slsa.ProvenanceInvocation{
+					ConfigSource: slsa.ConfigSource{
+						URI:        "github.com/test",
+						Digest:     map[string]string{"sha1": "ab123"},
+						EntryPoint: "build.yaml",
+					},
+					Parameters: map[string]v1beta1.ParamValue{
+						"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
+						"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
+						"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
+					},
+					Environment: map[string]map[string]string{
+						"labels": {"tekton.dev/pipelineTask": "build"},
+					},
+				},
+				Results: []v1beta1.TaskRunResult{
+					{
+						Name: "IMAGE_DIGEST",
+						Value: v1beta1.ParamValue{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+						},
+					},
+					{
+						Name: "IMAGE_URL",
+						Value: v1beta1.ParamValue{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "gcr.io/my/image",
+						},
+					},
+				},
+			},
+			//nolint:dupl
+			{
+				Name:  "build",
+				After: []string{"git-clone"},
+				Ref: v1beta1.TaskRef{
+					Name: "build",
+					Kind: "ClusterTask",
+				},
+				StartedOn:          e1BuildStart,
+				FinishedOn:         e1BuildFinished,
+				ServiceAccountName: "pipeline",
+				Status:             "Succeeded",
+				Steps: []attest.StepAttestation{
+					{
+						EntryPoint: "",
+						Arguments:  []string(nil),
+						Environment: map[string]interface{}{
+							"image":     artifacts.OCIScheme + "gcr.io/test4/test4@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+							"container": "step1",
+						},
+						Annotations: nil,
+					},
+					{
+						EntryPoint: "",
+						Arguments:  []string(nil),
+						Environment: map[string]interface{}{
+							"image":     artifacts.OCIScheme + "gcr.io/test5/test5@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
+							"container": "step2",
+						},
+						Annotations: nil,
+					},
+					{
+						EntryPoint: "",
+						Arguments:  []string(nil),
+						Environment: map[string]interface{}{
+							"image":     artifacts.OCIScheme + "gcr.io/test6/test6@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
+							"container": "step3",
+						},
+						Annotations: nil,
+					},
+				},
+				Invocation: slsa.ProvenanceInvocation{
+					ConfigSource: slsa.ConfigSource{
+						URI:        "github.com/test",
+						Digest:     map[string]string{"sha1": "ab123"},
+						EntryPoint: "build.yaml",
+					},
+					Parameters: map[string]v1beta1.ParamValue{
+						"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "sha:taskrun"},
+						"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
+						"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
+					},
+					Environment: map[string]map[string]string{
+						"labels": {"tekton.dev/pipelineTask": "build"},
+					},
+				},
+				Results: []v1beta1.TaskRunResult{
+					{
+						Name: "IMAGE_DIGEST",
+						Value: v1beta1.ParamValue{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+						},
+					},
+					{
+						Name: "IMAGE_URL",
+						Value: v1beta1.ParamValue{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "gcr.io/my/image",
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := logtesting.TestContextWithLogger(t)
+	tr4, err := objectloader.TaskRunV1Beta1FromFile("../../testdata/pipeline-v1beta1/taskrun4.json")
+	if err != nil {
+		panic(err)
+	}
+	tr5, err := objectloader.TaskRunV1Beta1FromFile("../../testdata/pipeline-v1beta1/taskrun5.json")
+	if err != nil {
+		panic(err)
+	}
+	pro.AppendTaskRun(tr4)
+	pro.AppendTaskRun(tr5)
 	got := buildConfig(ctx, pro)
 	if diff := cmp.Diff(expected, got); diff != "" {
 		t.Errorf("buildConfig(): -want +got: %s", diff)


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
this PR fixes the mapping between tr.Status.Steps and tr.Status.taskSpec.steps in this way:
- they should have the same size in the last 15 versions at least of pipelines
- if size are different, we fail altogether and do not try to sign anything
- if size are the same, we validate that if a step is name unamed-…, it has an empty name in the other list, if doesnt we fail
fixes https://github.com/tektoncd/chains/issues/1185
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
