### PR TITLE
Update go to 1.23 and plumbing vendoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/tektoncd/chains
 
 go 1.23.2
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0
@@ -31,7 +31,7 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.4.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tektoncd/pipeline v0.66.0
-	github.com/tektoncd/plumbing v0.0.0-20230907180608-5625252a2de1
+	github.com/tektoncd/plumbing v0.0.0-20250115133002-f515628dffea
 	go.opencensus.io v0.24.0
 	go.uber.org/zap v1.27.0
 	gocloud.dev v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -1310,8 +1310,8 @@ github.com/tdakkota/asciicheck v0.2.0 h1:o8jvnUANo0qXtnslk2d3nMKTFNlOnJjRrNcj0j9
 github.com/tdakkota/asciicheck v0.2.0/go.mod h1:Qb7Y9EgjCLJGup51gDHFzbI08/gbGhL/UVhYIPWG2rg=
 github.com/tektoncd/pipeline v0.66.0 h1:WLL98YEgWzblSAD2mPbpZN97tkOC50wiftaW+8+6zTY=
 github.com/tektoncd/pipeline v0.66.0/go.mod h1:V3cyfxxc7b3GLT2a13GX2mWA86qmxWhh4mOp4gfFQwQ=
-github.com/tektoncd/plumbing v0.0.0-20230907180608-5625252a2de1 h1:9paprRIBXQgcvdhGq3wKiSspXP0JIFSY52ru3sIMjKM=
-github.com/tektoncd/plumbing v0.0.0-20230907180608-5625252a2de1/go.mod h1:7eWs1XNkmReggow7ggRbRyRuHi7646B8b2XipCZ3VOw=
+github.com/tektoncd/plumbing v0.0.0-20250115133002-f515628dffea h1:z7uBS+485zM5dFs/ixc708MgIO8eCWPCRCreUQC/pzI=
+github.com/tektoncd/plumbing v0.0.0-20250115133002-f515628dffea/go.mod h1:Ks1fp1nPnhJxxT810eOkq2skeIiDuYjq3cIgpS5Gxk4=
 github.com/tenntenn/modver v1.0.1 h1:2klLppGhDgzJrScMpkj9Ujy3rXPUspSjAcev9tSEBgA=
 github.com/tenntenn/modver v1.0.1/go.mod h1:bePIyQPb7UeioSRkw3Q0XeMhYZSMx9B8ePqg6SAMGH0=
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpRQGxTSkNYKJ51yaw6ChIqO+Je8UqsTKN/cDag=

--- a/vendor/github.com/tektoncd/plumbing/.gitignore
+++ b/vendor/github.com/tektoncd/plumbing/.gitignore
@@ -13,3 +13,9 @@
 
 **/.bin
 **/.DS_Store
+
+# Release
+**/source.tar.gz
+tekton/**/.ko.yaml
+tekton/**/vendor/
+.release-*/

--- a/vendor/github.com/tektoncd/plumbing/OWNERS
+++ b/vendor/github.com/tektoncd/plumbing/OWNERS
@@ -3,11 +3,16 @@
 approvers:
 - abayer
 - afrittoli
+- AlanGreene
 - bobcatfish
+- chitrangpatel
 - dibyom
-- dlorenc
+- jeromeJu
 - jerop
-- nikhil-thomas
 - savitaashture
 - vdemeester
 - wlynch
+
+# Alumni ❤️
+# - nikhil-thomas
+# - dlorenc

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2091,8 +2091,8 @@ github.com/tektoncd/pipeline/pkg/result
 github.com/tektoncd/pipeline/pkg/spire/config
 github.com/tektoncd/pipeline/pkg/substitution
 github.com/tektoncd/pipeline/test
-# github.com/tektoncd/plumbing v0.0.0-20230907180608-5625252a2de1
-## explicit; go 1.19
+# github.com/tektoncd/plumbing v0.0.0-20250115133002-f515628dffea
+## explicit; go 1.22
 github.com/tektoncd/plumbing
 github.com/tektoncd/plumbing/scripts
 # github.com/tetafro/godot v1.4.18


### PR DESCRIPTION
# Changes

The vendored version of tektoncd/plumbing is from 2023.
Updating plumbing brings in an update of golang as well to 1.23.

```
go get github.com/tektoncd/plumbing@f515628dffea46d3a0556b52e19119ba21e9e4ad
go mod tidy
go mod vendor
```


/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
