### PR TITLE
feat: add release secrets for tektoncd/chains PAC namespace

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,10 @@ name: ci
 
 'on':
   pull_request: {}
+  merge_group: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull-request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 defaults:
@@ -110,3 +111,34 @@ jobs:
   e2e-tests:
     needs: [build]
     uses: ./.github/workflows/kind-e2e.yaml
+
+  ci-summary:
+    name: CI summary
+    needs: [build, linting, tests, e2e-tests]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+    - name: Check CI results
+      run: |
+        results=(
+          "build=${{ needs.build.result }}"
+          "linting=${{ needs.linting.result }}"
+          "tests=${{ needs.tests.result }}"
+          "e2e-tests=${{ needs.e2e-tests.result }}"
+        )
+        failed=0
+        for r in "${results[@]}"; do
+          name="${r%%=*}"
+          result="${r#*=}"
+          echo "${name}: ${result}"
+          if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+            failed=1
+          fi
+        done
+        if [ "$failed" -eq 1 ]; then
+          echo ""
+          echo "Some CI jobs failed or were cancelled"
+          exit 1
+        fi
+        echo ""
+        echo "All CI checks passed"


### PR DESCRIPTION
## What

Add the missing secrets to the `releases-chains` namespace so that PAC-triggered release pipelines can run for `tektoncd/chains`.

## Why

[tektoncd/chains#1656](https://github.com/tektoncd/chains/pull/1656) merged the PAC release automation (`.tekton/` PipelineRuns + GHA patch-release workflow), and the Repository CR + namespace + ServiceAccount were deployed via plumbing/ArgoCD. However, the release secrets were never provisioned in terraform, so no PipelineRun can actually succeed.

Branch `release-v0.27.x` was created on May 26 but the release didn't trigger because:
1. The `tekton-as-code` GitHub App isn't installed yet on `tektoncd/chains` (being done separately)
2. The secrets needed by the release pipeline are missing (this PR)

## Changes

### `releases.tf`
- Add `releases-chains` to `oci_release_secret_namespaces` → provisions `oci-release-secret`

### `secrets.tf`
- Add `ghcr-creds` secret mapping for `releases-chains`
- Add `github-token` secret mapping for `releases-chains`
- Import pre-existing `releases-chains` namespace (created by ArgoCD)
- Add `pac-incoming-secret` for incoming webhook authentication

## After merge

1. Run terraform apply
2. Install `tekton-as-code` GitHub App on `tektoncd/chains`
3. Re-trigger `release-v0.27.x` via manual incoming webhook or workflow_dispatch