### PR TITLE
Add agentic workflow context files

### DIFF
--- a/.agents/skills/commit-message/SKILL.md
+++ b/.agents/skills/commit-message/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: commit-message
+description: This skill should be used when the user asks to "create a commit", "generate commit message", "commit changes", "make a commit", mentions "conventional commits", or discusses commit message formatting. Provides guided workflow for creating properly formatted commit messages with line length validation and required trailers.
+version: 0.2.0
+---
+
+# Conventional Commit Message Creation
+
+Create properly formatted conventional commit messages following project standards with line length validation and required trailers.
+
+## Purpose
+
+Generate commit messages that:
+
+- Follow conventional commits format (`type(scope): description`)
+- Use component names or GitHub issue numbers as scope
+- Respect line length limits (50 for subject, 72 for body)
+- Include required trailers (Signed-off-by, Assisted-by)
+- Match [Tekton commit message standards](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
+
+## Quick Workflow
+
+1. **Analyze changes**: Run git status and git diff to understand modifications
+2. **Determine scope**: Use component name from changed files, or GitHub issue number if available
+3. **Generate message**: Create conventional commit message with proper formatting
+4. **Add trailers**: Include Signed-off-by and Assisted-by trailers
+5. **Confirm with user**: Display message and wait for approval before committing
+
+**CRITICAL**: Never commit without explicit user confirmation.
+
+## Conventional Commit Format
+
+### Structure
+
+```text
+<type>(<scope>): <description>
+
+[optional body]
+
+Signed-off-by: <name> <email>
+Assisted-by: <model-name> (via <Tool>)
+```
+
+### Type Selection
+
+Choose the appropriate commit type based on changes:
+
+| Type | Description | Example |
+| ------ | ------------- | --------- |
+| `feat` | New features | `feat(storage): add Archivista backend` |
+| `fix` | Bug fixes | `fix(signing): resolve KMS race condition` |
+| `docs` | Documentation | `docs(README): update installation steps` |
+| `refactor` | Code refactoring | `refactor(formats): simplify SLSA builder` |
+| `test` | Test changes | `test(e2e): add OCI storage tests` |
+| `chore` | Maintenance | `chore(deps): update go dependencies` |
+| `build` | Build system | `build(Makefile): add vendor target` |
+| `ci` | CI/CD changes | `ci(github): add golangci-lint action` |
+| `perf` | Performance | `perf(reconciler): reduce requeue latency` |
+| `style` | Code style | `style(format): run goimports` |
+| `revert` | Revert commit | `revert: undo breaking config change` |
+
+For complete type reference, see `references/commit-types.md`.
+
+### Scope Rules
+
+#### Priority 1: Component from changed files
+
+Analyze staged files to identify the primary component:
+
+```bash
+git diff --cached --name-only
+```
+
+| File pattern | Scope | Example commit |
+| ------------ | ----- | -------------- |
+| `pkg/chains/signing/*` | `signing` | `fix(signing): resolve x509 cert issue` |
+| `pkg/chains/storage/*` | `storage` | `feat(storage): add PubSub backend` |
+| `pkg/chains/formats/*` | `formats` | `refactor(formats): simplify SLSA v2` |
+| `pkg/reconciler/taskrun/*` | `taskrun` | `fix(taskrun): handle nil status` |
+| `pkg/reconciler/pipelinerun/*` | `pipelinerun` | `feat(pipelinerun): add deep inspection` |
+| `pkg/config/*` | `config` | `feat(config): add new signing key` |
+| `pkg/artifacts/*` | `artifacts` | `refactor(artifacts): simplify extraction` |
+| `cmd/*` | `controller` | `feat(controller): add new flag` |
+| `docs/*` | `docs` or filename | `docs(config): update signing options` |
+| `test/*` | component being tested | `test(storage): add GCS tests` |
+| Root files | filename | `chore(Makefile): add lint target` |
+| `AGENTS.md`, `CLAUDE.md` | `docs` | `docs(AGENTS.md): update conventions` |
+
+#### Priority 2: GitHub issue number (optional)
+
+If the work is tracked in a GitHub issue and the user provides one, it can be used as the scope:
+
+```text
+Fixes #123
+```
+
+Add `Fixes #NNN` or `Closes #NNN` in the commit body (not the scope).
+
+#### Priority 3: Ask user
+
+If changed files span multiple components or scope is unclear, ask the user which component is the primary focus.
+
+## Line Length Requirements
+
+### Subject Line
+
+- **Target**: 50 characters maximum
+- **Hard limit**: 72 characters (Tekton community standard)
+- **Format**: `type(scope): description` counts toward limit
+- **Tips**: Use present tense, no period at end
+
+### Body
+
+- **Wrap at 72 characters per line**
+- **Blank line** required between subject and body
+- **Content**: Explain why, not what (code shows what)
+
+## Required Trailers
+
+### Signed-off-by
+
+**Always include**: `Signed-off-by: <name> <email>`
+
+This certifies the Developer Certificate of Origin (DCO) — required by tektoncd upstream.
+
+**Detection priority order**:
+
+1. Environment variables: `$GIT_AUTHOR_NAME` and `$GIT_AUTHOR_EMAIL`
+2. Git config: `git config user.name` and `git config user.email`
+3. If neither configured, ask user to provide details
+
+For complete detection logic, see `references/trailer-detection.md`.
+
+### Assisted-by
+
+**Always include**: `Assisted-by: <model-name> (via <Tool>)`
+
+Use the actual model name and tool name.
+
+## User Confirmation Requirement
+
+**CRITICAL RULE**: Always ask for user confirmation before executing `git commit`.
+
+1. **Generate** the commit message following all rules above
+2. **Display** the complete message to the user
+3. **Ask**: "Should I commit with this message? (y/n)"
+4. **Wait** for user response
+5. **Commit** only if user confirms
+
+## Commit Execution
+
+Use heredoc format for proper multi-line handling:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(storage): add Archivista backend
+
+Enable storing attestations in Archivista for improved
+discoverability and querying.
+
+Signed-off-by: Developer Name <developer@example.com>
+Assisted-by: <Model name> (via <Tool>)
+EOF
+)"
+```
+
+**Never use**:
+
+- `--no-verify` (skips pre-commit hooks)
+- `--no-gpg-sign` (skips signing)
+- `--amend` (unless explicitly requested and safe)
+
+## Format standards
+
+Follow [Tekton commit message standards](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages):
+
+- Conventional commit format (`type(scope): description`)
+- Subject line: target 50 characters, hard limit 72
+- Body lines wrapped at 72 characters
+- Required `Signed-off-by` trailer (DCO)
+- No trailing punctuation on the subject
+
+## Auto-Detection Summary
+
+1. Run `git status` and `git diff` for staged/unstaged changes
+2. Identify primary component from staged file paths
+3. If scope unclear, ask user
+4. Analyze staged files to determine commit type
+5. Detect author info from environment variables or git config
+6. Ensure subject line is ≤50 characters (max 72)
+7. Wrap body text at 72 characters per line
+8. Add required trailers (Signed-off-by and Assisted-by)
+9. **Display message and ask for user confirmation**
+10. Only commit after receiving confirmation
+
+## Additional Resources
+
+- **`references/commit-types.md`** - Complete commit type reference with descriptions
+- **`references/trailer-detection.md`** - Author detection logic and priority order

--- a/.agents/skills/commit-message/references/commit-types.md
+++ b/.agents/skills/commit-message/references/commit-types.md
@@ -1,0 +1,201 @@
+# Commit Types Reference
+
+Complete reference for conventional commit types used in the Tekton Chains project.
+
+## Scope and issue references
+
+- Prefer **component names** as scope (e.g. `signing`, `storage`, `config`, `reconciler`).
+- To link work to a GitHub issue, add `Fixes #NNN` or `Closes #NNN` in the **commit body** (not the subject scope). Merging the PR then closes the issue automatically.
+
+## Standard Types
+
+### feat - New Features
+
+Use for new features or functionality added to the codebase.
+
+**Examples**:
+
+- `feat(storage): add Archivista backend`
+- `feat(signing): implement Vault KMS support`
+- `feat(formats): add SLSA v2alpha4 provenance`
+- `feat(config): expose new signing option`
+
+**When to use**:
+
+- Adding new capabilities
+- Introducing new storage/signing/format backends
+- Implementing new APIs or configuration options
+
+### fix - Bug Fixes
+
+Use for bug fixes that resolve incorrect behavior.
+
+**Examples**:
+
+- `fix(reconciler): resolve TaskRun race condition`
+- `fix(signing): correct x509 certificate chain`
+- `fix(storage): handle OCI registry timeout`
+- `fix(config): prevent nil pointer on missing key`
+
+**When to use**:
+
+- Fixing crashes or errors
+- Resolving incorrect behavior
+- Correcting logic errors
+
+**CVE / security fixes**: Use scope `cve` and cite the advisory in the subject (see examples on `main`). Routine dependency bumps from Dependabot use `chore(deps):`, not `fix`.
+
+### docs - Documentation
+
+Use for documentation-only changes.
+
+**Examples**:
+
+- `docs(README): update installation steps`
+- `docs(config): document new signing options`
+- `docs(tutorials): add GCS storage walkthrough`
+- `docs(AGENTS.md): update architecture section`
+
+**When to use**:
+
+- Updating README or docs/ files
+- Adding or improving code comments
+- Updating developer guides
+
+### refactor - Code Refactoring
+
+Use for code changes that neither fix bugs nor add features.
+
+**Examples**:
+
+- `refactor(formats): extract common SLSA logic`
+- `refactor(storage): consolidate backend interface`
+- `refactor(chains): simplify ObjectSigner flow`
+
+**When to use**:
+
+- Improving code readability
+- Simplifying complex logic
+- Reorganizing code structure
+
+**Must not** change observable behavior. If behavior changes, use `fix` (bug) or `feat` (new capability) instead.
+
+### test - Testing
+
+Use for adding or updating tests.
+
+**Examples**:
+
+- `test(e2e): add OCI storage integration test`
+- `test(signing): improve x509 test coverage`
+- `test(formats): add SLSA v2 edge case tests`
+
+**When to use**:
+
+- Adding new test cases
+- Improving test coverage
+- Fixing flaky tests
+
+### chore - Maintenance Tasks
+
+Use for routine maintenance tasks and tooling.
+
+**Examples**:
+
+- `chore(deps): update go dependencies`
+- `chore(vendor): run make vendor`
+- `chore(tools): update golangci-lint version`
+
+**When to use**:
+
+- Dependency updates
+- Tooling configuration
+- Repository maintenance
+
+### build - Build System
+
+Use for changes to how the project is built (not routine dependency bumps — those are `chore(deps):`).
+
+**Examples**:
+
+- `build(Makefile): add yamllint target`
+- `build(ko): update base image`
+- `build(go.mod): bump Go version to 1.24`
+
+**When to use**:
+
+- Changes to the root `Makefile` or build scripts
+- Container or `ko` image build configuration
+- Bumping the Go version in `go.mod`
+
+### ci - CI/CD Changes
+
+Use for changes to continuous integration and release automation.
+
+**Examples**:
+
+- `ci(.github/workflows): add golangci-lint to CI`
+- `ci(.github/workflows): update e2e matrix workflow`
+- `ci(.tekton): update release pipeline`
+
+**When to use**:
+
+- Changes under `.github/workflows/`
+- Changes under `.tekton/`
+
+### perf - Performance Improvements
+
+Use for changes that improve performance.
+
+**Examples**:
+
+- `perf(reconciler): reduce requeue latency`
+- `perf(storage): batch OCI uploads`
+- `perf(signing): cache KMS connections`
+
+### style - Code Style
+
+Use for formatting and style changes.
+
+**Examples**:
+
+- `style(format): run goimports`
+- `style(lint): fix golangci-lint warnings`
+
+### revert - Revert Previous Commit
+
+Use for reverting previous commits.
+
+**Examples**:
+
+- `revert: undo breaking config change`
+- `revert(signing): revert KMS refactoring`
+
+**Format**: Include reference to original commit in body.
+
+## Breaking Changes
+
+For any commit type, add `!` after type/scope to indicate breaking change:
+
+- `feat(config)!: change signing key format`
+- `fix(storage)!: remove deprecated GCS options`
+
+Body should include:
+
+```text
+BREAKING CHANGE: <description and migration path>
+```
+
+## Type Selection Guide
+
+1. **Does it add new functionality?** → `feat`
+2. **Does it fix a bug?** → `fix`
+3. **Is it documentation only?** → `docs`
+4. **Does it change code structure without behavior change?** → `refactor`
+5. **Is it test-related?** → `test`
+6. **Is it dependency/maintenance?** → `chore`
+7. **Is it build system related?** → `build`
+8. **Is it CI/CD related?** → `ci`
+9. **Does it improve performance?** → `perf`
+10. **Is it formatting/style only?** → `style`
+11. **Does it revert a previous commit?** → `revert`

