### PR TITLE
Add anti-affinity rules to controller's replicas

### DIFF
--- a/config/100-deployment.yaml
+++ b/config/100-deployment.yaml
@@ -85,6 +85,26 @@ spec:
         pipeline.tekton.dev/release: "devel"
         version: "devel"
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/os
+                  operator: NotIn
+                  values:
+                  - windows
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: controller
+                  app.kubernetes.io/component: controller
+                  app.kubernetes.io/instance: default
+                  app.kubernetes.io/part-of: tekton-chains
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       serviceAccountName: tekton-chains-controller
       containers:
         - name: tekton-chains-controller


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->
As part of the HA setup, we want to add anti-affinity rules to our deployment to make sure replicas do not end up in the same node.

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
As part of improving high availability (HA) for the Tekton Chains controller, this update adds a preferredDuringSchedulingIgnoredDuringExecution pod anti-affinity rule. This ensures that multiple replicas of the controller are preferably scheduled on different nodes, reducing the risk of service disruption in case of a node failure.

```
