### PR TITLE
fix: improve error handling during OCI auth initialization

### DIFF
--- a/pkg/chains/storage/oci/legacy.go
+++ b/pkg/chains/storage/oci/legacy.go
@@ -65,7 +65,7 @@ func NewStorageBackend(ctx context.Context, client kubernetes.Interface, cfg con
 					UseMountSecrets:    true,
 				})
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "creating new keychain from serviceaccount %s/%s", obj.GetNamespace(), obj.GetServiceAccountName())
 			}
 			return remote.WithAuthFromKeychain(kc), nil
 		},
@@ -77,7 +77,7 @@ func (b *Backend) StorePayload(ctx context.Context, obj objects.TektonObject, ra
 	logger := logging.FromContext(ctx)
 	auth, err := b.getAuthenticator(ctx, obj, b.client)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting oci authenticator")
 	}
 
 	logger.Infof("Storing payload on %s/%s/%s", obj.GetGVK(), obj.GetNamespace(), obj.GetName())


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Add context and stack trace to OCI storage auth initialization. In instances where the serviceaccount, imagepullsecret, or secret is malformed, an error will be returned. Without this added context, it can be difficult to understand the error. E.g. if the ServiceAccount has an imagepullsecret list item or secret list item which does not have a `name` field, e.g. `secrets: [{}]`, the reconciliation will fail with a message like  the below:
`{"level":"info","ts":"2025-06-03T15:21:56.391Z","logger":"watcher.event-broadcaster","caller":"record/event.go:377","msg":"Event(v1.ObjectReference{Kind:\"TaskRun\", Namespace:\"some-namespace\", Name:\"my-taskrun\", UID:\"b361efeb-a6eb-4b5f-9b35-76c2854c5538\", APIVersion:\"tekton.dev/v1\", ResourceVersion:\"1521875699\", FieldPath:\"\"}): type: 'Warning' reason: 'InternalError' 1 error occurred:\n\t* resource name may not be empty\n\n","commit":"65f8d90df06be35f440f832dd6245e40019709f0"}`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Add additional context to storage initialization error handling 
```