--- a/.agents/skills/commit-message/references/trailer-detection.md
+++ b/.agents/skills/commit-message/references/trailer-detection.md
@@ -1,0 +1,62 @@
+# Author Detection and Trailer Generation
+
+Guide for detecting author information and generating required commit trailers.
+
+## Required Trailers
+
+Every commit must include:
+
+1. **Signed-off-by**: Author's name and email (DCO requirement)
+2. **Assisted-by**: AI model information (when AI assists)
+
+## Signed-off-by Detection
+
+### Priority 1: Environment Variables (Highest)
+
+```bash
+echo "$GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>"
+```
+
+Common in dev containers and CI environments.
+
+### Priority 2: Git Configuration (Fallback)
+
+```bash
+git config user.name
+git config user.email
+```
+
+Checks repository config first, then global, then system.
+
+### Priority 3: Ask User (Last Resort)
+
+If neither source is available, ask the user to provide name and email.
+
+## Assisted-by Trailer
+
+**Format**: `Assisted-by: Model Name (via Tool Name)`
+
+**Examples**:
+
+```text
+Assisted-by: <Model name> (via <Tool>)
+```
+
+Always use the actual model and tool name.
+
+## Trailer Order and Spacing
+
+- **Blank line before trailers**: Separate body from trailers
+- **No blank lines between trailers**: Trailers are consecutive
+- **Signed-off-by first**, Assisted-by second
+
+**Correct**:
+
+```text
+feat(storage): add handler
+
+Implements storage support.
+
+Signed-off-by: Developer Name <developer@example.com>
+Assisted-by: <Model name> (via <Tool>)
+```

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: release-notes
+description: This skill should be used when the user asks to "create release note", "generate release notes", "release notes", "release changelog", "update GitHub release", or wants to generate categorized release notes between tags. Gathers PR/commit data via gh CLI, categorizes changes, and outputs formatted release notes. The user can optionally specify a release version (e.g. "create release note v0.25.0") to bypass auto-detection.
+version: 0.1.0
+---
+
+# Release Notes Generation
+
+Generate categorized release notes for Tekton Chains releases by gathering PR/commit data between two git tags and producing formatted markdown output.
+
+## Purpose
+
+Skill that:
+
+- Auto-detects current and previous tags
+- Gathers PR and commit data via `gh` CLI
+- Categorizes changes intelligently
+- Outputs release notes matching the project's established format
+- Optionally updates the GitHub release
+
+## Workflow
+
+### Step 1: Pull latest tags
+
+```bash
+git pull origin --tags
+```
+
+### Step 2: Detect repository info
+
+```bash
+gh repo view --json owner,name
+```
+
+### Step 3: Detect tags
+
+**If the user specified a version** (e.g. "create release note v0.25.0"), use that directly. Validate that the tag exists locally:
+
+```bash
+git tag --list 'v0.25.0'
+```
+
+**Otherwise, auto-detect current tag:**
+
+```bash
+git tag --points-at HEAD
+```
+
+Filter for `v*` prefixed tags. If no tag points at HEAD, list recent tags and ask the user:
+
+```bash
+git tag --list 'v*' --sort=-version:refname | head -10
+```
+
+**Previous tag:**
+
+```bash
+git tag --list 'v*' --sort=-version:refname
+```
+
+Find the entry immediately after the current tag in the version-sorted list.
+
+**CRITICAL**: Confirm both tags with the user before proceeding.
+
+### Step 4: Verify prerequisites
+
+```bash
+gh auth status
+```
+
+Validate both tags exist on GitHub:
+
+```bash
+gh api repos/{owner}/{repo}/git/ref/tags/{current_tag}
+gh api repos/{owner}/{repo}/git/ref/tags/{previous_tag}
+```
+
+### Step 5: Gather PR/commit data
+
+```bash
+gh api repos/{owner}/{repo}/compare/{previous_tag}...{current_tag} --jq '.commits[].sha'
+```
+
+For each commit, find associated PRs:
+
+```bash
+gh api repos/{owner}/{repo}/commits/{sha}/pulls
+```
+
+Deduplicate by PR number. Extract: PR number, title, body, author, URL, and labels.
+
+### Step 6: Categorize changes
+
+Sections (skip empty ones):
+
+- `## ✨ Major changes and Features`
+- `## 🐛 Bug Fixes`
+- `## 📚 Documentation Updates`
+- `## ⚙️ Chores`
+
+**Categorization guidelines:**
+
+- New capabilities, enhancements → Features
+- Bug fixes, error corrections → Bug Fixes
+- Documentation-only changes → Documentation Updates
+- Dependencies, CI/CD, refactoring, test-only → Chores
+
+**Internal vs user-facing**: CI/CD, release infra, test infra, build system, developer tooling, and internal refactoring belong in Chores even if prefixed with `feat:`.
+
+### Step 7: Assemble release notes
+
+Use `references/release-notes-format.md` for header, entry format, and installation section.
+
+Append GitHub auto-generated changelog:
+
+```bash
+gh api repos/{owner}/{repo}/releases/generate-notes -f tag_name="{current_tag}" -f previous_tag_name="{previous_tag}"
+```
+
+### Step 8: Output and optional GitHub release update
+
+1. Write to `/tmp/release-notes-{current_tag}.md`
+2. Display to user
+3. Ask if they want to update the GitHub release
+
+```bash
+gh release edit {current_tag} --notes-file /tmp/release-notes-{current_tag}.md
+```
+
+## Error Handling
+
+| Scenario | Action |
+| --- | --- |
+| No tag at HEAD | List recent tags, ask user to pick |
+| Tag doesn't exist on GitHub | Stop and report error |
+| `gh` not authenticated | Instruct user to run `gh auth login` |
+| No previous tag found | Ask user to provide one |
+| Release already published | Ask for confirmation before overriding |
+
+## User Confirmation Requirements
+
+**CRITICAL**: Always confirm tags before gathering data. Always confirm before updating a GitHub release.

