### PR TITLE
fix: aggregate per-artifact signing failures so signed annotation is not set

### DIFF
--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -149,6 +149,7 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 			if err != nil {
 				logger.Error(err)
 				o.recordError(ctx, signableType, metrics.PayloadCreationError)
+				merr = multierror.Append(merr, fmt.Errorf("creating payload for %s: %w", signableType.Type(), err))
 				continue
 			}
 			logger.Infof("Created payload of type %s for %s %s/%s", string(payloadFormat), tektonObj.GetGVK(), tektonObj.GetNamespace(), tektonObj.GetName())
@@ -175,6 +176,7 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 			if err != nil {
 				logger.Warnf("Unable to marshal payload for %s: %v", signerType, err)
 				o.recordError(ctx, signableType, metrics.MarshalPayloadError)
+				merr = multierror.Append(merr, fmt.Errorf("marshalling payload for %s: %w", signableType.Type(), err))
 				continue
 			}
 
@@ -182,6 +184,7 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 			if err != nil {
 				logger.Error(err)
 				o.recordError(ctx, signableType, metrics.SigningError)
+				merr = multierror.Append(merr, fmt.Errorf("signing payload for %s: %w", signableType.Type(), err))
 				continue
 			}
 			measureMetrics(ctx, metrics.SignedMessagesCount, o.Recorder)


### PR DESCRIPTION
# Changes

Per-artifact `CreatePayload`, payload marshalling and `SignMessage` failures in `ObjectSigner.Sign()` were only logged and `continue`d without contributing to `merr`. When every per-artifact operation failed this way, `merr` stayed nil, so `MarkSigned` set `chains.tekton.dev/signed=true` even though nothing was signed, permanently suppressing retries. These three paths now append to `merr` exactly like the storage-failure path a few lines below already does.

No new unit test is included: the change is the same `multierror.Append(merr, ...)` pattern already used for storage failures in the same loop, and exercising the payload/marshal/sign failure branches in isolation would require stubbing out the real formatter and x509 signer used by `TestSigner_Sign`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Fix Chains marking a TaskRun/PipelineRun as signed when all per-artifact payload creation, marshalling or signing operations failed.
```

Closes #1663