### PR TITLE
fix: replace HS256 token with RS256

### DIFF
--- a/pkg/chains/signing/x509/x509_test.go
+++ b/pkg/chains/signing/x509/x509_test.go
@@ -49,8 +49,10 @@ const ed25519Priv = `-----BEGIN PRIVATE KEY-----
 MC4CAQAwBQYDK2VwBCIEIGQn0bJwshjwuVdnd/FylMk3Gvb89aGgH49bQpgzCY0n
 -----END PRIVATE KEY-----`
 
-// npx jwtgen -a HS256 -s "my-secret" -c "iss=user123" -e 3600
-const token = `eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2Nzc1NjAyMTgsImV4cCI6MTY3NzU2MzgxOCwiaXNzIjoidXNlcjEyMyJ9.c-sDgCyuZA6VaIGl7Y3-9XxttW1PUkBeNBLE9gCKG8s`
+// Generated with RS256 algorithm (required for cosign v2.6.0+)
+// openssl genrsa -out private.pem 2048
+// python3 -c "import jwt; import time; private_key = open('/tmp/private.pem').read(); payload = {'iat': int(time.time()), 'exp': int(time.time()) + 3600 * 24 * 365 * 10, 'iss': 'user123'}; print(jwt.encode(payload, private_key, algorithm='RS256'))"
+const token = `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3NjIzMTIzOTQsImV4cCI6MjA3NzY3MjM5NCwiaXNzIjoidXNlcjEyMyJ9.Adm27mf955gZA2pcWLqF4LLrqzFbXYsdYNg1sScF9MbyeuE-4eVpqV91Rk-iRwwIrtKuOVkEDdulrAqeuIhMxGB7jNXWXxf6sVEHV57_QgB0KR_z-JVxEbTZBu6nIVBwDxmVFGQFVMtZbqsyX8J4F_jp0pSInFPqYQbS9xAGhvOnni_owp325Siev2Z-kWsnTTFOTi0C9g9BApPxXQEE17COYdXjxsBCJQQttb1Ww7IQLCf59wU5ZpNM7npzxvKuOBT1kmHPp1ZDCNxfA_a6JMIB4NQAzYV0ULRbXNftxwglFoyitWge-SyxohnTVfV1gplE8qi6kR2CQJORBMvx6w`
 
 func TestCreateSignerFulcioEnabledDefaultTokenFileMissing(t *testing.T) {
 	ctx := logtesting.TestContextWithLogger(t)


### PR DESCRIPTION
# Changes

This pull request updates the JWT token used in the `x509_test.go` test file to use the RS256 algorithm instead of HS256. This change ensures compatibility with cosign v2.6.0 and newer, which require RS256-signed tokens. 

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note

Breaking Change: 

Due to the upgrade of Cosign from v2.5.3 to v2.6.0 (PR #1441), Tekton Chains now requires identity tokens for Fulcio signing to use the RS256 algorithm instead of HS256 or other symmetric algorithms.

Impact:

If you are using Fulcio for keyless signing with custom identity tokens (via signers.x509.identity.token.file configuration), you must ensure your tokens are signed using the RS256 (RSA with SHA-256) algorithm.
Tokens using HS256, HS384, HS512, or other non-RS256 algorithms will be rejected, causing signature operations to fail with errors like: new signer: reading id token: getting id token: open <token>: no such file or directory

Who is affected:

- Users who provide custom JWT identity tokens for Fulcio authentication
- Users who have implemented custom OIDC token providers with non-RS256 algorithms
- Default Kubernetes service account tokens and standard OIDC providers (Google, GitHub, etc.) are not affected as they already use RS256

Action required:

Update your identity token generation to use RS256 algorithm. If using custom token generation scripts, ensure they sign with RSA keys
```
