### PR TITLE
fix: improve e2e test failure analysis with chains controller logs

### DIFF
--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -82,9 +82,12 @@ jobs:
         # Restart chains controller so picks up the changes.
         kubectl -n tekton-chains delete po -l app=tekton-chains-controller
 
-        # TODO(vaikas): Better way to find when the chains has picked up
-        # the changes
-        sleep 20
+        # Wait for chains controller to be ready again
+        echo "Waiting for chains controller to be ready"
+        kubectl wait --for=condition=ready --timeout=2m -n tekton-chains pod -l app=tekton-chains-controller
+
+        # Give chains a moment to reload the configuration
+        sleep 5
 
         kubectl create -f https://raw.githubusercontent.com/tektoncd/chains/main/examples/taskruns/task-output-image.yaml
 
@@ -116,6 +119,9 @@ jobs:
         done
 
         # Did not find entry, fail
+        echo "Failed to find rekor transparency entry after 10 attempts"
+        kubectl get taskruns -oyaml
+        kubectl logs -n tekton-chains -l app=tekton-chains-controller --tail=100
         exit 1
 
     - name: Collect diagnostics


### PR DESCRIPTION
# Changes

This pull request attempts to improve the reliability of the Tekton Chains controller restart process in the `.github/workflows/reusable-e2e.yaml` workflow. The main changes focus on ensuring the controller is ready before proceeding and providing better diagnostics if a Rekor transparency entry is not found.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
