### PR TITLE
Fix subpath capitalisation

### DIFF
--- a/release/release-pipeline.yaml
+++ b/release/release-pipeline.yaml
@@ -89,7 +89,7 @@ spec:
     workspaces:
     - name: output
       workspace: workarea
-      subpath: git
+      subPath: git
     params:
     - name: url
       value: https://$(params.package)
@@ -118,7 +118,7 @@ spec:
     workspaces:
     - name: source-to-release
       workspace: workarea
-      subpath: git
+      subPath: git
   - name: unit-tests
     runAfter: [precheck]
     when:
@@ -140,7 +140,7 @@ spec:
     workspaces:
     - name: source
       workspace: workarea
-      subpath: git
+      subPath: git
   - name: build
     runAfter: [precheck]
     when:
@@ -162,7 +162,7 @@ spec:
     workspaces:
     - name: source
       workspace: workarea
-      subpath: git
+      subPath: git
   - name: publish-images
     runAfter: [build, unit-tests]
     taskRef:
@@ -204,10 +204,10 @@ spec:
     workspaces:
     - name: source
       workspace: workarea
-      subpath: git
+      subPath: git
     - name: output
       workspace: workarea
-      subpath: bucket
+      subPath: bucket
     - name: release-secret
       workspace: release-images-secret
   - name: publish-to-bucket
@@ -226,7 +226,7 @@ spec:
       workspace: release-secret
     - name: source
       workspace: workarea
-      subpath: bucket
+      subPath: bucket
     params:
     - name: location
       value: $(params.releaseBucket)/previous/$(params.versionTag)
@@ -254,7 +254,7 @@ spec:
       workspace: release-secret
     - name: source
       workspace: workarea
-      subpath: bucket
+      subPath: bucket
     params:
     - name: location
       value: $(params.releaseBucket)/latest


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The latest Tekton Pipelines release is stricter about validation and rejects the incorrect `subpath` field name. Update this to the expected `subPath`.

Follow-up to https://github.com/tektoncd/plumbing/pull/2537
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
