### PR TITLE
fix: replace hard coded go version reference with value from mod file

### DIFF
--- a/.github/workflows/goclean.yml
+++ b/.github/workflows/goclean.yml
@@ -24,12 +24,12 @@ jobs:
   goclean:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4.1.7
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
     - name: Setup Go
-      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
-        go-version: '1.22'
+        go-version-file: "go.mod"
 
     - name: go vet
       run: |


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
This pull request updates the Go workflow configurations:
* Updated the `actions/checkout` step to use version `v6.0.1` instead of `v4.1.7` aligning to the ci workflow (https://github.com/tektoncd/chains/blob/main/.github/workflows/ci.yaml#L56) 
* Changed the Go setup step to use the `go-version-file` option referencing `go.mod`, ensuring the workflow always uses the project's specified Go version instead of a hardcoded version.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
/kind misc