### PR TITLE
chore: improve release cheat sheet structure

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -1,170 +1,169 @@
 # Tekton Chains Official Release Cheat Sheet
 
-Follow these steps to perform an official release of Tekton Chains! To follow
-these steps you'll need a checkout of the chains repo, a terminal window and a
-text editor.
+These steps provide a no-frills guide to performing an official release
+of Tekton Chains. To follow these steps you'll need a checkout of
+the chains repo, a terminal window and a text editor.
 
-1. [Setup a context to connect to the dogfooding cluster](#setup-dogfooding-context)
-   if you haven't already.
+1. [Setup a context to connect to the dogfooding cluster](#setup-dogfooding-context) if you haven't already.
 
-1. `cd` to the root of the chains repo
+1. Install the [rekor CLI](https://docs.sigstore.dev/rekor/installation/) if you haven't already.
 
-1. Apply release Tekton resources
+1. `cd` to root of Chains git checkout.
 
-   - [`chains-release`](release-pipeline.yaml) - This is the pipeline that
-     stitches everything together.
+1. Select the commit you would like to build the release from (NOTE: the commit is full (40-digit) hash.)
+    - Select the most recent commit on the ***main branch*** if you are cutting a major or minor release i.e. `x.0.0` or `0.x.0`
+    - Select the most recent commit on the ***`release-<version number>x` branch***, e.g. [`release-v0.26.x`](https://github.com/tektoncd/chains/tree/release-v0.26.x) if you are patching a release i.e. `v0.26.2`.
 
-     ```sh
-     kubectl apply -f release/release-pipeline.yaml
-     ```
+1. Ensure the correct version of the release pipeline is installed on the cluster.
+   To do that, the selected commit should be checked-out locally
 
-1. Select the commit you would like to build the release from, most likely the
-   most recent commit at https://github.com/tektoncd/chains/commits/main and
-   note the commit's hash.
+    ```bash
+    kubectl --context dogfooding apply -f release/release-pipeline.yaml
+    ```
 
-1. Create environment variables for bash scripts in later steps.
+1. Create a `release.env` file with environment variables for bash scripts in later steps, and source it:
 
-   ```bash
-   CHAINS_VERSION_TAG=# UPDATE THIS. Example: v0.6.2
-   CHAINS_RELEASE_GIT_SHA=# SHA of the release to be released
-   ```
+    ```bash
+    cat <<EOF > release.env
+    CHAINS_VERSION_TAG= # Example: v0.6.2
+    CHAINS_RELEASE_GIT_SHA= # SHA of the release to be released, e.g. 5b082b1106753e093593d12152c82e1c4b0f37e5
+    CHAINS_OLD_VERSION= # Example: v0.5.0
+    CHAINS_PACKAGE=tektoncd/chains
+    EOF
+    . ./release.env
+    ```
 
 1. Confirm commit SHA matches what you want to release.
 
-   ```bash
-   git show $CHAINS_RELEASE_GIT_SHA
-   ```
+    ```bash
+    git show $CHAINS_RELEASE_GIT_SHA
+    ```
 
 1. Create a workspace template file:
 
    ```bash
-     cat <<EOF > workspace-template.yaml
-     spec:
-       accessModes:
-       - ReadWriteOnce
-       resources:
-         requests:
-           storage: 1Gi
+   WORKSPACE_TEMPLATE=$(mktemp /tmp/workspace-template.XXXXXX.yaml)
+   cat <<'EOF' > $WORKSPACE_TEMPLATE
+   spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
    EOF
    ```
 
-1. Decide if new release will be latest release.
+1. Execute the release pipeline (takes ~45 mins).
+    
+    **The minimum required tkn version is v0.30.0 or later**
+
+    **If you are back-porting include this flag: `--param=releaseAsLatest="false"`**
 
    ```bash
-   CHAINS_LATEST_RELEASE='true' # Set to 'false' if not latest release
-
+    tkn --context dogfooding pipeline start chains-release \
+      --param=gitRevision="${CHAINS_RELEASE_GIT_SHA}" \
+      --param=versionTag="${CHAINS_VERSION_TAG}" \
+      --param=serviceAccountImagesPath=credentials \
+      --param=releaseBucket=tekton-releases \
+      --param=releaseAsLatest="true" \
+      --workspace name=release-secret,secret=oci-release-secret \
+      --workspace name=release-images-secret,secret=ghcr-creds \
+      --use-param-defaults \
+      --workspace name=workarea,volumeClaimTemplateFile="${WORKSPACE_TEMPLATE}" \
+      --tasks-timeout 2h \
+      --pipeline-timeout 3h
    ```
 
-1. Execute the release pipeline.
-
-   ```bash
-   tkn --context dogfooding pipeline start chains-release \
-     --param=gitRevision="${CHAINS_RELEASE_GIT_SHA}" \
-     --param=versionTag="${CHAINS_VERSION_TAG}" \
-     --param=serviceAccountPath=release.json \
-     --param=serviceAccountImagesPath=credentials \
-     --param=releaseBucket=gs://tekton-releases/chains \
-     --param=releaseAsLatest="${CHAINS_LATEST_RELEASE}" \
-     --workspace name=release-secret,secret=release-secret \
-     --workspace name=release-images-secret,secret=ghcr-creds \
-     --use-param-defaults \
-     --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml
-   ```
+    Accept the default values of the parameters (except for "releaseAsLatest" if backporting).
 
 1. Watch logs of chains-release.
 
-1. Once the pipeline run is complete, check its results:
+1. Once the pipeline is complete, check its results:
 
-   ```bash
-   tkn --context dogfooding pr describe <pipeline-run-name>
+    ```bash
+    tkn --context dogfooding pr describe <pipeline-run-name>
 
-   (...)
-   📝 Results
+    (...)
+    📝 Results
 
-   NAME                    VALUE
-   commit-sha                 420adfcdf225326605f2b2c2264b42a2f7b86e4e
-   release-file               https://infra.tekton.dev/tekton-releases/chains/previous/v0.13.0/release.yaml
-   release-file-no-tag        https://infra.tekton.dev/tekton-releases/chains/previous/v0.13.0/release.notag.yaml
+    NAME                    VALUE
+    ∙ commit-sha            420adfcdf225326605f2b2c2264b42a2f7b86e4e
+    ∙ release-file           https://infra.tekton.dev/tekton-releases/chains/previous/v0.13.0/release.yaml
+    ∙ release-file-no-tag    https://infra.tekton.dev/tekton-releases/chains/previous/v0.13.0/release.notag.yaml
 
-   (...)
-   ```
+    (...)
+    ```
 
-   The `commit-sha` should match `$CHAINS_RELEASE_GIT_SHA`. The two URLs can be
-   opened in the browser or via `curl` to download the release manifests.
+    The `commit-sha` should match `$CHAINS_RELEASE_GIT_SHA`.
+    The two URLs can be opened in the browser or via `curl` to download the release manifests.
 
-   1. The YAMLs are now released! Anyone installing Tekton Chains will now get
-      the new version. Time to create a new GitHub release announcement:
+1. The YAMLs are now released! Anyone installing Tekton Chains will get the new version. Time to create a new GitHub release announcement:
 
-   1. Find the Rekor UUID for the release
+    1. Find the Rekor UUID for the release
 
-      ```bash
-      RELEASE_FILE=https://infra.tekton.dev/tekton-releases/chains/previous/${CHAINS_VERSION_TAG}/release.yaml
-      CONTROLLER_IMAGE_SHA=$(curl $RELEASE_FILE | egrep 'ghcr.io.*controller' | cut -d'@' -f2)
-      REKOR_UUID=$(rekor-cli search --sha $CONTROLLER_IMAGE_SHA | grep -v Found | head -1)
-      echo -e "CONTROLLER_IMAGE_SHA: ${CONTROLLER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
-      ```
+    ```bash
+    RELEASE_FILE=https://infra.tekton.dev/tekton-releases/chains/previous/${CHAINS_VERSION_TAG}/release.yaml
+    CONTROLLER_IMAGE_SHA=$(curl -L $RELEASE_FILE | egrep 'ghcr.io.*controller' | cut -d'@' -f2)
+    REKOR_UUID=$(rekor-cli search --sha $CONTROLLER_IMAGE_SHA | grep -v Found | head -1)
+    echo -e "CONTROLLER_IMAGE_SHA: ${CONTROLLER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
+    ```
 
-   1. Create additional environment variables
+    1. Execute the Draft Release Pipeline.
 
-      ```bash
-      CHAINS_OLD_VERSION=# Example: v0.11.1
-      CHAINS_RELEASE_NAME=$CHAINS_VERSION_TAG
-      CHAINS_PACKAGE=tektoncd/chains
-      ```
+        ```bash
+        tkn --context dogfooding pipeline start \
+          --workspace name=shared,volumeClaimTemplateFile="${WORKSPACE_TEMPLATE}" \
+          --workspace name=credentials,secret=oci-release-secret \
+          -p package="${CHAINS_PACKAGE}" \
+          -p git-revision="$CHAINS_RELEASE_GIT_SHA" \
+          -p release-tag="${CHAINS_VERSION_TAG}" \
+          -p previous-release-tag="${CHAINS_OLD_VERSION}" \
+          -p release-name="${CHAINS_VERSION_TAG}" \
+          -p bucket="tekton-releases" \
+          -p rekor-uuid="$REKOR_UUID" \
+          release-draft
+        ```
 
-   1. Execute the Draft Release task.
+    1. Watch logs of resulting pipeline run on pipeline `release-draft`
 
-      ```bash
-      tkn --context dogfooding pipeline start \
-        --workspace name=shared,volumeClaimTemplateFile=workspace-template.yaml \
-        --workspace name=credentials,secret=release-secret \
-        -p package="${CHAINS_PACKAGE}" \
-        -p git-revision="$CHAINS_RELEASE_GIT_SHA" \
-        -p release-tag="${CHAINS_VERSION_TAG}" \
-        -p previous-release-tag="${CHAINS_OLD_VERSION}" \
-        -p release-name="${CHAINS_RELEASE_NAME}" \
-        -p bucket="gs://tekton-releases/chains" \
-        -p rekor-uuid="$REKOR_UUID" \
-        release-draft
-      ```
-
-   1. Watch logs of create-draft-release
-
-   1. On successful completion, a URL will be logged. Visit that URL and look
-      through the release notes.
-
-      1. Manually add upgrade and deprecation notices based on the generated
-         release notes
+    1. On successful completion, a URL will be logged. Visit that URL and look through the release notes.
+      1. Manually add upgrade and deprecation notices based on the generated release notes
       1. Double-check that the list of commits here matches your expectations
-         for the release. You might need to remove incorrect commits or
-         copy/paste commits from the release branch. Refer to previous releases
-         to confirm the expected format.
+         for the release. You might need to remove incorrect commits or copy/paste commits
+         from the release branch. Refer to previous releases to confirm the expected format.
 
-   1. Un-check the "This is a pre-release" checkbox since you're making a legit
-      for-reals release!
+    1. Un-check the "This is a pre-release" checkbox since you're making a legit for-reals release!
 
-   1. Publish the GitHub release once all notes are correct and in order.
+    1. Publish the GitHub release once all notes are correct and in order.
 
-1. Create a branch for the release named `release-<version number>x`, e.g.
-   `release-v0.28.x` and push it to the repo https://github.com/tektoncd/chains.
-   Make sure to fetch the commit specified in `$CHAINS_RELEASE_GIT_SHA` to
-   create the released branch.
+1. Create a branch for the release named `release-<version number>x`, e.g. [`release-v0.26.x`](https://github.com/tektoncd/chains/tree/release-v0.26.x)
+   and push it to the repo https://github.com/tektoncd/chains.
+   (This can be done on the Github UI.)
+   Make sure to fetch the commit specified in `CHAINS_RELEASE_GIT_SHA` to create the released branch.
+   > Background: The reason why we need to create a branch for the release named `release-<version number>x` is for future patch releases. Cherrypicked PRs for the patch release will be merged to this branch. For example, [v0.26.0](https://github.com/tektoncd/chains/releases/tag/v0.26.0) has been already released, but later on we found that an important PR should have been included to that release. Therefore, we need to do a patch release i.e. v0.26.1 by cherrypicking this PR, which will trigger tekton-robot to create a new PR to merge the changes to the [release-v0.26.x branch](https://github.com/tektoncd/chains/tree/release-v0.26.x).
 
-1. Test release that you just made against your own cluster (note
-   `--context my-dev-cluster`):
+1. Edit `releases.md` on the `main` branch, add an entry for the release.
+   - In case of a patch release, replace the latest release with the new one,
+     including links to docs and examples. Append the new release to the list
+     of patch releases as well.
+   - In case of a minor or major release, add a new entry for the
+     release, including links to docs and example
+   - Check if any release is EOL, if so move it to the "End of Life Releases"
+     section
 
-   ```bash
-   # Test latest
-   kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/chains/latest/release.yaml
-   ```
+1. Push & make PR for updated `releases.md`
 
-   ```bash
-   # Test backport
-   kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/chains/previous/$CHAINS_VERSION_TAG/release.yaml
-   ```
+1. Test release that you just made against your own cluster (note `--context my-dev-cluster`):
 
-1. Update releases page at
-   [releases/.md](https://github.com/tektoncd/chains/blob/main/releases.md)
+    ```bash
+    # Test latest
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/chains/latest/release.yaml
+    ```
+
+    ```bash
+    # Test backport
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/chains/previous/$CHAINS_VERSION_TAG/release.yaml
+    ```
 
 1. Announce the release in Slack channels #general, #chains and #announcements.
 
@@ -175,20 +174,58 @@ Congratulations, you're done!
 1. Configure `kubectl` to connect to
    [the dogfooding cluster](https://github.com/tektoncd/plumbing/blob/main/docs/dogfooding.md):
 
-   ```bash
-   gcloud container clusters get-credentials dogfooding --zone us-central1-a --project tekton-releases
-   ```
+   The dogfooding cluster is currently an OKE cluster in oracle cloud. we need the Oracle Cloud CLI client. Install oracle cloud cli (https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm) 
 
-1. Give
-   [the context](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
+    ```bash
+    oci ce cluster create-kubeconfig --cluster-id <CLUSTER-OCID> --file $HOME/.kube/config --region <CLUSTER-REGION> --token-version 2.0.0  --kube-endpoint PUBLIC_ENDPOINT
+    ```
+
+1. Give [the context](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
    a short memorable name such as `dogfooding`:
 
    ```bash
-   kubectl config rename-context gke_tekton-releases_us-central1-a_dogfooding dogfooding
+   kubectl config current-context
+   ```
+   get the context name and replace with current_context_name
+
+   ```bash
+   kubectl config rename-context <current_context_name> dogfooding
    ```
 
-## Important: Switch `kubectl` back to your own cluster by default.
+1. **Important: Switch `kubectl` back to your own cluster by default.**
 
-```bash
+    ```bash
     kubectl config use-context my-dev-cluster
+    ```
+
+## Cherry-picking commits for patch releases
+
+The easiest way to cherry-pick a commit into a release branch is to use the "cherrypicker" plugin (see https://prow.tekton.dev/plugins for documentation).
+To use the plugin, comment "/cherry-pick <branch-to-cherry-pick-onto>" on the pull request containing the commits that need to be cherry-picked.
+Make sure this command is on its own line, and use one comment per branch that you're cherry-picking onto.
+Automation will create a pull request cherry-picking the commits into the named branch, e.g. `release-v0.26.x`.
+
+The cherrypicker plugin isn't able to resolve merge conflicts. If there are merge conflicts, you'll have to manually cherry-pick following these steps:
+1. Fetch the branch you're backporting to and check it out:
+```sh
+git fetch upstream <branchname>
+git checkout upstream/<branchname>
 ```
+1. (Optional) Rename the local branch to make it easier to work with:
+```sh
+git switch -c <new-name-for-local-branch>
+```
+1. Find the 40-character commit hash to cherry-pick. Note: automation creates a new commit when merging contributors' commits into main.
+You'll need to use the hash of the commit created by tekton-robot.
+
+1. [Cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commit onto the branch:
+```sh
+git cherry-pick <commit-hash>
+```
+1. Resolve any merge conflicts.
+1. Finish the cherry-pick:
+```sh
+git add <changed-files>
+git cherry-pick --continue
+```
+1. Push your changes to your fork and open a pull request against the upstream branch.

--- a/release/release-pipeline.yaml
+++ b/release/release-pipeline.yaml
@@ -14,7 +14,7 @@
 
 # Modified for chains from tekton triggers: https://github.com/tektoncd/triggers/blob/main/tekton/release-pipeline.yaml
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: chains-release
@@ -22,275 +22,284 @@ metadata:
     chains.tekton.dev/transparency-upload: "true"
 spec:
   params:
-  - name: package
-    description: package to release
-    default: github.com/tektoncd/chains
-  - name: gitRevision
-    description: the git revision to release
-  - name: imageRegistry
-    description: The target image registry
-    default: ghcr.io
-  - name: imageRegistryPath
-    description: The path (project) in the image registry
-    default: tektoncd/chains
-  - name: imageRegistryRegions
-    description: The target image registry regions
-    default: ""
-  - name: imageRegistryUser
-    description: The user for the image registry credentials
-    default: tekton-robot
-  - name: versionTag
-    description: The X.Y.Z version that the artifacts should be tagged with
-  - name: releaseBucket
-    description: bucket where the release is stored. The bucket must be project specific.
-    default: gs://tekton-releases/chains
-  - name: releaseAsLatest
-    description: Whether to tag and publish this release as chains' latest
-    default: "true"
-  - name: platforms
-    description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
-    default: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-  - name: koExtraArgs
-    description: Extra args to be passed to ko
-    default: ""
-  - name: serviceAccountPath
-    description: The path to the service account file within the release-secret workspace
-  - name: serviceAccountImagesPath
-    description: The path to the service account file or credentials within the release-images-secret workspace
-  - name: runTests
-    description: If set to something other than "true", skip the build and test tasks
-    default: "true"
-  workspaces:
-  - name: workarea
-    description: The workspace where the repo will be cloned.
-  - name: release-secret
-    description: The secret that contains a service account authorized to push to the output bucket
-  - name: release-images-secret
-    description: The secret that contains a service account authorized to push to the imageRegistry
-  results:
-  - name: commit-sha
-    description: the sha of the commit that was released
-    value: $(tasks.git-clone.results.commit)
-  - name: release-file
-    description: the URL of the release file
-    value: $(tasks.report-bucket.results.release)
-  - name: release-file-no-tag
-    description: the URL of the release file
-    value: $(tasks.report-bucket.results.release-no-tag)
-  tasks:
-  - name: git-clone
-    taskRef:
-      resolver: hub
-      params:
-        - name: name
-          value: git-clone
-        - name: version
-          value: "0.7"
-    workspaces:
-    - name: output
-      workspace: workarea
-      subPath: git
-    params:
-    - name: url
-      value: https://$(params.package)
-    - name: revision
-      value: $(params.gitRevision)
-  - name: precheck
-    runAfter: [git-clone]
-    taskRef:
-      resolver: git
-      params:
-        - name: repo
-          value: plumbing
-        - name: org
-          value: tektoncd
-        - name: revision
-          value: aeed19e5a36f335ebfdc4b96fa78d1ce5bb4f7b8
-        - name: pathInRepo
-          value: tekton/resources/release/base/prerelease_checks.yaml
-    params:
     - name: package
-      value: $(params.package)
+      description: package to release
+      default: github.com/tektoncd/chains
+    - name: gitRevision
+      description: the git revision to release
+    - name: imageRegistry
+      description: The target image registry
+      default: ghcr.io
+    - name: imageRegistryPath
+      description: The path (project) in the image registry
+      default: tektoncd/chains
+    - name: imageRegistryRegions
+      description: The target image registry regions
+      default: ""
+    - name: imageRegistryUser
+      description: The user for the image registry credentials
+      default: tekton-robot
     - name: versionTag
-      value: $(params.versionTag)
+      description: The X.Y.Z version that the artifacts should be tagged with
     - name: releaseBucket
-      value: $(params.releaseBucket)
-    workspaces:
-    - name: source-to-release
-      workspace: workarea
-      subPath: git
-  - name: unit-tests
-    runAfter: [precheck]
-    when:
-      - cel: "'$(params.runTests)' == 'true'"
-    taskRef:
-      resolver: bundles
+      description: bucket where the release is stored. The bucket must be project specific.
+      default: tekton-releases
+    - name: releaseAsLatest
+      description: Whether to tag and publish this release as chains' latest
+      default: "true"
+    - name: platforms
+      description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
+      default: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+    - name: koExtraArgs
+      description: Extra args to be passed to ko
+      default: ""
+    - name: serviceAccountImagesPath
+      description: The path to the service account file or credentials within the release-images-secret workspace
+    - name: runTests
+      description: If set to something other than "true", skip the build and test tasks
+      default: "true"
+  workspaces:
+    - name: workarea
+      description: The workspace where the repo will be cloned.
+    - name: release-secret
+      description: The secret that contains auth credentials to push to the output bucket
+    - name: release-images-secret
+      description: The secret that contains a service account authorized to push to the imageRegistry
+  results:
+    - name: commit-sha
+      description: the sha of the commit that was released
+      value: $(tasks.git-clone.results.commit)
+    - name: release-file
+      description: the URL of the release file
+      value: $(tasks.report-bucket.results.release)
+    - name: release-file-no-tag
+      description: the URL of the release file
+      value: $(tasks.report-bucket.results.release-no-tag)
+  tasks:
+    - name: git-clone
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+          - name: name
+            value: git-clone
+          - name: kind
+            value: task
+      workspaces:
+        - name: output
+          workspace: workarea
+          subPath: git
       params:
-        - name: bundle
-          value: ghcr.io/tektoncd/catalog/upstream/tasks/golang-test:0.2
-        - name: name
-          value: golang-test
-        - name: kind
-          value: task
-    params:
-    - name: package
-      value: $(params.package)
-    - name: flags
-      value: -v -mod=vendor
-    workspaces:
-    - name: source
-      workspace: workarea
-      subPath: git
-  - name: build
-    runAfter: [precheck]
-    when:
-      - cel: "'$(params.runTests)' == 'true'"
-    taskRef:
-      resolver: bundles
-      params:
-        - name: bundle
-          value: ghcr.io/tektoncd/catalog/upstream/tasks/golang-build:0.3
-        - name: name
-          value: golang-build
-        - name: kind
-          value: task
-    params:
-    - name: package
-      value: $(params.package)
-    - name: packages
-      value: ./cmd/...
-    workspaces:
-    - name: source
-      workspace: workarea
-      subPath: git
-  - name: publish-images
-    runAfter: [build, unit-tests]
-    taskRef:
-      resolver: git
-      params:
-        - name: repo
-          value: chains
-        - name: org
-          value: tektoncd
+        - name: url
+          value: https://$(params.package)
         - name: revision
           value: $(params.gitRevision)
-        - name: pathInRepo
-          value: release/publish.yaml
-    params:
-    - name: package
-      value: $(params.package)
-    - name: versionTag
-      value: $(params.versionTag)
-    - name: imageRegistry
-      value: $(params.imageRegistry)
-    - name: imageRegistryPath
-      value: $(params.imageRegistryPath)
-    - name: imageRegistryUser
-      value: $(params.imageRegistryUser)
-    - name: imageRegistryRegions
-      value: $(params.imageRegistryRegions)
-    - name: releaseAsLatest
-      value: $(params.releaseAsLatest)
-    - name: serviceAccountPath
-      value: $(params.serviceAccountImagesPath)
-    - name: platforms
-      value: $(params.platforms)
-    - name: koExtraArgs
-      value: $(params.koExtraArgs)
-    - name: CHAINS-GIT_COMMIT
-      value: $(tasks.git-clone.results.commit)
-    - name: CHAINS-GIT_URL
-      value: https://$(params.package)
-    workspaces:
-    - name: source
-      workspace: workarea
-      subPath: git
-    - name: output
-      workspace: workarea
-      subPath: bucket
-    - name: release-secret
-      workspace: release-images-secret
-  - name: publish-to-bucket
-    runAfter: [publish-images]
-    taskRef:
-      resolver: bundles
+    - name: precheck
+      runAfter: [git-clone]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/plumbing
+          - name: revision
+            value: 8d3152d3d39982ce1768325b373d321efaa83031
+          - name: pathInRepo
+            value: tekton/resources/release/base/prerelease_checks_oci.yaml
       params:
-        - name: bundle
-          value: ghcr.io/tektoncd/catalog/upstream/tasks/gcs-upload:0.3
-        - name: name
-          value: gcs-upload
-        - name: kind
-          value: task
-    workspaces:
-    - name: credentials
-      workspace: release-secret
-    - name: source
-      workspace: workarea
-      subPath: bucket
-    params:
-    - name: location
-      value: $(params.releaseBucket)/previous/$(params.versionTag)
-    - name: path
-      value: $(params.versionTag)
-    - name: serviceAccountPath
-      value: $(params.serviceAccountPath)
-  - name: publish-to-bucket-latest
-    runAfter: [publish-images]
-    when:
-    - input: "$(params.releaseAsLatest)"
-      operator: in
-      values: ["true"]
-    taskRef:
-      resolver: bundles
+        - name: package
+          value: $(params.package)
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: releaseBucket
+          value: $(params.releaseBucket)/chains
+      workspaces:
+        - name: source-to-release
+          workspace: workarea
+          subPath: git
+        - name: oci-credentials
+          workspace: release-secret
+    - name: unit-tests
+      runAfter: [precheck]
+      when:
+        - cel: "'$(params.runTests)' == 'true'"
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/golang-test:0.2
+          - name: name
+            value: golang-test
+          - name: kind
+            value: task
       params:
-        - name: bundle
-          value: ghcr.io/tektoncd/catalog/upstream/tasks/gcs-upload:0.3
-        - name: name
-          value: gcs-upload
-        - name: kind
-          value: task
-    workspaces:
-    - name: credentials
-      workspace: release-secret
-    - name: source
-      workspace: workarea
-      subPath: bucket
-    params:
-    - name: location
-      value: $(params.releaseBucket)/latest
-    - name: path
-      value: $(params.versionTag)
-    - name: serviceAccountPath
-      value: $(params.serviceAccountPath)
-    - name: deleteExtraFiles
-      value: "true"  # Uses rsync to copy content into latest
-  - name: report-bucket
-    runAfter: [publish-to-bucket]
-    params:
-    - name: releaseBucket
-      value: $(params.releaseBucket)
-    - name: versionTag
-      value: $(params.versionTag)
-    taskSpec:
+        - name: package
+          value: $(params.package)
+        - name: flags
+          value: -v -mod=vendor
+      workspaces:
+        - name: source
+          workspace: workarea
+          subPath: git
+    - name: build
+      runAfter: [precheck]
+      when:
+        - cel: "'$(params.runTests)' == 'true'"
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/golang-build:0.3
+          - name: name
+            value: golang-build
+          - name: kind
+            value: task
       params:
-      - name: releaseBucket
-      - name: versionTag
-      results:
-      - name: release
-        description: The full URL of the main release file in the bucket
-      - name: release-no-tag
-        description: The full URL of the main release file (no tag) in the bucket
-      steps:
-      - name: create-results
-        image: docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
-        env:
-          - name: RELEASE_BUCKET
-            value: $(params.releaseBucket)
-          - name: VERSION_TAG
-            value: $(params.versionTag)
-        script: |
-          BASE_URL=$(echo "${RELEASE_BUCKET}/previous/${VERSION_TAG}")
-          # If the bucket is in the gs:// return the corresponding public https URL
-          BASE_URL=$(echo ${BASE_URL} | sed 's,gs://,https://storage.googleapis.com/,g')
-          echo "${BASE_URL}/release.yaml" > $(results.release.path)
-          echo "${BASE_URL}/release.notag.yaml" > $(results.release-no-tag.path)
+        - name: package
+          value: $(params.package)
+        - name: packages
+          value: ./cmd/...
+      workspaces:
+        - name: source
+          workspace: workarea
+          subPath: git
+    - name: publish-images
+      runAfter: [build, unit-tests]
+      taskRef:
+        resolver: git
+        params:
+          - name: repo
+            value: chains
+          - name: org
+            value: tektoncd
+          - name: revision
+            value: $(params.gitRevision)
+          - name: pathInRepo
+            value: release/publish.yaml
+      params:
+        - name: package
+          value: $(params.package)
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: imageRegistry
+          value: $(params.imageRegistry)
+        - name: imageRegistryPath
+          value: $(params.imageRegistryPath)
+        - name: imageRegistryUser
+          value: $(params.imageRegistryUser)
+        - name: imageRegistryRegions
+          value: $(params.imageRegistryRegions)
+        - name: releaseAsLatest
+          value: $(params.releaseAsLatest)
+        - name: serviceAccountPath
+          value: $(params.serviceAccountImagesPath)
+        - name: platforms
+          value: $(params.platforms)
+        - name: koExtraArgs
+          value: $(params.koExtraArgs)
+        - name: CHAINS-GIT_COMMIT
+          value: $(tasks.git-clone.results.commit)
+        - name: CHAINS-GIT_URL
+          value: https://$(params.package)
+      workspaces:
+        - name: source
+          workspace: workarea
+          subPath: git
+        - name: output
+          workspace: workarea
+          subPath: bucket
+        - name: release-secret
+          workspace: release-images-secret
+    - name: publish-to-bucket
+      runAfter: [publish-images]
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
+          - name: name
+            value: oracle-cloud-storage-upload
+          - name: kind
+            value: task
+      workspaces:
+        - name: credentials
+          workspace: release-secret
+        - name: source
+          workspace: workarea
+          subPath: bucket
+      params:
+        - name: path
+          value: $(params.versionTag)
+        - name: bucketName
+          value: $(params.releaseBucket)
+        - name: objectPrefix
+          value: chains/previous/$(params.versionTag)/
+        - name: replaceExistingFiles
+          value: "true"
+        - name: recursive
+          value: "true"
+    - name: publish-to-bucket-latest
+      runAfter: [publish-images]
+      when:
+        - input: "$(params.releaseAsLatest)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
+          - name: name
+            value: oracle-cloud-storage-upload
+          - name: kind
+            value: task
+      workspaces:
+        - name: credentials
+          workspace: release-secret
+        - name: source
+          workspace: workarea
+          subPath: bucket
+      params:
+        - name: path
+          value: $(params.versionTag)
+        - name: bucketName
+          value: $(params.releaseBucket)
+        - name: objectPrefix
+          value: chains/latest/
+        - name: replaceExistingFiles
+          value: "true"
+        - name: recursive
+          value: "true"
+        - name: deleteExtraFiles
+          value: "true" # Uses sync to copy content into latest
+    - name: report-bucket
+      runAfter: [publish-to-bucket]
+      params:
+        - name: releaseBucket
+          value: $(params.releaseBucket)
+        - name: versionTag
+          value: $(params.versionTag)
+      taskSpec:
+        params:
+          - name: releaseBucket
+          - name: versionTag
+        results:
+          - name: release
+            description: The full URL of the release file in the bucket
+          - name: release-no-tag
+            description: The full URL of the release file (no tag) in the bucket
+        steps:
+          - name: create-results
+            image: docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
+            env:
+              - name: RELEASE_BUCKET
+                value: $(params.releaseBucket)
+              - name: VERSION_TAG
+                value: $(params.versionTag)
+            script: |
+              # Oracle Cloud Storage: Construct public URL
+              # Format: https://infra.tekton.dev/<releaseBucket>/chains/previous/<versionTag>
+              BASE_URL="https://infra.tekton.dev/${RELEASE_BUCKET}/chains/previous/${VERSION_TAG}"
+
+              echo "${BASE_URL}/release.yaml" > $(results.release.path)
+              echo "${BASE_URL}/release.notag.yaml" > $(results.release-no-tag.path)


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This change updates the Chains release cheat sheet (release/README.md) to align with the structure used in the Tekton Pipeline project's release documentation, while preserving all Chains-specific details. And release-pipeline to point to OCI.
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
