### PR TITLE
Add KUBERNETES_MIN_VERSION env to override k8s variable

### DIFF
--- a/config/100-deployment.yaml
+++ b/config/100-deployment.yaml
@@ -105,6 +105,8 @@ spec:
               value: tekton-chains-config-observability
             - name: CONFIG_LEADERELECTION_NAME
               value: tekton-chains-config-leader-election
+            - name: KUBERNETES_MIN_VERSION
+              value: "v1.28.0"
 
           ports:
             - name: metrics


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Added an environment variable `KUBERNETES_MIN_VERSION` in the deployment YAML file to enforce compatibility with Kubernetes v1.28.0 or higher.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) been updated if any changes are user-facing?
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) been added if any functionality was introduced or modified?
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, and code quality)
- [ ] The release notes block below has been updated with any user-facing changes (e.g., API changes, bug fixes, upgrade notices, or deprecation warnings)
- [ ] The release notes contain the string **"action required"** if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