--- a/.agents/skills/release-notes/references/release-notes-format.md
+++ b/.agents/skills/release-notes/references/release-notes-format.md
@@ -1,0 +1,34 @@
+# Release Notes Format Reference
+
+## Entry Format
+
+Each release note entry MUST follow this exact format. The Link line MUST be indented with two spaces so it renders as a nested sub-bullet:
+
+```markdown
+* **Bold title:** One-sentence description of the change.
+  * Link: <PR_OR_COMMIT_URL>
+```
+
+### Rules
+
+- The first bullet MUST start with `*` (no indent) with a bold title followed by a colon and a description.
+- The Link line MUST start with `* Link:` (two-space indent) with the PR or commit URL.
+- Do NOT add a Contributors section.
+
+## Header Template
+
+```markdown
+# Tekton Chains {tag}
+
+Release of Tekton Chains {tag}.
+```
+
+## Installation Section Template
+
+```markdown
+## Installation
+
+To install this release:
+
+kubectl apply -f https://storage.googleapis.com/tekton-releases/chains/previous/{tag}/release.yaml
+```

--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+*.local.json

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# Tekton Chains
+
+Kubernetes controller for supply chain security. Watches TaskRun and
+PipelineRun completions, signs them, generates attestations (in-toto,
+SLSA), and stores signatures in configurable backends (OCI, Tekton
+annotations, GCS, Grafeas, DocDB, Archivista, PubSub).
+
+---
+
+## Build & Test Commands
+
+```bash
+# Build
+make bin/controller
+
+# Unit tests (no cluster needed)
+make test-unit
+make test-unit-verbose-and-race
+make test-unit PKG=./pkg/chains/storage/...  # single package (fast)
+
+# Lint — must pass before every PR
+make golangci-lint                          # all packages
+make golangci-lint PKG=./pkg/chains/...     # single package (fast)
+make yamllint                               # YAML linting
+
+# Code generation — after changing pkg/config types
+make generated
+
+# Dependency update — after go.mod changes
+make vendor
+
+# Deploy locally (requires cluster + Tekton Pipelines installed)
+ko apply -f config/
+```
+
+E2E tests require a live cluster and are tagged `//go:build e2e`.
+See [DEVELOPMENT.md](./DEVELOPMENT.md) for cluster setup.
+
+---
+
+## Key Conventions
+
+1. **Single binary.** Only `cmd/controller` — no CLI, no webhook binary.
+   The controller registers both TaskRun and PipelineRun reconcilers.
+
+2. **Vendored dependencies.** All builds use `-mod=vendor`. Run
+   `make vendor` (calls `hack/update-deps.sh`) after any `go.mod` change.
+
+3. **Knative controller runtime.** Reconcilers use `knative.dev/pkg`,
+   not `controller-runtime`. Status conditions use
+   `condSet.Manage(status).MarkTrue/MarkFalse`.
+
+4. **ConfigMap-driven configuration.** All runtime config lives in
+   `pkg/config/` and is loaded from the `chains-config` ConfigMap.
+   See [docs/config.md](./docs/config.md) for all keys.
+
+5. **Sigstore ecosystem.** Signing uses cosign/Fulcio/Rekor. KMS
+   providers (AWS, Azure, GCP, Vault) are registered at startup in
+   `cmd/controller/main.go`.
+
+---
+
+## Architecture
+
+```
+cmd/controller/             → Binary entrypoint, registers reconcilers + KMS
+pkg/reconciler/taskrun/     → TaskRun controller — watches completions
+pkg/reconciler/pipelinerun/ → PipelineRun controller
+pkg/chains/                 → Core signing orchestration (ObjectSigner)
+pkg/chains/signing/         → Signer interface + x509/KMS implementations
+pkg/chains/formats/         → Attestation formats (simple, SLSA v1/v2alpha)
+pkg/chains/storage/         → Storage backends (oci, tekton, gcs, grafeas…)
+pkg/config/                 → ConfigMap parsing + deepcopy codegen
+pkg/artifacts/              → Artifact/signable abstractions
+config/                     → Kubernetes manifests (deployment, RBAC, ConfigMaps)
+test/                       → E2E tests (Go + shell) and test data
+```
+
+---
+
+## PR Conventions
+
+- Pull requests must follow the repository PR template defined in `.github/pull_request_template.md`.
+- Commit messages should follow [Tekton community standards](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages).
+- `make golangci-lint` must pass with zero issues.
+- `make test-unit` must pass with zero failures.
+- Run `make generated` and commit results after changing `pkg/config/` types.
+- Commits require `Signed-off-by` (DCO).
+
+---
+
+## Windows checkout
+
+`CLAUDE.md` points to `AGENTS.md`, and `.claude/skills` points to `.agents/skills`.
+This works on Linux, macOS, and GitHub; on Windows, enable symlinks when cloning:
+
+```bash
+git clone -c core.symlinks=true https://github.com/tektoncd/chains.git
+```
+
+Alternatively, set `core.symlinks=true` in your git config before checkout.
+
+---
+
+## Skills
+
+- **Commit messages**: Conventional commits with component scopes,
+  line length validation, DCO Signed-off-by, and Assisted-by trailers.
+- **Release notes**: Gather PRs between tags, categorize, output
+  formatted markdown, optionally update GitHub release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ test-unit-verbose-and-race: ARGS=-v -race
 $(TEST_UNIT_TARGETS): test-unit
 .PHONY: $(TEST_UNIT_TARGETS) test-unit
 test-unit: ## Run unit tests
