### PR TITLE
Update default address for `signers.x509.fulcio.address`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -146,7 +146,7 @@ chains.tekton.dev/transparency-upload: "true"
 | Key                                | Description                                                   | Supported Values                           | Default                                            |
 | :--------------------------------- | :------------------------------------------------------------ | :----------------------------------------- | :------------------------------------------------- |
 | `signers.x509.fulcio.enabled`      | Whether to enable automatic certificates from fulcio.         | `true`, `false`                            | `false`                                            |
-| `signers.x509.fulcio.address`      | Fulcio address to request certificate from, if enabled        |                                            | `https://v1.fulcio.sigstore.dev`                   |
+| `signers.x509.fulcio.address`      | Fulcio address to request certificate from, if enabled        |                                            | `https://fulcio.sigstore.dev`                   |
 | `signers.x509.fulcio.issuer`       | Expected OIDC issuer.                                         |                                            | `https://oauth2.sigstore.dev/auth`                 |
 | `signers.x509.fulcio.provider`     | Provider to request ID Token from                             | `google`, `spiffe`, `github`, `filesystem` | Unset, each provider will be attempted.            |
 | `signers.x509.identity.token.file` | Path to file containing ID Token.                             |                                            |


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
Since v1.fulcio.sigstore.dev is not available anymore and has been changed to fulcio.sigstore.dev, the default should be changed accordingly in the documentation.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
