### PR TITLE
update golangci-lint version that supports go1.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
       if: ${{ needs.changes.outputs.non-docs == 'true' }}
       with:
-        version: v2.1.6
+        version: v2.7.2
         only-new-issues: true
         args: --timeout=10m
     - name: yamllint


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

PR https://github.com/tektoncd/chains/pull/1503 updates the project Go version to 1.25, which causes golangci-lint failures because the previously used golangci-lint version was built with Go 1.24. Support for Go 1.25 was added from golangci-lint v2.4.0 ([golangci-lint#5872)](https://github.com/golangci/golangci-lint/pull/5872), so this PR updates golangci-lint to latest version [2.7.2](https://github.com/golangci/golangci-lint/releases/tag/v2.7.2) in order to restore CI compatibility. 

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
