### PR TITLE
feat: embed Rekor bundle in OCI attestation layer annotations

### DIFF
--- a/docs/sigstore.md
+++ b/docs/sigstore.md
@@ -35,6 +35,16 @@ Right now, Chains default to storing entries in the public Rekor instance
 kubectl patch configmap chains-config -n tekton-chains -p='{"data":{"transparency.url": "<YOUR URL>"}}'
 ```
 
+### Offline Verification with Rekor Bundle
+
+When transparency is enabled and the OCI storage backend is used, Chains automatically embeds the Rekor bundle (`dev.sigstore.cosign/bundle`) in the OCI attestation layer annotations. This enables offline verification of transparency log entries without querying the Rekor server.
+
+This applies to **attestations only** (in-toto / DSSE-wrapped SLSA provenance stored via `cosign verify-attestation`). OCI image signatures using the simplesigning format do not currently embed the bundle, so `cosign verify` will not find it.
+
+No additional configuration is required — the bundle is embedded automatically when `transparency.enabled` is set to `true` and attestations are stored in an OCI registry.
+
+> **Note:** If the Rekor upload fails (e.g. due to a transient network error), attestation storage still proceeds but the bundle annotation will be absent. Consumers that rely on the bundle for offline verification will silently receive an attestation without it.
+
 ## Keyless Signing Mode
 
 Chains also supports a keyless signing mode with

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	intoto "github.com/in-toto/attestation/go/v1"
+	cbundle "github.com/sigstore/cosign/v2/pkg/cosign/bundle"
 	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/annotations"
 	"github.com/tektoncd/chains/pkg/chains/formats"
@@ -142,6 +143,18 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 		// Extract all the "things" to be signed.
 		// We might have a few of each type (several binaries, or images)
 		objects := signableType.ExtractObjects(ctx, tektonObj)
+
+		// Create the Rekor client once before iterating over objects since it is
+		// stateless and config-driven.
+		var tlogClient rekorClient
+		if shouldUploadTlog(cfg, tektonObj) {
+			var err error
+			tlogClient, err = getRekor(cfg.Transparency.URL)
+			if err != nil {
+				return err
+			}
+		}
+
 		// Go through each object one at a time.
 		for _, obj := range objects {
 
@@ -186,6 +199,29 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 			}
 			measureMetrics(ctx, metrics.SignedMessagesCount, o.Recorder)
 
+			// Upload to Rekor before storage so the bundle is available for OCI attestation annotations.
+			// On upload failure, storage proceeds but the bundle annotation will be absent —
+			// consumers that rely on the bundle for offline verification will get an attestation without it.
+			var rekorBundle *cbundle.RekorBundle
+			if tlogClient != nil {
+				entry, err := tlogClient.UploadTlog(ctx, signer, signature, rawPayload, signer.Cert(), string(payloadFormat))
+				if err != nil {
+					logger.Warnf("error uploading entry to tlog: %v", err)
+					o.recordError(ctx, signableType, metrics.TlogError)
+					merr = multierror.Append(merr, err)
+				} else {
+					logger.Infof("Uploaded entry to %s with index %d", cfg.Transparency.URL, *entry.LogIndex)
+					extraAnnotations[annotations.ChainsTransparencyAnnotation] = fmt.Sprintf("%s/api/v1/log/entries?logIndex=%d", cfg.Transparency.URL, *entry.LogIndex)
+					rekorBundle = cbundle.EntryToBundle(entry)
+					if rekorBundle != nil {
+						logger.Infof("Resolved Rekor bundle for offline verification (logIndex: %d)", rekorBundle.Payload.LogIndex)
+					} else {
+						logger.Warn("Rekor entry missing verification data, skipping bundle for offline verification")
+					}
+					measureMetrics(ctx, metrics.PayloadUploadedCount, o.Recorder)
+				}
+			}
+
 			// Now store those!
 			for _, backend := range sets.List[string](signableType.StorageBackend(cfg)) {
 				b, ok := o.Backends[backend]
@@ -203,6 +239,7 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 					Cert:          signer.Cert(),
 					Chain:         signer.Chain(),
 					PayloadFormat: payloadFormat,
+					RekorBundle:   rekorBundle,
 				}
 				if err := b.StorePayload(ctx, tektonObj, rawPayload, string(signature), storageOpts); err != nil {
 					logger.Error(err)
@@ -210,24 +247,6 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 					merr = multierror.Append(merr, err)
 				} else {
 					measureMetrics(ctx, metrics.SignsStoredCount, o.Recorder)
-				}
-			}
-
-			if shouldUploadTlog(cfg, tektonObj) {
-				rekorClient, err := getRekor(cfg.Transparency.URL)
-				if err != nil {
-					return err
-				}
-
-				entry, err := rekorClient.UploadTlog(ctx, signer, signature, rawPayload, signer.Cert(), string(payloadFormat))
-				if err != nil {
-					logger.Warnf("error uploading entry to tlog: %v", err)
-					o.recordError(ctx, signableType, metrics.TlogError)
-					merr = multierror.Append(merr, err)
-				} else {
-					logger.Infof("Uploaded entry to %s with index %d", cfg.Transparency.URL, *entry.LogIndex)
-					extraAnnotations[annotations.ChainsTransparencyAnnotation] = fmt.Sprintf("%s/api/v1/log/entries?logIndex=%d", cfg.Transparency.URL, *entry.LogIndex)
-					measureMetrics(ctx, metrics.PayloadUploadedCount, o.Recorder)
 				}
 			}
 

--- a/pkg/chains/signing/iface.go
+++ b/pkg/chains/signing/iface.go
@@ -14,6 +14,7 @@ limitations under the License.
 package signing
 
 import (
+	"github.com/sigstore/cosign/v2/pkg/cosign/bundle"
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
@@ -39,6 +40,8 @@ type Bundle struct {
 	Signature []byte
 	// Cert is an optional PEM encoded x509 certificate, if one was used for signing.
 	Cert []byte
-	// Cert is an optional PEM encoded x509 certificate chain, if one was used for signing.
+	// Chain is an optional PEM encoded x509 certificate chain, if one was used for signing.
 	Chain []byte
+	// RekorBundle is an optional Rekor transparency log bundle, populated when transparency is enabled.
+	RekorBundle *bundle.RekorBundle
 }

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -40,6 +40,11 @@ import (
 	_ "github.com/tektoncd/chains/pkg/chains/formats/all"
 )
 
+const (
+	testLogID    = "test-log-id"
+	testRekorURL = "https://rekor.example.com"
+)
+
 func TestSigner_Sign(t *testing.T) {
 	// Sign does three main things:
 	// - generates payloads
@@ -334,6 +339,203 @@ func TestSigner_Transparency(t *testing.T) {
 	}
 }
 
+func TestSigner_TransparencyRekorBundle(t *testing.T) {
+	// Verify that when transparency is enabled, the Rekor bundle is passed through to storage opts.
+	tests := []struct {
+		name         string
+		cfg          *config.Config
+		getNewObject func(string) objects.TektonObject
+	}{
+		{
+			name: "taskrun with transparency enabled",
+			cfg: &config.Config{
+				Artifacts: config.ArtifactConfigs{
+					TaskRuns: config.Artifact{
+						Format:         "slsa/v1",
+						StorageBackend: sets.New[string]("mock"),
+						Signer:         "x509",
+					},
+				},
+				Transparency: config.TransparencyConfig{
+					Enabled: true,
+					URL:     testRekorURL,
+				},
+			},
+			getNewObject: func(name string) objects.TektonObject {
+				return objects.NewTaskRunObjectV1(&v1.TaskRun{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+				})
+			},
+		},
+		{
+			name: "pipelinerun with transparency enabled",
+			cfg: &config.Config{
+				Artifacts: config.ArtifactConfigs{
+					PipelineRuns: config.Artifact{
+						Format:         "slsa/v1",
+						StorageBackend: sets.New[string]("mock"),
+						Signer:         "x509",
+					},
+				},
+				Transparency: config.TransparencyConfig{
+					Enabled: true,
+					URL:     testRekorURL,
+				},
+			},
+			getNewObject: func(name string) objects.TektonObject {
+				return objects.NewPipelineRunObjectV1(&v1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rekor := &mockRekor{}
+			backend := &mockBackend{backendType: "mock"}
+			cleanup := setupMocks(rekor)
+			defer cleanup()
+
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ps := fakepipelineclient.Get(ctx)
+			ctx = config.ToContext(ctx, tt.cfg.DeepCopy())
+
+			os := &ObjectSigner{
+				Backends:          fakeAllBackends([]*mockBackend{backend}),
+				SecretPath:        "./signing/x509/testdata/",
+				Pipelineclientset: ps,
+			}
+
+			obj := tt.getNewObject("test-rekor-bundle")
+			tekton.CreateObject(t, ctx, ps, obj)
+
+			if err := os.Sign(ctx, obj); err != nil {
+				t.Fatalf("Signer.Sign() error = %v", err)
+			}
+
+			if len(rekor.entries) != 1 {
+				t.Fatalf("expected 1 transparency log entry, got %d", len(rekor.entries))
+			}
+
+			if backend.storedOpts.RekorBundle == nil {
+				t.Fatal("expected RekorBundle to be set in StorageOpts, got nil")
+			}
+
+			if string(backend.storedOpts.RekorBundle.SignedEntryTimestamp) != "signed-entry-timestamp" {
+				t.Errorf("unexpected SignedEntryTimestamp: %s", string(backend.storedOpts.RekorBundle.SignedEntryTimestamp))
+			}
+
+			if backend.storedOpts.RekorBundle.Payload.IntegratedTime != 1234567890 {
+				t.Errorf("unexpected IntegratedTime: %d", backend.storedOpts.RekorBundle.Payload.IntegratedTime)
+			}
+
+			if backend.storedOpts.RekorBundle.Payload.LogID != testLogID {
+				t.Errorf("unexpected LogID: %s", backend.storedOpts.RekorBundle.Payload.LogID)
+			}
+		})
+	}
+}
+
+func TestSigner_NilVerificationSkipsBundle(t *testing.T) {
+	// When Rekor upload succeeds but the entry has no Verification data,
+	// RekorBundle should be nil in StorageOpts (exercises the "Rekor entry
+	// missing verification data, skipping bundle" path).
+	backend := &mockBackend{backendType: "mock"}
+	rekor := &mockRekorNilVerification{}
+	cleanup := setupMocks(rekor)
+	defer cleanup()
+
+	cfg := &config.Config{
+		Artifacts: config.ArtifactConfigs{
+			TaskRuns: config.Artifact{
+				Format:         "slsa/v1",
+				StorageBackend: sets.New[string]("mock"),
+				Signer:         "x509",
+			},
+		},
+		Transparency: config.TransparencyConfig{
+			Enabled: true,
+			URL:     testRekorURL,
+		},
+	}
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ps := fakepipelineclient.Get(ctx)
+	ctx = config.ToContext(ctx, cfg.DeepCopy())
+
+	os := &ObjectSigner{
+		Backends:          fakeAllBackends([]*mockBackend{backend}),
+		SecretPath:        "./signing/x509/testdata/",
+		Pipelineclientset: ps,
+	}
+
+	obj := objects.NewTaskRunObjectV1(&v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-nil-verification"},
+	})
+	tekton.CreateObject(t, ctx, ps, obj)
+
+	if err := os.Sign(ctx, obj); err != nil {
+		t.Fatalf("Signer.Sign() error = %v", err)
+	}
+
+	if len(rekor.entries) != 1 {
+		t.Fatalf("expected 1 transparency log entry, got %d", len(rekor.entries))
+	}
+
+	if backend.storedOpts.RekorBundle != nil {
+		t.Error("expected RekorBundle to be nil when Verification is nil")
+	}
+}
+
+func TestSigner_NoRekorBundleWithoutTransparency(t *testing.T) {
+	// Verify that RekorBundle is nil when transparency is disabled.
+	backend := &mockBackend{backendType: "mock"}
+	rekor := &mockRekor{}
+	cleanup := setupMocks(rekor)
+	defer cleanup()
+
+	cfg := &config.Config{
+		Artifacts: config.ArtifactConfigs{
+			TaskRuns: config.Artifact{
+				Format:         "slsa/v1",
+				StorageBackend: sets.New[string]("mock"),
+				Signer:         "x509",
+			},
+		},
+		Transparency: config.TransparencyConfig{
+			Enabled: false,
+		},
+	}
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ps := fakepipelineclient.Get(ctx)
+	ctx = config.ToContext(ctx, cfg.DeepCopy())
+
+	os := &ObjectSigner{
+		Backends:          fakeAllBackends([]*mockBackend{backend}),
+		SecretPath:        "./signing/x509/testdata/",
+		Pipelineclientset: ps,
+	}
+
+	obj := objects.NewTaskRunObjectV1(&v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-no-rekor-bundle"},
+	})
+	tekton.CreateObject(t, ctx, ps, obj)
+
+	if err := os.Sign(ctx, obj); err != nil {
+		t.Fatalf("Signer.Sign() error = %v", err)
+	}
+
+	if len(rekor.entries) != 0 {
+		t.Fatalf("expected no transparency log entries, got %d", len(rekor.entries))
+	}
+
+	if backend.storedOpts.RekorBundle != nil {
+		t.Error("expected RekorBundle to be nil when transparency is disabled")
+	}
+}
+
 func TestSigningObjects(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -556,7 +758,7 @@ func TestObjectSigner_Sign_OCIDisabled(t *testing.T) {
 	}
 }
 
-func setupMocks(rekor *mockRekor) func() {
+func setupMocks(rekor rekorClient) func() {
 	oldRekor := getRekor
 	getRekor = func(_ string) (rekorClient, error) {
 		return rekor, nil
@@ -573,13 +775,22 @@ type mockRekor struct {
 func (r *mockRekor) UploadTlog(ctx context.Context, signer signing.Signer, signature, rawPayload []byte, cert, payloadFormat string) (*models.LogEntryAnon, error) {
 	r.entries = append(r.entries, signature)
 	index := int64(len(r.entries) - 1)
+	logID := testLogID
+	integratedTime := int64(1234567890)
 	return &models.LogEntryAnon{
-		LogIndex: &index,
+		LogIndex:       &index,
+		LogID:          &logID,
+		IntegratedTime: &integratedTime,
+		Body:           "dGVzdC1ib2R5", // base64("test-body")
+		Verification: &models.LogEntryAnonVerification{
+			SignedEntryTimestamp: []byte("signed-entry-timestamp"),
+		},
 	}, nil
 }
 
 type mockBackend struct {
 	storedPayload []byte
+	storedOpts    config.StorageOpts
 	shouldErr     bool
 	backendType   string
 }
@@ -590,6 +801,7 @@ func (b *mockBackend) StorePayload(ctx context.Context, _ objects.TektonObject, 
 		return errors.New("mock error storing")
 	}
 	b.storedPayload = rawPayload
+	b.storedOpts = opts
 	return nil
 }
 
@@ -603,4 +815,22 @@ func (b *mockBackend) RetrievePayloads(ctx context.Context, _ objects.TektonObje
 
 func (b *mockBackend) RetrieveSignatures(ctx context.Context, _ objects.TektonObject, opts config.StorageOpts) (map[string][]string, error) {
 	return nil, fmt.Errorf("not implemented")
+}
+
+type mockRekorNilVerification struct {
+	entries [][]byte
+}
+
+func (r *mockRekorNilVerification) UploadTlog(_ context.Context, _ signing.Signer, signature, _ []byte, _, _ string) (*models.LogEntryAnon, error) {
+	r.entries = append(r.entries, signature)
+	index := int64(len(r.entries) - 1)
+	logID := testLogID
+	integratedTime := int64(1234567890)
+	return &models.LogEntryAnon{
+		LogIndex:       &index,
+		LogID:          &logID,
+		IntegratedTime: &integratedTime,
+		Body:           "dGVzdC1ib2R5",
+		Verification:   nil,
+	}, nil
 }

--- a/pkg/chains/storage/oci/attestation.go
+++ b/pkg/chains/storage/oci/attestation.go
@@ -73,6 +73,9 @@ func (s *AttestationStorer) Store(ctx context.Context, req *api.StoreRequest[nam
 	if req.Bundle.Cert != nil {
 		attOpts = append(attOpts, static.WithCertChain(req.Bundle.Cert, req.Bundle.Chain))
 	}
+	if req.Bundle.RekorBundle != nil {
+		attOpts = append(attOpts, static.WithBundle(req.Bundle.RekorBundle))
+	}
 	att, err := static.NewAttestation(req.Bundle.Signature, attOpts...)
 	if err != nil {
 		return nil, err

--- a/pkg/chains/storage/oci/attestation_test.go
+++ b/pkg/chains/storage/oci/attestation_test.go
@@ -15,6 +15,7 @@
 package oci
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http/httptest"
 	"strings"
@@ -26,7 +27,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	intoto "github.com/in-toto/attestation/go/v1"
+	"github.com/sigstore/cosign/v2/pkg/cosign/bundle"
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
+	"github.com/sigstore/cosign/v2/pkg/oci/static"
 	"github.com/tektoncd/chains/pkg/chains/signing"
 	"github.com/tektoncd/chains/pkg/chains/storage/api"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -108,6 +111,184 @@ func TestAttestationStorer_Store(t *testing.T) {
 				t.Fatalf("error during Store(): %s", err)
 			}
 		})
+	}
+}
+
+func TestAttestationStorer_StoreWithRekorBundle(t *testing.T) {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	registryName := strings.TrimPrefix(s.URL, "http://")
+
+	// Push a random image to the registry.
+	img, err := random.Image(1024, 2)
+	if err != nil {
+		t.Fatalf("failed to create random image: %s", err)
+	}
+	imgDigest, err := img.Digest()
+	if err != nil {
+		t.Fatalf("failed to get image digest: %v", err)
+	}
+	ref, err := name.NewDigest(fmt.Sprintf("%s/test/img@%s", registryName, imgDigest))
+	if err != nil {
+		t.Fatalf("failed to parse digest: %v", err)
+	}
+	if err := remote.Write(ref, img); err != nil {
+		t.Fatalf("failed to write image to mock registry: %v", err)
+	}
+
+	rekorBundle := &bundle.RekorBundle{
+		SignedEntryTimestamp: []byte("test-signed-entry-timestamp"),
+		Payload: bundle.RekorPayload{
+			Body:           "dGVzdC1ib2R5",
+			IntegratedTime: 1234567890,
+			LogIndex:       0,
+			LogID:          "test-log-id",
+		},
+	}
+
+	storer, err := NewAttestationStorer(WithTargetRepository(ref.Repository))
+	if err != nil {
+		t.Fatalf("failed to create storer: %v", err)
+	}
+
+	ctx := logtesting.TestContextWithLogger(t)
+	_, err = storer.Store(ctx, &api.StoreRequest[name.Digest, *intoto.Statement]{
+		Artifact: ref,
+		Payload:  &intoto.Statement{},
+		Bundle: &signing.Bundle{
+			Cert:        []byte("test-cert"),
+			Chain:       []byte("test-chain"),
+			RekorBundle: rekorBundle,
+		},
+	})
+	if err != nil {
+		t.Fatalf("error during Store(): %s", err)
+	}
+
+	// Verify the attestation was stored with the Rekor bundle annotation.
+	se, err := ociremote.SignedEntity(ref)
+	if err != nil {
+		t.Fatalf("failed to get signed entity: %v", err)
+	}
+
+	atts, err := se.Attestations()
+	if err != nil {
+		t.Fatalf("failed to get attestations: %v", err)
+	}
+
+	sigs, err := atts.Get()
+	if err != nil {
+		t.Fatalf("failed to get signatures: %v", err)
+	}
+
+	if len(sigs) != 1 {
+		t.Fatalf("expected 1 attestation, got %d", len(sigs))
+	}
+
+	annotations, err := sigs[0].Annotations()
+	if err != nil {
+		t.Fatalf("failed to get annotations: %v", err)
+	}
+
+	bundleAnnotation, ok := annotations[static.BundleAnnotationKey]
+	if !ok {
+		t.Fatal("expected dev.sigstore.cosign/bundle annotation to be present")
+	}
+
+	// Verify the bundle content can be deserialized back.
+	var gotBundle bundle.RekorBundle
+	if err := json.Unmarshal([]byte(bundleAnnotation), &gotBundle); err != nil {
+		t.Fatalf("failed to unmarshal bundle annotation: %v", err)
+	}
+
+	if string(gotBundle.SignedEntryTimestamp) != "test-signed-entry-timestamp" {
+		t.Errorf("unexpected SignedEntryTimestamp: got %s", string(gotBundle.SignedEntryTimestamp))
+	}
+
+	if gotBundle.Payload.IntegratedTime != 1234567890 {
+		t.Errorf("unexpected IntegratedTime: got %d, want 1234567890", gotBundle.Payload.IntegratedTime)
+	}
+
+	if gotBundle.Payload.LogID != "test-log-id" {
+		t.Errorf("unexpected LogID: got %s, want test-log-id", gotBundle.Payload.LogID)
+	}
+
+	// Also verify cert and chain annotations are present.
+	if _, ok := annotations[static.CertificateAnnotationKey]; !ok {
+		t.Error("expected dev.sigstore.cosign/certificate annotation to be present")
+	}
+
+	if _, ok := annotations[static.ChainAnnotationKey]; !ok {
+		t.Error("expected dev.sigstore.cosign/chain annotation to be present")
+	}
+}
+
+func TestAttestationStorer_StoreWithoutRekorBundle(t *testing.T) {
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	registryName := strings.TrimPrefix(s.URL, "http://")
+
+	img, err := random.Image(1024, 2)
+	if err != nil {
+		t.Fatalf("failed to create random image: %s", err)
+	}
+	imgDigest, err := img.Digest()
+	if err != nil {
+		t.Fatalf("failed to get image digest: %v", err)
+	}
+	ref, err := name.NewDigest(fmt.Sprintf("%s/test/img@%s", registryName, imgDigest))
+	if err != nil {
+		t.Fatalf("failed to parse digest: %v", err)
+	}
+	if err := remote.Write(ref, img); err != nil {
+		t.Fatalf("failed to write image to mock registry: %v", err)
+	}
+
+	storer, err := NewAttestationStorer(WithTargetRepository(ref.Repository))
+	if err != nil {
+		t.Fatalf("failed to create storer: %v", err)
+	}
+
+	ctx := logtesting.TestContextWithLogger(t)
+	_, err = storer.Store(ctx, &api.StoreRequest[name.Digest, *intoto.Statement]{
+		Artifact: ref,
+		Payload:  &intoto.Statement{},
+		Bundle: &signing.Bundle{
+			Cert:  []byte("test-cert"),
+			Chain: []byte("test-chain"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("error during Store(): %s", err)
+	}
+
+	// Verify no bundle annotation is present.
+	se, err := ociremote.SignedEntity(ref)
+	if err != nil {
+		t.Fatalf("failed to get signed entity: %v", err)
+	}
+
+	atts, err := se.Attestations()
+	if err != nil {
+		t.Fatalf("failed to get attestations: %v", err)
+	}
+
+	sigs, err := atts.Get()
+	if err != nil {
+		t.Fatalf("failed to get signatures: %v", err)
+	}
+
+	if len(sigs) != 1 {
+		t.Fatalf("expected 1 attestation, got %d", len(sigs))
+	}
+
+	annotations, err := sigs[0].Annotations()
+	if err != nil {
+		t.Fatalf("failed to get annotations: %v", err)
+	}
+
+	if _, ok := annotations[static.BundleAnnotationKey]; ok {
+		t.Error("expected dev.sigstore.cosign/bundle annotation to NOT be present when RekorBundle is nil")
 	}
 }
 

--- a/pkg/chains/storage/oci/legacy.go
+++ b/pkg/chains/storage/oci/legacy.go
@@ -204,10 +204,11 @@ func (b *Backend) uploadAttestation(ctx context.Context, attestation *intoto.Sta
 			Artifact: ref,
 			Payload:  attestation,
 			Bundle: &signing.Bundle{
-				Content:   nil,
-				Signature: []byte(signature),
-				Cert:      []byte(storageOpts.Cert),
-				Chain:     []byte(storageOpts.Chain),
+				Content:     nil,
+				Signature:   []byte(signature),
+				Cert:        []byte(storageOpts.Cert),
+				Chain:       []byte(storageOpts.Chain),
+				RekorBundle: storageOpts.RekorBundle,
 			},
 		}); err != nil {
 			return err

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package config
 
+import (
+	"github.com/sigstore/cosign/v2/pkg/cosign/bundle"
+)
+
 // PayloadType specifies the format to store payload in.
 // - For OCI artifact, Chains only supports `simplesigning` format. https://www.redhat.com/en/blog/container-image-signing
 // - For Tekton artifacts, Chains supports `tekton` and `in-toto` format. https://slsa.dev/provenance/v0.2
@@ -47,4 +51,7 @@ type StorageOpts struct {
 
 	// PayloadFormat is the format to store payload in.
 	PayloadFormat PayloadType
+
+	// RekorBundle is an optional Rekor transparency log bundle for offline verification.
+	RekorBundle *bundle.RekorBundle
 }


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This PR adds support for embedding the Rekor transparency log bundle (`dev.sigstore.cosign/bundle`) in OCI attestation layer annotations when `transparency.enabled=true`. This enables offline signature verification of attestations signed by Tekton Chains using keyless (Fulcio) signing, bringing Chains' attestation format in line with what `cosign attest` produces.

Fixes #1598

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Embed Rekor bundle in OCI attestation layer annotations to enable offline verification of keyless-signed attestations.
```
