### PR TITLE
chore: replace gcs storage path with infra.tekton.dev

### DIFF
--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -27,7 +27,7 @@ jobs:
       KO_DOCKER_REPO: registry.local:5000/knative
       KOCACHE: ~/ko
       SIGSTORE_SCAFFOLDING_RELEASE_VERSION: "v0.7.24"
-      TEKTON_PIPELINES_RELEASE: "https://storage.googleapis.com/tekton-releases/pipeline/previous/${{ inputs.pipelines-release }}/release.yaml"
+      TEKTON_PIPELINES_RELEASE: "https://infra.tekton.dev/tekton-releases/pipeline/previous/${{ inputs.pipelines-release }}/release.yaml"
       # Note that we do not include the v prefix here so we can use it in all
       # the places this is used.
       SKIP_INITIALIZE: true

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ installed on your cluster before you install Chains.
 To install the latest version of Chains to your Kubernetes cluster, run:
 
 ```shell
-kubectl apply --filename https://storage.googleapis.com/tekton-releases/chains/latest/release.yaml
+kubectl apply --filename https://infra.tekton.dev/tekton-releases/chains/latest/release.yaml
 ```
 
 To install a specific version of Chains, run:
 
 ```shell
-kubectl apply -f https://storage.googleapis.com/tekton-releases/chains/previous/${VERSION}/release.yaml
+kubectl apply -f https://infra.tekton.dev/tekton-releases/chains/previous/${VERSION}/release.yaml
 ```
 
 To verify that installation was successful, wait until all Pods have Status

--- a/docs/tutorials/provenance-storage-gcs-tutorial.md
+++ b/docs/tutorials/provenance-storage-gcs-tutorial.md
@@ -57,8 +57,8 @@ kind create cluster -n tekton
 
 4. Install **Tekton Pipelines** and **Tekton Chains**
 ```shell
-kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
-kubectl apply --filename https://storage.googleapis.com/tekton-releases/chains/latest/release.yaml
+kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml
+kubectl apply --filename https://infra.tekton.dev/tekton-releases/chains/latest/release.yaml
 ```
 Ensure that all pods in the `tekton-pipelines` and `tekton-chains` namespaces are running, and that the pods are in the "Running" status. Below is an example of what the pods should look like:
 

--- a/docs/vendor/gcp/slsa-2/setup.sh
+++ b/docs/vendor/gcp/slsa-2/setup.sh
@@ -128,9 +128,9 @@ kubectl annotate serviceaccount $KSA_NAME \
   iam.gke.io/gcp-service-account=$GSA_NAME@$PROJECT_ID.iam.gserviceaccount.com
 
 # install pipelines
-kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.46.0/release.yaml
+kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/previous/v0.46.0/release.yaml
 # install chains
-kubectl apply -f https://storage.googleapis.com/tekton-releases/chains/previous/v0.15.0/release.yaml
+kubectl apply -f https://infra.tekton.dev/tekton-releases/chains/previous/v0.15.0/release.yaml
 
 gcloud iam service-accounts add-iam-policy-binding $GSA_NAME@$PROJECT_ID.iam.gserviceaccount.com \
   --role "roles/iam.workloadIdentityUser" \

--- a/docs/vendor/openshift.md
+++ b/docs/vendor/openshift.md
@@ -36,7 +36,7 @@ for more information.
 1. Install Tekton Chains:
 
    ```bash
-   oc apply --filename https://storage.googleapis.com/tekton-releases/chains/latest/release.yaml
+   oc apply --filename https://infra.tekton.dev/tekton-releases/chains/latest/release.yaml
    ```
 
    See the

--- a/release/README.md
+++ b/release/README.md
@@ -83,8 +83,8 @@ text editor.
 
    NAME                    VALUE
    commit-sha                 420adfcdf225326605f2b2c2264b42a2f7b86e4e
-   release-file               https://storage.googleapis.com/tekton-releases/chains/previous/v0.13.0/release.yaml
-   release-file-no-tag        https://storage.googleapis.com/tekton-releases/chains/previous/v0.13.0/release.notag.yaml
+   release-file               https://infra.tekton.dev/tekton-releases/chains/previous/v0.13.0/release.yaml
+   release-file-no-tag        https://infra.tekton.dev/tekton-releases/chains/previous/v0.13.0/release.notag.yaml
 
    (...)
    ```
@@ -98,7 +98,7 @@ text editor.
    1. Find the Rekor UUID for the release
 
       ```bash
-      RELEASE_FILE=https://storage.googleapis.com/tekton-releases/chains/previous/${CHAINS_VERSION_TAG}/release.yaml
+      RELEASE_FILE=https://infra.tekton.dev/tekton-releases/chains/previous/${CHAINS_VERSION_TAG}/release.yaml
       CONTROLLER_IMAGE_SHA=$(curl $RELEASE_FILE | egrep 'ghcr.io.*controller' | cut -d'@' -f2)
       REKOR_UUID=$(rekor-cli search --sha $CONTROLLER_IMAGE_SHA | grep -v Found | head -1)
       echo -e "CONTROLLER_IMAGE_SHA: ${CONTROLLER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
@@ -155,12 +155,12 @@ text editor.
 
    ```bash
    # Test latest
-   kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/chains/latest/release.yaml
+   kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/chains/latest/release.yaml
    ```
 
    ```bash
    # Test backport
-   kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/chains/previous/$CHAINS_VERSION_TAG/release.yaml
+   kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/chains/previous/$CHAINS_VERSION_TAG/release.yaml
    ```
 
 1. Update releases page at

--- a/test/microshift_test.sh
+++ b/test/microshift_test.sh
@@ -141,7 +141,7 @@ function wait_until_pods_running() {
   return 1
 }
 
-curl https://storage.googleapis.com/tekton-releases/pipeline/latest/release.notags.yaml | yq 'del(.spec.template.spec.containers[]?.securityContext.runAsUser, .spec.template.spec.containers[]?.securityContext.runAsGroup)' | kubectl apply -f -
+curl https://infra.tekton.dev/tekton-releases/pipeline/latest/release.notags.yaml | yq 'del(.spec.template.spec.containers[]?.securityContext.runAsUser, .spec.template.spec.containers[]?.securityContext.runAsGroup)' | kubectl apply -f -
 
 install_chains
 


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
This pull request updates all references to Tekton release assets from the old Google Cloud Storage URLs to the new `infra.tekton.dev` domain. This ensures that installation instructions, scripts, and workflows consistently use the new, supported hosting location for Tekton Pipelines and Chains release files.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
/kind cleanup