### PR TITLE
Fix release instructions

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -63,8 +63,10 @@ text editor.
      --param=gitRevision="${CHAINS_RELEASE_GIT_SHA}" \
      --param=versionTag="${CHAINS_VERSION_TAG}" \
      --param=serviceAccountPath=release.json \
+     --param=serviceAccountImagesPath=credentials \
      --param=releaseBucket=gs://tekton-releases/chains \
      --workspace name=release-secret,secret=release-secret \
+     --workspace name=release-images-secret,secret=ghcr-creds \
      --use-param-defaults \
      --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml
    ```
@@ -97,7 +99,7 @@ text editor.
 
       ```bash
       RELEASE_FILE=https://storage.googleapis.com/tekton-releases/chains/previous/${CHAINS_VERSION_TAG}/release.yaml
-      CONTROLLER_IMAGE_SHA=$(curl $RELEASE_FILE | egrep 'gcr.io.*controller' | cut -d'@' -f2)
+      CONTROLLER_IMAGE_SHA=$(curl $RELEASE_FILE | egrep 'ghcr.io.*controller' | cut -d'@' -f2)
       REKOR_UUID=$(rekor-cli search --sha $CONTROLLER_IMAGE_SHA | grep -v Found | head -1)
       echo -e "CONTROLLER_IMAGE_SHA: ${CONTROLLER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
       ```

--- a/release/publish.yaml
+++ b/release/publish.yaml
@@ -29,20 +29,21 @@ spec:
     default: "controller"
   - name: koExtraArgs
     description: Extra args to be passed to ko
-    default: "--preserve-import-paths"
+    default: ""
   - name: versionTag
     description: The vX.Y.Z version that the artifacts should be tagged with (including `v`)
   - name: imageRegistry
     description: The target image registry
-    default: gcr.io
+    default: ghcr.io
   - name: imageRegistryPath
     description: The path (project) in the image registry
+    default: tektoncd/chains
   - name: imageRegistryRegions
     description: The target image registry regions
-    default: "us eu asia"
+    default: ""
   - name: imageRegistryUser
     description: Username to be used to login to the container registry
-    default: "_json_key"
+    default: "tekton-robot"
   - name: releaseAsLatest
     description: Whether to tag and publish this release as chainss' latest
     default: "true"

--- a/release/release-pipeline.yaml
+++ b/release/release-pipeline.yaml
@@ -29,16 +29,16 @@ spec:
     description: the git revision to release
   - name: imageRegistry
     description: The target image registry
-    default: gcr.io
+    default: ghcr.io
   - name: imageRegistryPath
     description: The path (project) in the image registry
-    default: tekton-releases
+    default: tektoncd/chains
   - name: imageRegistryRegions
     description: The target image registry regions
-    default: "us eu asia"
+    default: ""
   - name: imageRegistryUser
     description: The user for the image registry credentials
-    default: _json_key
+    default: tekton-robot
   - name: versionTag
     description: The X.Y.Z version that the artifacts should be tagged with
   - name: releaseBucket
@@ -52,7 +52,7 @@ spec:
     default: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
   - name: koExtraArgs
     description: Extra args to be passed to ko
-    default: "--preserve-import-paths"
+    default: ""
   - name: serviceAccountPath
     description: The path to the service account file within the release-secret workspace
   - name: serviceAccountImagesPath

--- a/releases.md
+++ b/releases.md
@@ -100,6 +100,12 @@ deprecation window timers begin from when the release is published.
 
 ## Current Releases
 
+### v0.23 (LTS)
+- **Latest Release**: [v0.23.0][v0-23-0] (2024-11-06)
+- **Initial Release**: [v0.23.0][v0-23-0] (2024-11-06)
+
+[v0-23-0]: https://github.com/tektoncd/chains/releases/tag/v0.23.0
+
 ### v0.22 (LTS)
 - **Latest Release**: [v0.22.2][v0-22-2] (2024-09-16)
 - **Initial Release**: [v0.22.0][v0-22-0] (2024-08-19)
@@ -113,20 +119,6 @@ deprecation window timers begin from when the release is published.
 
 [v0-21-0]: https://github.com/tektoncd/chains/releases/tag/v0.21.0
 [v0-21-1]: https://github.com/tektoncd/chains/releases/tag/v0.21.1
-
-### v0.20 (LTS)
-
-- **Latest Release**: [v0.20.0][v0-20-0] (2024-01-31)
-- **Initial Release**: [v0.20.0][v0-20-0] (2024-01-31)
-
-[v0-20-0]: https://github.com/tektoncd/chains/releases/tag/v0.20.0
-
-### v0.19 (LTS)
-
-- **Latest Release**: [v0.19.0][v0-19-0] (2023-10-26)
-- **Initial Release**: [v0.19.0][v0-19-0] (2023-10-26)
-
-[v0-19-0]: https://github.com/tektoncd/chains/releases/tag/v0.19.0
 
 ## Older Releases
 

--- a/releases.md
+++ b/releases.md
@@ -14,7 +14,7 @@ follows:
   - The first Tekton Chains LTS release will be **v0.13.0** in October 2022
 
 Tekton Chains produces nightly builds, publicly available on
-`gcr.io/tekton-nightly`.
+[ghcr.io/tektoncd/chains/controller-92006fd957c0afd31de6a40b3e33b39f](https://github.com/tektoncd/chains/pkgs/container/chains%2Fcontroller-92006fd957c0afd31de6a40b3e33b39f).
 
 ### Transition Process
 


### PR DESCRIPTION
Now that images are deployed to ghcr.io, different parameters are needed for the release Pipeline.
