### PR TITLE
Update base image used in ko build (#1205)

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,4 @@
+---
+# The default base image, cgr.dev/chainguard/static, no longer provides all the platforms the Chains
+# controller claims support for.
+defaultBaseImage: ghcr.io/wolfi-dev/static:alpine


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

The default base image, cgr.dev/chainguard/static, no longer provides all the platforms the Chains controller claims support for.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Fix missing platforms in controller image
```
