### PR TITLE
Use server-side apply for managing annotations

### DIFF
--- a/pkg/chains/annotations.go
+++ b/pkg/chains/annotations.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/tektoncd/chains/pkg/chains/objects"
@@ -26,6 +27,8 @@ import (
 )
 
 const (
+	// ChainsAnnotationPrefix is the prefix for all Chains annotations
+	ChainsAnnotationPrefix = "chains.tekton.dev/"
 	// ChainsAnnotation is the standard annotation to indicate a TR has been signed.
 	ChainsAnnotation             = "chains.tekton.dev/signed"
 	RetryAnnotation              = "chains.tekton.dev/retries"
@@ -63,6 +66,10 @@ func reconciledFromAnnotations(annotations map[string]string) bool {
 // MarkSigned marks a Tekton object as signed.
 func MarkSigned(ctx context.Context, obj objects.TektonObject, ps versioned.Interface, annotations map[string]string) error {
 	if _, ok := obj.GetAnnotations()[ChainsAnnotation]; ok {
+		// Object is already signed, but we may still need to apply additional annotations
+		if len(annotations) > 0 {
+			return AddAnnotation(ctx, obj, ps, ChainsAnnotation, "true", annotations)
+		}
 		return nil
 	}
 	return AddAnnotation(ctx, obj, ps, ChainsAnnotation, "true", annotations)
@@ -97,12 +104,36 @@ func AddRetry(ctx context.Context, obj objects.TektonObject, ps versioned.Interf
 }
 
 func AddAnnotation(ctx context.Context, obj objects.TektonObject, ps versioned.Interface, key, value string, annotations map[string]string) error {
-	// Use patch instead of update to help prevent race conditions.
-	if annotations == nil {
-		annotations = map[string]string{}
+	// Get current annotations from API server to ensure we have the latest state
+	currentAnnotations, err := obj.GetLatestAnnotations(ctx, ps)
+	if err != nil {
+		return err
 	}
-	annotations[key] = value
-	patchBytes, err := patch.GetAnnotationsPatch(annotations)
+
+	// Start with existing chains annotations, ignore annotations from other controllers,
+	// so we do not take ownership of them.
+	mergedAnnotations := make(map[string]string)
+	for k, v := range currentAnnotations {
+		if strings.HasPrefix(k, ChainsAnnotationPrefix) {
+			mergedAnnotations[k] = v
+		}
+	}
+
+	// Add the new chains annotations, they all must be chains annotations
+	for k, v := range annotations {
+		if !strings.HasPrefix(k, ChainsAnnotationPrefix) {
+			return fmt.Errorf("invalid annotation key %q: all annotations must have prefix %q", k, ChainsAnnotationPrefix)
+		}
+		mergedAnnotations[k] = v
+	}
+
+	// Add the specific key-value pair, again it must be chains annotation
+	if !strings.HasPrefix(key, ChainsAnnotationPrefix) {
+		return fmt.Errorf("invalid annotation key %q: all annotations must have prefix %q", key, ChainsAnnotationPrefix)
+	}
+	mergedAnnotations[key] = value
+
+	patchBytes, err := patch.GetAnnotationsPatch(mergedAnnotations, obj)
 	if err != nil {
 		return err
 	}
@@ -110,5 +141,10 @@ func AddAnnotation(ctx context.Context, obj objects.TektonObject, ps versioned.I
 	if err != nil {
 		return err
 	}
+
+	// Note: Ideally here we'll update the in-memory object to keep it consistent through
+	// the reconciliation loop. It hasn't been done to preserve the existing controller behavior
+	// and maintain compatibility with existing tests. This could be revisited in the future.
+
 	return nil
 }

--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -22,14 +22,23 @@ import (
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/ptr"
 )
 
 // Label added to TaskRuns identifying the associated pipeline Task
 const PipelineTaskLabel = "tekton.dev/pipelineTask"
+
+// patchOptions contains the default patch options
+var patchOptions = metav1.PatchOptions{
+	FieldManager: "tekton-chains-controller",
+	Force:        ptr.Bool(false),
+}
 
 // Object is used as a base object of all Kubernetes objects
 // ref: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.4/pkg/client#Object
@@ -121,8 +130,19 @@ func (tro *TaskRunObjectV1) GetObject() interface{} {
 
 // Patch the original TaskRun object
 func (tro *TaskRunObjectV1) Patch(ctx context.Context, clientSet versioned.Interface, patchBytes []byte) error {
+	logger := logging.FromContext(ctx)
 	_, err := clientSet.TektonV1().TaskRuns(tro.Namespace).Patch(
-		ctx, tro.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+		ctx, tro.Name, types.ApplyPatchType, patchBytes, patchOptions)
+	if apierrors.IsConflict(err) {
+		// Since we only update the list of annotations we manage, there shouldn't be any conflicts unless
+		// another controller/client is updating our annotations. We log the issue and force patch.
+		logger.Warnf("failed to patch object %s/%s due to Server-Side Apply patch conflict, using force patch.", tro.Namespace, tro.Name)
+		// use a copy to avoid changing the global var
+		patchOptionsForce := patchOptions
+		patchOptionsForce.Force = ptr.Bool(true)
+		_, err = clientSet.TektonV1().TaskRuns(tro.Namespace).Patch(
+			ctx, tro.Name, types.ApplyPatchType, patchBytes, patchOptionsForce)
+	}
 	return err
 }
 
@@ -260,8 +280,19 @@ func (pro *PipelineRunObjectV1) GetObject() interface{} {
 
 // Patch the original PipelineRun object
 func (pro *PipelineRunObjectV1) Patch(ctx context.Context, clientSet versioned.Interface, patchBytes []byte) error {
+	logger := logging.FromContext(ctx)
 	_, err := clientSet.TektonV1().PipelineRuns(pro.Namespace).Patch(
-		ctx, pro.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+		ctx, pro.Name, types.ApplyPatchType, patchBytes, patchOptions)
+	if apierrors.IsConflict(err) {
+		// Since we only update the list of annotations we manage, there shouldn't be any conflicts unless
+		// another controller/client is updating our annotations. We log the issue and force patch.
+		logger.Warnf("failed to patch object %s/%s due to Server-Side Apply patch conflict, using force patch.", pro.Namespace, pro.Name)
+		// use a copy to avoid changing the global var
+		patchOptionsForce := patchOptions
+		patchOptionsForce.Force = ptr.Bool(true)
+		_, err = clientSet.TektonV1().PipelineRuns(pro.Namespace).Patch(
+			ctx, pro.Name, types.ApplyPatchType, patchBytes, patchOptionsForce)
+	}
 	return err
 }
 

--- a/pkg/chains/storage/tekton/tekton.go
+++ b/pkg/chains/storage/tekton/tekton.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	intoto "github.com/in-toto/attestation/go/v1"
 	"github.com/tektoncd/chains/pkg/chains/objects"
@@ -30,6 +31,8 @@ import (
 )
 
 const (
+	// ChainsAnnotationPrefix is the prefix for all Chains annotations
+	ChainsAnnotationPrefix    = "chains.tekton.dev/"
 	StorageBackendTekton      = "tekton"
 	PayloadAnnotationFormat   = "chains.tekton.dev/payload-%s"
 	SignatureAnnotationFormat = "chains.tekton.dev/signature-%s"
@@ -168,13 +171,28 @@ func (s *Storer) Store(ctx context.Context, req *api.StoreRequest[objects.Tekton
 	if key == "" {
 		key = string(obj.GetUID())
 	}
-	patchBytes, err := patch.GetAnnotationsPatch(map[string]string{
-		// Base64 encode both the signature and the payload
-		fmt.Sprintf(PayloadAnnotationFormat, key):   base64.StdEncoding.EncodeToString(req.Bundle.Content),
-		fmt.Sprintf(SignatureAnnotationFormat, key): base64.StdEncoding.EncodeToString(req.Bundle.Signature),
-		fmt.Sprintf(CertAnnotationsFormat, key):     base64.StdEncoding.EncodeToString(req.Bundle.Cert),
-		fmt.Sprintf(ChainAnnotationFormat, key):     base64.StdEncoding.EncodeToString(req.Bundle.Chain),
-	})
+
+	// Get current annotations from API server to ensure we have the latest state
+	currentAnnotations, err := obj.GetLatestAnnotations(ctx, s.client)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge existing annotations with new Chains annotations
+	mergedAnnotations := make(map[string]string)
+	for k, v := range currentAnnotations {
+		if strings.HasPrefix(k, ChainsAnnotationPrefix) {
+			mergedAnnotations[k] = v
+		}
+	}
+
+	// Add Chains-specific annotations
+	mergedAnnotations[fmt.Sprintf(PayloadAnnotationFormat, key)] = base64.StdEncoding.EncodeToString(req.Bundle.Content)
+	mergedAnnotations[fmt.Sprintf(SignatureAnnotationFormat, key)] = base64.StdEncoding.EncodeToString(req.Bundle.Signature)
+	mergedAnnotations[fmt.Sprintf(CertAnnotationsFormat, key)] = base64.StdEncoding.EncodeToString(req.Bundle.Cert)
+	mergedAnnotations[fmt.Sprintf(ChainAnnotationFormat, key)] = base64.StdEncoding.EncodeToString(req.Bundle.Chain)
+
+	patchBytes, err := patch.GetAnnotationsPatch(mergedAnnotations, obj)
 	if err != nil {
 		return nil, err
 	}
@@ -183,5 +201,10 @@ func (s *Storer) Store(ctx context.Context, req *api.StoreRequest[objects.Tekton
 	if patchErr != nil {
 		return nil, patchErr
 	}
+
+	// Note: Ideally here we'll update the in-memory object to keep it consistent through
+	// the reconciliation loop. It hasn't been done to preserve the existing controller behavior
+	// and maintain compatibility with existing tests. This could be revisited in the future.
+
 	return &api.StoreResponse{}, nil
 }

--- a/pkg/chains/storage/tekton/tekton_test.go
+++ b/pkg/chains/storage/tekton/tekton_test.go
@@ -18,7 +18,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	intoto "github.com/in-toto/attestation/go/v1"
 	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/chains/pkg/chains/signing"
+	"github.com/tektoncd/chains/pkg/chains/storage/api"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/chains/pkg/test/tekton"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -136,4 +139,138 @@ func TestBackend_StorePayload(t *testing.T) {
 type mockPayload struct {
 	A string
 	B int
+}
+
+// TestStorerAnnotationPreservation tests that the Storer preserves existing Chains annotations
+func TestStorerAnnotationPreservation(t *testing.T) {
+	tests := []struct {
+		name                string
+		existingAnnotations map[string]string
+		expectedPreserved   []string
+		expectedIgnored     []string
+	}{
+		{
+			name: "preserve existing chains annotations",
+			existingAnnotations: map[string]string{
+				"chains.tekton.dev/existing1": "value1",
+				"chains.tekton.dev/existing2": "value2",
+				"tekton.dev/other":            "ignore",
+				"kubernetes.io/annotation":    "ignore",
+				"chains.tekton.dev/preserve":  "keep-me",
+			},
+			expectedPreserved: []string{
+				"chains.tekton.dev/existing1",
+				"chains.tekton.dev/existing2",
+				"chains.tekton.dev/preserve",
+			},
+			expectedIgnored: []string{
+				"tekton.dev/other",
+				"kubernetes.io/annotation",
+			},
+		},
+		{
+			name: "no existing chains annotations",
+			existingAnnotations: map[string]string{
+				"tekton.dev/other":         "ignore",
+				"kubernetes.io/annotation": "ignore",
+			},
+			expectedPreserved: []string{},
+			expectedIgnored: []string{
+				"tekton.dev/other",
+				"kubernetes.io/annotation",
+			},
+		},
+		{
+			name: "only chains annotations",
+			existingAnnotations: map[string]string{
+				"chains.tekton.dev/existing1": "value1",
+				"chains.tekton.dev/existing2": "value2",
+			},
+			expectedPreserved: []string{
+				"chains.tekton.dev/existing1",
+				"chains.tekton.dev/existing2",
+			},
+			expectedIgnored: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			c := fakepipelineclient.Get(ctx)
+
+			obj := objects.NewTaskRunObjectV1(&v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-taskrun",
+					Namespace:   "default",
+					Annotations: tt.existingAnnotations,
+				},
+			})
+
+			tekton.CreateObject(t, ctx, c, obj)
+
+			storer := &Storer{
+				client: c,
+				key:    "test-key",
+			}
+
+			mockPayload := []byte(`{"test": "payload"}`)
+			mockSignature := []byte("mock-signature")
+			mockCert := []byte("mock-cert")
+			mockChain := []byte("mock-chain")
+
+			req := &api.StoreRequest[objects.TektonObject, *intoto.Statement]{
+				Object:   obj,
+				Artifact: obj,
+				Payload:  nil,
+				Bundle: &signing.Bundle{
+					Content:   mockPayload,
+					Signature: mockSignature,
+					Cert:      mockCert,
+					Chain:     mockChain,
+				},
+			}
+
+			_, err := storer.Store(ctx, req)
+			if err != nil {
+				t.Fatalf("Store() error = %v", err)
+			}
+
+			// Verify preserved annotations still exist
+			updated, err := tekton.GetObject(t, ctx, c, obj)
+			if err != nil {
+				t.Fatalf("Get() error = %v", err)
+			}
+
+			annotations := updated.GetAnnotations()
+
+			// Check preserved annotations
+			for _, key := range tt.expectedPreserved {
+				if expectedValue := tt.existingAnnotations[key]; annotations[key] != expectedValue {
+					t.Errorf("Expected preserved annotation %s=%s, got %s", key, expectedValue, annotations[key])
+				}
+			}
+
+			// Check ignored annotations (should still be there, just not in patch)
+			for _, key := range tt.expectedIgnored {
+				if expectedValue := tt.existingAnnotations[key]; annotations[key] != expectedValue {
+					t.Errorf("Expected ignored annotation %s=%s to remain, got %s", key, expectedValue, annotations[key])
+				}
+			}
+
+			// Check that new storage annotations were added
+			expectedStorageAnnotations := []string{
+				"chains.tekton.dev/payload-test-key",
+				"chains.tekton.dev/signature-test-key",
+				"chains.tekton.dev/cert-test-key",
+				"chains.tekton.dev/chain-test-key",
+			}
+
+			for _, key := range expectedStorageAnnotations {
+				if _, exists := annotations[key]; !exists {
+					t.Errorf("Expected storage annotation %s to be added", key)
+				}
+			}
+		})
+	}
 }

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -19,7 +19,24 @@ import (
 	"testing"
 )
 
+// mockTektonObject implements TektonObject interface for testing
+type mockTektonObject struct {
+	name      string
+	namespace string
+	gvk       string
+}
+
+func (m *mockTektonObject) GetName() string      { return m.name }
+func (m *mockTektonObject) GetNamespace() string { return m.namespace }
+func (m *mockTektonObject) GetGVK() string       { return m.gvk }
+
 func TestGetAnnotationsPatch(t *testing.T) {
+	mockObj := &mockTektonObject{
+		name:      "test-taskrun",
+		namespace: "test-namespace",
+		gvk:       "tekton.dev/v1/TaskRun",
+	}
+
 	tests := []struct {
 		name           string
 		newAnnotations map[string]string
@@ -29,14 +46,14 @@ func TestGetAnnotationsPatch(t *testing.T) {
 		{
 			name:           "empty",
 			newAnnotations: map[string]string{},
-			want:           `{"metadata":{}}`,
+			want:           `{"apiVersion":"tekton.dev/v1","kind":"TaskRun","metadata":{"name":"test-taskrun","namespace":"test-namespace"}}`,
 		},
 		{
 			name: "one",
 			newAnnotations: map[string]string{
 				"foo": "bar",
 			},
-			want: `{"metadata":{"annotations":{"foo":"bar"}}}`,
+			want: `{"apiVersion":"tekton.dev/v1","kind":"TaskRun","metadata":{"name":"test-taskrun","namespace":"test-namespace","annotations":{"foo":"bar"}}}`,
 		},
 		{
 			name: "many",
@@ -44,12 +61,12 @@ func TestGetAnnotationsPatch(t *testing.T) {
 				"foo": "bar",
 				"baz": "bat",
 			},
-			want: `{"metadata":{"annotations":{"baz":"bat","foo":"bar"}}}`,
+			want: `{"apiVersion":"tekton.dev/v1","kind":"TaskRun","metadata":{"name":"test-taskrun","namespace":"test-namespace","annotations":{"baz":"bat","foo":"bar"}}}`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetAnnotationsPatch(tt.newAnnotations)
+			got, err := GetAnnotationsPatch(tt.newAnnotations, mockObj)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetAnnotationsPatch() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This is part of broader effort to switch all Tekton components to using Server-Side Apply patch to improve performance (less retries when merge patches are combined with resourceVersion) and reliability (when merge patches are used without resourceVersion). The underlying problem is that in the case of PipelineRun and TaskRun objects, there are multiple controllers operating on those objects and that leads to issues such as one controller overriding the changes (annotations, labels) of other controllers.

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
