### PR TITLE
Disable linter for dependabot PRs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,11 @@ permissions:
   pull-requests: read
 jobs:
   golangci:
+    # Because this repository uses vendored dependencies, and grouping for dependabot updates, the
+    # PRs created by dependabot are huge. This causes issues for the linter:
+    #   https://github.com/golangci/golangci-lint-action/issues/996
+    # The chances of dependabot creating new linting issues are minimal.
+    if: github.actor != 'dependabot[bot]'
     name: lint
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

Because this repository uses vendored dependencies, and grouping for dependabot updates, the PRs created by dependabot are huge. This causes issues for the linter:
    https://github.com/golangci/golangci-lint-action/issues/996
The chances of dependabot creating new linting issues are minimal.

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
