### PR TITLE
ci: fix and modernize e2e workflow step ordering

### DIFF
--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -33,19 +33,16 @@ jobs:
       SKIP_INITIALIZE: true
 
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32  # v5.0.2
-      with:
-        go-version: 1.22.x
-
-    - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d  # v0.9
-      with:
-        version: tip
 
     - name: Check out our repo
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v4.1.7
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+    - name: Set up Go
+      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
-        path: ./src/github.com/tektoncd/chains
+        go-version-file: "go.mod"
+
+    - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
     - name: Install mirror, kind, knative + sigstore
       uses: sigstore/scaffolding/actions/setup@d40cf576f588d980142f0b8462c425d7b32f00b1  # v0.7.25
@@ -66,7 +63,6 @@ jobs:
         kubectl -n tekton-pipelines delete po -l app=tekton-pipelines-controller
 
     - name: Run integration tests
-      working-directory: ./src/github.com/tektoncd/chains
       run: |
         ./test/presubmit-tests.sh --integration-tests
 


### PR DESCRIPTION
# Changes

This PR fixes the e2e workflow step ordering and modernizes the GitHub Actions:

- Checkout code before Go setup to enable go-version-file
- Update actions to latest versions (checkout@v6.0.1, setup-go@v6.1.0)
- Remove hardcoded Go version in favor of go.mod
- Simplify checkout path and working directory configuration

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```