### PR TITLE
bump golangci-lint to v2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,12 +24,12 @@ jobs:
     steps:
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc # v4.1.7
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.2.0
+        uses: golangci/golangci-lint-action@v8.0.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,11 @@
-# Documentation: https://golangci-lint.run/usage/configuration/
+version: "2"
+run:
+  build-tags:
+    - e2e
+  modules-download-mode: vendor
+  issues-exit-code: 1
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - containedctx
@@ -16,11 +21,8 @@ linters:
     - exhaustive
     - goconst
     - gocritic
-    - gofmt
-    - goimports
     - gomodguard
     - gosec
-    - gosimple
     - govet
     - ireturn
     - maintidx
@@ -36,40 +38,45 @@ linters:
     - revive
     - staticcheck
     - thelper
-    - typecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
     - whitespace
-linters-settings:
-  depguard:
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          allow:
+            - $gostd
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      main:
-        list-mode: lax
-        allow:
-          - $gostd
-output:
-  uniq-by-line: false
+      - linters:
+          - errcheck
+          - gosec
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # Only flag new issues
-  new: true
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
-        - gosec
   max-issues-per-linter: 0
   max-same-issues: 0
-  include:
-    # Enable off-by-default rules for revive requiring that all exported elements have a properly formatted comment.
-    - EXC0012 # https://golangci-lint.run/usage/false-positives/#exc0012
-    - EXC0014 # https://golangci-lint.run/usage/false-positives/#exc0014
-run:
-  issues-exit-code: 1
-  build-tags:
-    - e2e
-  # skip-dirs:
-  #   - vendor
-  timeout: 20m
-  modules-download-mode: vendor
+  new: true
+  uniq-by-line: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
# Changes

Bumps golangci-lint to use v2. To support this, also bumps the `lint.yaml` workflow to utilize the version of go listed in `go.mod` and bumps to the latest version of the `golangci-lint` action.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
updates golangci-lint to v2
```
