### PR TITLE
drop imagePullSecrets for OCI backend (refs #1336)

### DIFF
--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -63,7 +62,6 @@ type TektonObject interface {
 	GetResults() []Result
 	GetProvenance() *v1.Provenance
 	GetServiceAccountName() string
-	GetPullSecrets() []string
 	IsDone() bool
 	IsSuccessful() bool
 	SupportsTaskRunArtifact() bool
@@ -179,11 +177,6 @@ func (tro *TaskRunObjectV1) GetSidecarImages() []string {
 // Get the ServiceAccount declared in the TaskRun
 func (tro *TaskRunObjectV1) GetServiceAccountName() string {
 	return tro.Spec.ServiceAccountName
-}
-
-// Get the imgPullSecrets from the pod template
-func (tro *TaskRunObjectV1) GetPullSecrets() []string {
-	return getPodPullSecrets(tro.Spec.PodTemplate)
 }
 
 func (tro *TaskRunObjectV1) SupportsTaskRunArtifact() bool {
@@ -326,11 +319,6 @@ func (pro *PipelineRunObjectV1) GetTaskRunsFromTask(taskName string) []*TaskRunO
 	return taskRuns
 }
 
-// Get the imgPullSecrets from the pod template
-func (pro *PipelineRunObjectV1) GetPullSecrets() []string {
-	return getPodPullSecrets(pro.Spec.TaskRunTemplate.PodTemplate)
-}
-
 func (pro *PipelineRunObjectV1) SupportsTaskRunArtifact() bool {
 	return false
 }
@@ -403,17 +391,6 @@ func (pro *PipelineRunObjectV1) GetExecutedTasks() (tro []*TaskRunObjectV1) {
 	}
 
 	return
-}
-
-// Get the imgPullSecrets from a pod template, if they exist
-func getPodPullSecrets(podTemplate *pod.Template) []string {
-	imgPullSecrets := []string{}
-	if podTemplate != nil {
-		for _, secret := range podTemplate.ImagePullSecrets {
-			imgPullSecrets = append(imgPullSecrets, secret.Name)
-		}
-	}
-	return imgPullSecrets
 }
 
 // PipelineRunObjectV1Beta1 extends v1.PipelineRun with additional functions.
@@ -528,11 +505,6 @@ func (pro *PipelineRunObjectV1Beta1) GetTaskRunsFromTask(taskName string) []*Tas
 		}
 	}
 	return taskRuns
-}
-
-// Get the imgPullSecrets from the pod template
-func (pro *PipelineRunObjectV1Beta1) GetPullSecrets() []string {
-	return getPodPullSecrets(pro.Spec.PodTemplate)
 }
 
 func (pro *PipelineRunObjectV1Beta1) SupportsTaskRunArtifact() bool {
@@ -690,11 +662,6 @@ func (tro *TaskRunObjectV1Beta1) GetSidecarImages() []string {
 // Get the ServiceAccount declared in the TaskRun
 func (tro *TaskRunObjectV1Beta1) GetServiceAccountName() string {
 	return tro.Spec.ServiceAccountName
-}
-
-// Get the imgPullSecrets from the pod template
-func (tro *TaskRunObjectV1Beta1) GetPullSecrets() []string {
-	return getPodPullSecrets(tro.Spec.PodTemplate)
 }
 
 func (tro *TaskRunObjectV1Beta1) SupportsTaskRunArtifact() bool {

--- a/pkg/chains/objects/objects_test.go
+++ b/pkg/chains/objects/objects_test.go
@@ -20,19 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func getPullSecretTemplate(pullSecret string) *pod.PodTemplate {
-	return &pod.PodTemplate{
-		ImagePullSecrets: []corev1.LocalObjectReference{
-			{
-				Name: pullSecret,
-			},
-		},
-	}
-}
 
 func getEmptyTemplate() *pod.PodTemplate {
 	return &pod.PodTemplate{}
@@ -142,77 +131,6 @@ func getPipelineRun() *v1.PipelineRun {
 				},
 			},
 		},
-	}
-}
-
-func TestTaskRun_ImagePullSecrets(t *testing.T) {
-	pullSecret := "pull-secret"
-
-	tests := []struct {
-		name     string
-		template *pod.PodTemplate
-		want     []string
-	}{
-		{
-			name:     "Test pull secret found",
-			template: getPullSecretTemplate(pullSecret),
-			want:     []string{pullSecret},
-		},
-		{
-			name:     "Test pull secret missing",
-			template: nil,
-			want:     []string{},
-		},
-		{
-			name:     "Test podTemplate missing",
-			template: getEmptyTemplate(),
-			want:     []string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tr := NewTaskRunObjectV1(getTaskRun())
-			tr.Spec.PodTemplate = tt.template
-			secret := tr.GetPullSecrets()
-			assert.ElementsMatch(t, secret, tt.want)
-		})
-	}
-
-}
-
-func TestPipelineRun_ImagePullSecrets(t *testing.T) {
-	pullSecret := "pull-secret"
-
-	tests := []struct {
-		name     string
-		template *pod.PodTemplate
-		want     []string
-	}{
-		{
-			name:     "Test pull secret found",
-			template: getPullSecretTemplate(pullSecret),
-			want:     []string{pullSecret},
-		},
-		{
-			name:     "Test pull secret missing",
-			template: nil,
-			want:     []string{},
-		},
-		{
-			name:     "Test podTemplate missing",
-			template: getEmptyTemplate(),
-			want:     []string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pr := NewPipelineRunObjectV1(getPipelineRun())
-			pr.Spec.TaskRunTemplate.PodTemplate = tt.template
-			secret := pr.GetPullSecrets()
-			assert.ElementsMatch(t, secret, tt.want)
-		})
 	}
 }
 

--- a/pkg/chains/storage/oci/legacy.go
+++ b/pkg/chains/storage/oci/legacy.go
@@ -62,7 +62,6 @@ func NewStorageBackend(ctx context.Context, client kubernetes.Interface, cfg con
 				k8schain.Options{
 					Namespace:          obj.GetNamespace(),
 					ServiceAccountName: obj.GetServiceAccountName(),
-					ImagePullSecrets:   obj.GetPullSecrets(),
 					UseMountSecrets:    true,
 				})
 			if err != nil {


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

This PR partially addresses issue [#1336](https://github.com/tektoncd/pipeline/issues/1336).

As described in the issue, there are two instances where imagePullSecrets are referenced when using OCI as the storage backend. This PR fixes one of those instances — where imagePullSecrets are retrieved from podTemplateTaskRun/PipelineRun specs.

The use of imagePullSecrets in the k8schain.Options while invoking github.com/google/go-containerregistry/pkg/authn/k8schain has been removed.
As a result, the functions used to fetch imagePullSecrets from TaskRuns and PipelineRuns (across versioned APIs) became unused and have also been cleaned up in this PR.

The second instance noted in the issue will be addressed separately.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
When 'oci' is configured as the storage option for signed artifacts, the tekton-chains-controller 
NO LONGER USES 'imagePullSecrets' defined in 'TaskRun' or 'PipelineRun' specs to authenticate 
with the target OCI registry.

To ensure successful artifact uploads, make sure to:
- Create a Kubernetes 'Secret' containing the necessary 'push credentials' for the target OCI registry.
- Patch this 'Secret' to the 'ServiceAccount' used by the corresponding 'TaskRun' or 'PipelineRun'.
```
