### PR TITLE
Handle signing OCI artifacts in *ARTIFACT_OUTPUTS

### DIFF
--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -200,6 +200,20 @@ func ExtractOCIImagesFromResults(ctx context.Context, results []objects.Result) 
 		}
 	}
 
+	// Also check structured ARTIFACT_OUTPUTS for OCI artifacts that are marked as build artifacts
+	// These are results that contain object values with "uri", "digest" and isBuildArtifact=="true"
+	for _, s := range ExtractBuildArtifactsFromResults(ctx, results) {
+		if !hasImageRequirements(*s) {
+			continue
+		}
+		dgst, err := name.NewDigest(fmt.Sprintf("%s@%s", s.URI, s.Digest))
+		if err != nil {
+			logger.Errorf("error getting digest for structured output %s@%s: %v", s.URI, s.Digest, err)
+			continue
+		}
+		objs = append(objs, dgst)
+	}
+
 	return objs
 }
 

--- a/pkg/artifacts/signable_test.go
+++ b/pkg/artifacts/signable_test.go
@@ -183,12 +183,15 @@ func TestExtractOCIImagesFromResults(t *testing.T) {
 		{Name: "img5_IMAGE_DIGEST", Value: *v1.NewStructuredValues("sha123:abc")},
 		{Name: "empty_str_IMAGE_DIGEST", Value: *v1.NewStructuredValues("")},
 		{Name: "empty_str_IMAGE_URL", Value: *v1.NewStructuredValues("")},
+		// structured ARTIFACT_OUTPUTS should also be detected as OCI images when marked as build artifacts
+		{Name: "art1-ARTIFACT_OUTPUTS", Value: v1.ParamValue{ObjectVal: map[string]string{"uri": "gcr.io/new/image", "digest": digest2, isBuildArtifactField: "true"}}},
 	}
 
 	want := []interface{}{
 		createDigest(t, fmt.Sprintf("img1@%s", digest1)),
 		createDigest(t, fmt.Sprintf("img2@%s", digest2)),
 		createDigest(t, fmt.Sprintf("img3@%s", digest1)),
+		createDigest(t, fmt.Sprintf("gcr.io/new/image@%s", digest2)),
 	}
 	ctx := logtesting.TestContextWithLogger(t)
 	got := ExtractOCIImagesFromResults(ctx, results)

--- a/pkg/chains/formats/slsa/v2alpha4/internal/pipelinerun/pipelinerun_test.go
+++ b/pkg/chains/formats/slsa/v2alpha4/internal/pipelinerun/pipelinerun_test.go
@@ -109,6 +109,12 @@ func TestGenerateAttestation(t *testing.T) {
 						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 					},
 				},
+				{
+					Name: "index.docker.io/library/abc",
+					Digest: common.DigestSet{
+						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+					},
+				},
 			},
 			expectedResolvedDependencies: []*intoto.ResourceDescriptor{
 				{
@@ -182,6 +188,12 @@ func TestGenerateAttestation(t *testing.T) {
 				},
 				{
 					Name: "test.io/test/image",
+					Digest: common.DigestSet{
+						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+					},
+				},
+				{
+					Name: "index.docker.io/library/abc",
 					Digest: common.DigestSet{
 						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 					},
@@ -312,6 +324,12 @@ func TestGenerateAttestation(t *testing.T) {
 				},
 				{
 					Name: "test.io/test/image",
+					Digest: common.DigestSet{
+						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+					},
+				},
+				{
+					Name: "index.docker.io/library/abc",
 					Digest: common.DigestSet{
 						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
 					},


### PR DESCRIPTION
# Changes

Handle signing OCI artifacts that are hinted using *ARTIFACT_OUTPUTS

Fixes #1575

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Sign OCI artifacts hinted by `*ARTIFACT_OUTPUTS` and `isbuildArtifact: true`
```
