### PR TITLE
Add GitHub Actions workflow for build and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: Tekton CI
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build tests
+    runs-on: ubuntu-24.04
+
+    env:
+      GOPATH: ${{ github.workspace }}
+      GO111MODULE: ''
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: ${{ github.workspace }}/src/github.com/tektoncd/chains
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          cache-dependency-path: "${{ github.workspace }}/src/github.com/tektoncd/chains/go.sum"
+          go-version-file: "${{ github.workspace }}/src/github.com/tektoncd/chains/go.mod"
+
+      - name: Install dependencies
+        run: |
+          echo "${GOPATH}/bin" >> "$GITHUB_PATH"
+          GO111MODULE="on" go install github.com/google/go-licenses@v1.0.0
+          # TODO: re-enable this and fix the license headers / exclusions
+          # GO111MODULE="on" go install github.com/google/addlicense@v1.2.0
+          GO111MODULE="on" go install github.com/jstemmer/go-junit-report@latest
+
+          # Install GolangCI linter: https://github.com/golangci/golangci-lint/
+          GOLANGCI_VERSION=2.1.6
+          curl -sL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xvzf - --strip-components=1 --wildcards "*/golangci-lint"
+
+      - name: Run tests
+        working-directory: ${{ github.workspace }}/src/github.com/tektoncd/chains
+        run: |
+          ./test/presubmit-tests.sh --build-tests
+
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: ${{ github.workspace }}/src/github.com/tektoncd/chains
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          cache-dependency-path: "${{ github.workspace }}/src/github.com/tektoncd/chains/go.sum"
+          go-version-file: "${{ github.workspace }}/src/github.com/tektoncd/chains/go.mod"
+
+      - name: Install dependencies
+        run: |
+          echo "${GOPATH}/bin" >> "$GITHUB_PATH"
+          GO111MODULE="on" go install github.com/jstemmer/go-junit-report@latest
+
+      - name: Run tests
+        working-directory: ${{ github.workspace }}/src/github.com/tektoncd/chains
+        run: |
+          ./test/presubmit-tests.sh --unit-tests


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
https://github.com/tektoncd/plumbing/issues/2842
https://github.com/tektoncd/chains/issues/1423

Add GitHub Actions workflow to replace the build test and unit test jobs in prow

I noticed that the build tests weren't actually running the `addlicense` check, as there are a number of files flagged:
```
$ git diff --stat
 .github/dependabot.yml                                   | 14 ++++++++++++++
 .github/workflows/ci.yml                                 | 16 +++++++++++++++-
 .github/workflows/codeql.yml                             | 14 ++++++++++++++
 .github/workflows/goclean.yml                            | 14 ++++++++++++++
 .github/workflows/kind-e2e.yaml                          | 14 ++++++++++++++
 .github/workflows/lint.yaml                              | 14 ++++++++++++++
 .github/workflows/reusable-e2e.yaml                      | 14 ++++++++++++++
 .github/workflows/test-on-microshift.yaml                | 14 ++++++++++++++
 .golangci.yaml                                           | 14 ++++++++++++++
 .ko.yaml                                                 | 14 ++++++++++++++
 examples/v2alpha4/pipeline-with-object-type-hinting.yaml | 14 ++++++++++++++
 examples/v2alpha4/pipeline-with-repeated-results.yaml    | 14 ++++++++++++++
 examples/v2alpha4/task-with-object-type-hinting.yaml     | 14 ++++++++++++++
 pkg/chains/formats/slsa/v1/internal/protos/protos.go     | 14 ++++++++++++++
 test/microshift_test.sh                                  | 14 ++++++++++++++
 15 files changed, 211 insertions(+), 1 deletion(-)
```

Disabled installing the tool until that's resolved, in which case uncommenting the install will result in it running as expected.

Unit tests are also failing:
```
=== RUN   TestCreateSignerFulcioEnabled
    logger.go:146: 2025-10-01T12:23:17.116Z	INFO	x509/x509.go:99	Attempting to get id token from provider filesystem-custom-path
    logger.go:146: 2025-10-01T12:23:17.117Z	INFO	x509/x509.go:116	Signing with fulcio ...
    x509_test.go:106: new signer: reading id token: getting id token: open *** no such file or directory
--- FAIL: TestCreateSignerFulcioEnabled (0.00s)
=== RUN   TestCreateSignerFulcioEnabledFilesystemProvider
    logger.go:146: 2025-10-01T12:23:17.118Z	INFO	x509/x509.go:99	Attempting to get id token from provider filesystem-custom-path
    logger.go:146: 2025-10-01T12:23:17.118Z	INFO	x509/x509.go:116	Signing with fulcio ...
    x509_test.go:142: new signer: reading id token: getting id token: open *** no such file or directory
--- FAIL: TestCreateSignerFulcioEnabledFilesystemProvider (0.00s)
```

These same 2 tests are also failing locally, so unrelated to the move to GHA.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
