### PR TITLE
Enable Integration tests in GH actions

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -6,6 +6,10 @@ on:
       - main
       - release-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -32,6 +32,7 @@ jobs:
       # Note that we do not include the v prefix here so we can use it in all
       # the places this is used.
       TEKTON_CLI_RELEASE: "0.30.0"
+      SKIP_INITIALIZE: true 
 
     steps:
     - name: Set up Go
@@ -72,12 +73,14 @@ jobs:
         # Restart so picks up the changes.
         kubectl -n tekton-pipelines delete po -l app=tekton-pipelines-controller
 
-    - name: Install all the everythings
+    - name: Run integration tests
       working-directory: ./src/github.com/tektoncd/chains
-      timeout-minutes: 10
       run: |
-        ko apply -BRf ./config/
+        ./test/presubmit-tests.sh --integration-tests
 
+
+    - name: Run tutorial taskrun
+      run: |
         kubectl patch configmap/chains-config \
         --namespace tekton-chains \
         --type merge \
@@ -88,10 +91,8 @@ jobs:
 
         # TODO(vaikas): Better way to find when the chains has picked up
         # the changes
-        sleep 10
+        sleep 20
 
-    - name: Run tutorial taskrun
-      run: |
         kubectl create -f https://raw.githubusercontent.com/tektoncd/chains/main/examples/taskruns/task-output-image.yaml
 
         # Sleep so the taskrun shows up.

--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -31,8 +31,7 @@ jobs:
       TEKTON_PIPELINES_RELEASE: "https://storage.googleapis.com/tekton-releases/pipeline/previous/${{ inputs.pipelines-release }}/release.yaml"
       # Note that we do not include the v prefix here so we can use it in all
       # the places this is used.
-      TEKTON_CLI_RELEASE: "0.30.0"
-      SKIP_INITIALIZE: true 
+      SKIP_INITIALIZE: true
 
     steps:
     - name: Set up Go
@@ -43,12 +42,6 @@ jobs:
     - uses: ko-build/setup-ko@v0.9
       with:
         version: tip
-
-    - name: Install tkn cli
-      run: |
-        curl -Lo ./tkn_${{ env.TEKTON_CLI_RELEASE }}_Linux_x86_64.tar.gz https://github.com/tektoncd/cli/releases/download/v${{ env.TEKTON_CLI_RELEASE }}/tkn_${{ env.TEKTON_CLI_RELEASE }}_Linux_x86_64.tar.gz
-        tar xvzf ./tkn_${{ env.TEKTON_CLI_RELEASE }}_Linux_x86_64.tar.gz tkn
-        chmod u+x ./tkn
 
     - name: Check out our repo
       uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc # v4.1.7
@@ -104,7 +97,7 @@ jobs:
         echo "Waiting for Chains to do it's thing"
         for i in {1..10}
         do
-          ./tkn tr describe --last -o jsonpath="{.metadata.annotations.chains\.tekton\.dev/transparency}" > tektonentry
+          tkn tr describe --last -o jsonpath="{.metadata.annotations.chains\.tekton\.dev/transparency}" > tektonentry
 
           if [ -s ./tektonentry ]; then
             if grep --quiet rekor.rekor-system.svc ./tektonentry ; then

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -31,11 +31,11 @@ source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
 
 function install_tkn() {
   echo ">> Installing tkn"
-  TKN_VERSION=0.20.0
+  TKN_VERSION=0.41.0
   # Get the tar.xz
-  curl -LO https://github.com/tektoncd/cli/releases/download/v$TKN_VERSION/tkn_$TKN_VERSION_Linux_x86_64.tar.gz
+  curl -LO https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz
   # Extract tkn to your PATH (e.g. /usr/local/bin)
-  tar xvzf tkn_$TKN_VERSION_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
+  tar xvzf tkn_${TKN_VERSION}_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
 }
 
 function install_pipeline_crd() {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -17,22 +17,23 @@
 # This script calls out to scripts in tektoncd/plumbing to setup a cluster
 # and deploy Tekton Pipelines to it for running integration tests.
 
+SKIP_INITIALIZE=${SKIP_INITIALIZE:="false"}
+export GCE_METADATA_HOST=${GCE_METADATA_HOST:="localhost"}
+
 export namespace="${NAMESPACE:-tekton-chains}"
 echo "Using namespace: $namespace"
 
 source $(git rev-parse --show-toplevel)/test/e2e-common.sh
 
 # Script entry point.
-
-initialize $@
+if [ "${SKIP_INITIALIZE}" != "true" ]; then
+  initialize $@
+fi
 
 header "Setting up environment"
 
 # Test against nightly instead of latest.
 install_tkn
-
-export RELEASE_YAML="https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.62.0/release.yaml"
-install_pipeline_crd
 
 install_chains
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -45,6 +45,8 @@ chains_patch_spire
 
 failed=0
 
+go install github.com/jstemmer/go-junit-report/v2@latest
+
 # Run the integration tests
 header "Running Go e2e tests"
 go_test_e2e -timeout=35m ./test/... || failed=1


### PR DESCRIPTION
E2E tests aren't running after being disabled from prow. We are only running a tutorial as a test.

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
