### PR TITLE
Add TaskRun status info to SLSA v1.0 provenance

### DIFF
--- a/test/testdata/slsa/v2alpha4/pipeline-with-repeated-results.json
+++ b/test/testdata/slsa/v2alpha4/pipeline-with-repeated-results.json
@@ -190,6 +190,21 @@
                     "content": "eyJkaWdlc3QiOiJzaGEyNTY6NTg2Nzg5YWEwMzFmYWZjN2Q3OGE1MzkzY2RjNzcyZTBiNTUxMDdlYTU0YmI4YmNmM2YyY2RhYzZjNmRhNTFlZSIsInVyaSI6Imdjci5pby9mb28vaW1nMiJ9",
                     "mediaType": "application/json",
                     "name": "taskRunResults/{{index .ChildTaskRunNames 0}}/output2"
+                },
+                {
+                    "content": "eyJzdGF0dXMiOiJTdWNjZWVkZWQifQ==",
+                    "mediaType": "application/json",
+                    "name": "taskRunStatus/{{index .ChildTaskRunNames 0}}"
+                },
+                {
+                    "content": "eyJzdGF0dXMiOiJTdWNjZWVkZWQifQ==",
+                    "mediaType": "application/json",
+                    "name": "taskRunStatus/{{index .ChildTaskRunNames 1}}"
+                },
+                {
+                    "content": "eyJzdGF0dXMiOiJTdWNjZWVkZWQifQ==",
+                    "mediaType": "application/json",
+                    "name": "taskRunStatus/{{index .ChildTaskRunNames 2}}"
                 }
             ],
             "metadata": {


### PR DESCRIPTION
# Changes

SLSA v1.0 provenance currently lacks information about TaskRun execution outcomes. This is problematic because a PipelineRun can succeed even when individual TaskRuns fail, if the task definition uses 'onError: continue'. See:
https://tekton.dev/docs/pipelines/pipelines/#using-the-onerror-field

This commit adds TaskRun execution status as byproducts in SLSA v1.0 attestations. Each TaskRun's status ("Succeeded", "Failed", or "Running") is included as a ResourceDescriptor with:
- Name: taskRunStatus/<taskname>
- Content: Base64-encoded JSON {"status": "<status>"}
- MediaType: application/json

The status is placed in runDetails.byproducts rather than in the buildDefinition, since:
1. Task definitions in buildDefinition.externalParameters.runSpec represent the pipeline specification (what was requested), not execution results
2. The SLSA v1.0 spec designates byproducts for "additional artifacts generated during the build...useful for debugging and incident response"
3. This approach avoids modifying the standard PipelineTask structure from github.com/tektoncd/pipeline/pkg/apis/pipeline/v1

Status byproducts are only included when deep inspection is enabled.

Fixes: https://github.com/tektoncd/chains/issues/1466

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```