### PR TITLE
Update base image used in ko build

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,4 @@
+---
+# The default base image, cgr.dev/chainguard/static, no longer provides all the platforms the Chains
+# controller claims support for.
+defaultBaseImage: ghcr.io/wolfi-dev/static:alpine


### PR DESCRIPTION
The default base image, cgr.dev/chainguard/static, no longer provides all the platforms the Chains controller claims support for.

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Use `ghcr.io/wolfi-dev/static:alpine` as the base image for the controller. This restores the platforms supported by the Chains controller: `linux/amd64`, `linux/arm64`, `linux/ppc64le`, `linux/s390x`.
```