-	$(GO) test -timeout $(TIMEOUT_UNIT) $(ARGS) ./...
+	$(GO) test -timeout $(TIMEOUT_UNIT) $(ARGS) $(or $(PKG),./...)
 
 TEST_E2E_TARGETS := test-e2e-short test-e2e-verbose test-e2e-race
 test-e2e-short:   ARGS=-short
@@ -171,7 +171,7 @@ $(BIN)/golangci-lint-$(GOLANGCI_VERSION): ; $(info $(M) getting golangci-lint $(
 .PHONY: golangci-lint
 golangci-lint: | $(GOLANGCILINT) ; $(info $(M) running golangci-lint…) @ ## Run golangci-lint
 	$Q $(GOLANGCILINT) config verify
-	$Q $(GOLANGCILINT) run --modules-download-mode=vendor --max-issues-per-linter=0 --max-same-issues=0 --timeout 5m
+	$Q $(GOLANGCILINT) run --modules-download-mode=vendor --max-issues-per-linter=0 --max-same-issues=0 --timeout 5m $(PKG)
 
 .PHONY: golangci-lint-check
 golangci-lint-check: | $(GOLANGCILINT) ; $(info $(M) Testing if golint has been done…) @ ## Run golangci-lint for build tests CI job


### PR DESCRIPTION
Prepare the Tekton Chains repository for agentic workflows as part of [SRVKP-11815](https://redhat.atlassian.net/browse/SRVKP-11815).
- **AGENTS.md**: minimal agent-oriented context file covering build/test commands, key conventions (single binary, vendored deps, Knative runtime, ConfigMap config, Sigstore ecosystem), architecture, and PR rules
- **CLAUDE.md**: symlink to AGENTS.md
- **.claude/skills/**: commit-message and release-notes skills adapted for this project
- **.agents/skills**: symlink to .claude/skills for agent auto-discovery
- **.gitlint**: commit message linting config (matches operator pattern)
- **Makefile**: add `make gitlint` target
- **.gitignore**: add missing patterns (coverage.txt, .idea/, .DS_Store, etc.)
### agentready score
- **69.8/100 (Silver)** — baseline assessment
- Most failures are out of scope 

### Notes
- AGENTS.md is 95 lines (target was <60), though 60 is really short, and doesnt fit much info
- Skills are adapted from the operator PR, with Chains-specific scopes and examples.

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
