### PR TITLE
fix: pass insecure option to name.NewDigest for OCI storage

### DIFF
--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -161,7 +161,8 @@ func (oa *OCIArtifact) ExtractObjects(ctx context.Context, obj objects.TektonObj
 }
 
 // ExtractOCIImagesFromResults returns all the results marked as OCIImage type-hint result.
-func ExtractOCIImagesFromResults(ctx context.Context, results []objects.Result) []interface{} {
+// Optional name.Option values (e.g. name.Insecure) are forwarded to every name.NewDigest call.
+func ExtractOCIImagesFromResults(ctx context.Context, results []objects.Result, opts ...name.Option) []interface{} {
 	logger := logging.FromContext(ctx)
 	objs := []interface{}{}
 	seen := map[string]bool{}
@@ -172,7 +173,7 @@ func ExtractOCIImagesFromResults(ctx context.Context, results []objects.Result) 
 		isValid:      hasImageRequirements,
 	}
 	for _, s := range extractor.extract(ctx, results) {
-		dgst, err := name.NewDigest(fmt.Sprintf("%s@%s", s.URI, s.Digest))
+		dgst, err := name.NewDigest(fmt.Sprintf("%s@%s", s.URI, s.Digest), opts...)
 		if err != nil {
 			logger.Errorf("error getting digest: %v", err)
 			continue
@@ -197,7 +198,7 @@ func ExtractOCIImagesFromResults(ctx context.Context, results []objects.Result) 
 			if trimmed == "" {
 				continue
 			}
-			dgst, err := name.NewDigest(trimmed)
+			dgst, err := name.NewDigest(trimmed, opts...)
 			if err != nil {
 				logger.Errorf("error getting digest for img %s: %v", trimmed, err)
 				continue
@@ -217,7 +218,7 @@ func ExtractOCIImagesFromResults(ctx context.Context, results []objects.Result) 
 		if !hasImageRequirements(*s) {
 			continue
 		}
-		dgst, err := name.NewDigest(fmt.Sprintf("%s@%s", s.URI, s.Digest))
+		dgst, err := name.NewDigest(fmt.Sprintf("%s@%s", s.URI, s.Digest), opts...)
 		if err != nil {
 			logger.Errorf("error getting digest for structured output %s@%s: %v", s.URI, s.Digest, err)
 			continue

--- a/pkg/chains/storage/oci/legacy.go
+++ b/pkg/chains/storage/oci/legacy.go
@@ -143,7 +143,7 @@ func (b *Backend) uploadSignature(ctx context.Context, format simple.SimpleConta
 	imageName := format.ImageName()
 	logger.Infof("Uploading %s signature", imageName)
 
-	ref, err := name.NewDigest(imageName)
+	ref, err := name.NewDigest(imageName, nameOpts(b.cfg)...)
 	if err != nil {
 		return errors.Wrap(err, "getting digest")
 	}
@@ -183,7 +183,7 @@ func (b *Backend) uploadAttestation(ctx context.Context, attestation *intoto.Sta
 		imageName := fmt.Sprintf("%s@sha256:%s", subj.Name, subj.Digest["sha256"])
 		logger.Infof("Starting attestation upload to OCI for %s...", imageName)
 
-		ref, err := name.NewDigest(imageName)
+		ref, err := name.NewDigest(imageName, nameOpts(b.cfg)...)
 		if err != nil {
 			return errors.Wrapf(err, "getting digest for subj %s", imageName)
 		}
@@ -294,7 +294,7 @@ func (b *Backend) RetrievePayloads(ctx context.Context, obj objects.TektonObject
 
 func (b *Backend) RetrieveArtifact(ctx context.Context, obj objects.TektonObject, opts config.StorageOpts) (map[string]oci.SignedImage, error) {
 	// Given the TaskRun, retrieve the OCI images.
-	images := artifacts.ExtractOCIImagesFromResults(ctx, obj.GetResults())
+	images := artifacts.ExtractOCIImagesFromResults(ctx, obj.GetResults(), nameOpts(b.cfg)...)
 	m := make(map[string]oci.SignedImage)
 
 	for _, image := range images {
@@ -312,11 +312,15 @@ func (b *Backend) RetrieveArtifact(ctx context.Context, obj objects.TektonObject
 	return m, nil
 }
 
-func newRepo(cfg config.Config, imageName name.Digest) (name.Repository, error) {
-	var opts []name.Option
+func nameOpts(cfg config.Config) []name.Option {
 	if cfg.Storage.OCI.Insecure {
-		opts = append(opts, name.Insecure)
+		return []name.Option{name.Insecure}
 	}
+	return nil
+}
+
+func newRepo(cfg config.Config, imageName name.Digest) (name.Repository, error) {
+	opts := nameOpts(cfg)
 
 	if storageOCIRepository := cfg.Storage.OCI.Repository; storageOCIRepository != "" {
 		return name.NewRepository(storageOCIRepository, opts...)


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Fix OCI storage failing against insecure `.cluster.local` registries when using `go-containerregistry` v0.21.6+.
`name.NewDigest()` was called without `name.Insecure` even when `storage.oci.repository.insecure: "true"` was configured, causing HTTPS connections to plain HTTP registries.
Extract `nameOpts()` helper from `newRepo()` and reuse it in`uploadSignature()` and `uploadAttestation()` for consistent insecure flag propagation.

  ### Context

  `go-containerregistry` [v0.21.6](https://github.com/google/go-containerregistry/releases/tag/v0.21.6) tightened `.local` domain handling ([google/go-containerregistry#2281](https://github.com/google/go-containerregistry/pull/2281)) —
  only `.localhost` is now treated as HTTP by default. Domains like `registry.<ns>.svc.cluster.local:5000` previously worked without the insecure flag but now require it explicitly.

This fix unblocks the dependency bump in [#1680](https://github.com/tektoncd/chains/pull/1680), which updates `go-containerregistry` to v0.21.6 and currently fails all e2e tests due to this issue.
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Fix OCI signature and attestation uploads to correctly honour `storage.oci.repository.insecure: "true"` for plain-HTTP in-cluster registries, restoring compatibility with go-containerregistry v0.21.6+
```
