### PR TITLE
fix nil pointer dereference when taksrun is canceled

### DIFF
--- a/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/slsa/v1/pipelinerun/pipelinerun.go
@@ -119,7 +119,7 @@ func buildConfig(ctx context.Context, pro *objects.PipelineRunObjectV1Beta1) Bui
 
 			steps := []attest.StepAttestation{}
 			// tr.Status.TaskSpec.Steps and tr.Status.Steps should be sime size
-			if len(tr.Status.TaskSpec.Steps) != len(tr.Status.Steps) {
+			if tr.Status.TaskSpec == nil || len(tr.Status.TaskSpec.Steps) != len(tr.Status.Steps) {
 				logger.Errorf("Mismatch in number of steps for task run %s. TaskSpec steps: %d, Status steps: %d",
 					tr.Name, len(tr.Status.TaskSpec.Steps), len(tr.Status.Steps))
 				continue // Skip this task run entirely


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
When taskrun is status TaskRunCancelled, there is no Status.TaskSpec.,  the PR aims to fix the test so we dont fall in the nil pointer dereference
 here is a status of canceled taskrun
 ```

status:
  completionTime: "2024-10-30T01:40:17Z"
  conditions:
  - lastTransitionTime: "2024-10-30T01:40:17Z"
    message: TaskRun "simple-tasks"
      was cancelled. TaskRun cancelled as the PipelineRun it belongs to has timed
      out.
    reason: TaskRunCancelled
    status: "False"
    type: Succeeded
  podName: ""
  startTime: "2024-10-30T01
```
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
