### PR TITLE
Fix the repo for remote resolution

### DIFF
--- a/release/release-pipeline.yaml
+++ b/release/release-pipeline.yaml
@@ -169,7 +169,7 @@ spec:
       resolver: git
       params:
         - name: repo
-          value: pipeline
+          value: chains
         - name: org
           value: tektoncd
         - name: revision


### PR DESCRIPTION
# Changes

The repo for remote resolution of the publish task in the release pipeline points to "pipeline" instead of "chains". Fix that.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```

/kind misc