### PR TITLE
feat: add retest workflow using plumbing reusable workflow

### DIFF
--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -1,0 +1,14 @@
+name: Rerun Failed Actions
+
+permissions:
+  contents: read
+
+on:
+  repository_dispatch:
+    types: [retest-command]
+
+jobs:
+  retest:
+    name: Rerun Failed Actions
+    uses: tektoncd/plumbing/.github/workflows/_chatops_retest.yml@c9d6729a374829a3486b3b4a3c7c67d8b0926f04
+    secrets: inherit

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -1,0 +1,17 @@
+name: Slash Command Routing
+
+permissions:
+  contents: read
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check_comments:
+    if: ${{ github.event.issue.pull_request }}
+    permissions:
+      issues: write # for peter-evans/slash-command-dispatch to create issue reaction
+      pull-requests: write # for peter-evans/slash-command-dispatch to create PR reaction
+    uses: tektoncd/plumbing/.github/workflows/_slash.yml@48c53b4e7f1e0bb206575b80eb9fcf07b5854907
+    secrets: inherit


### PR DESCRIPTION
This adds the chatops_retest.yaml workflow to enable the /retest command for retrying failed GitHub Actions checks on pull requests.

The workflow uses the centralized reusable workflow from:
`tektoncd/plumbing/.github/workflows/_chatops_retest.yml@c9d6729a374829a3486b3b4a3c7c67d8b0926f04`

This also adds the slash.yml workflow for slash command routing.

Note: This PR adds slash.yml which may conflict with the cherry-pick PR. The delegating version used here will support both commands once merged.

Related to tektoncd/plumbing#3005

/kind misc