### PR TITLE
Add migration cleanup for SSA finalizers

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -14,8 +14,11 @@ limitations under the License.
 package pipelinerun
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"time"
 
 	signing "github.com/tektoncd/chains/pkg/chains"
 	"github.com/tektoncd/chains/pkg/chains/annotations"
@@ -24,7 +27,11 @@ import (
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	pipelinerunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/pipelinerun"
 	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/tracker"
@@ -33,6 +40,8 @@ import (
 const (
 	// SecretPath contains the path to the secrets volume that is mounted in.
 	SecretPath = "/etc/signing-secrets"
+
+	pipelineRunFinalizerName = "chains.tekton.dev/pipelinerun"
 )
 
 type Reconciler struct {
@@ -57,7 +66,34 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 // We utilize finalizers to ensure that we get a crack at signing every pipelinerun
 // that we see flowing through the system.  If we don't add a finalizer, it could
 // get cleaned up before we see the final state and sign it.
-func (r *Reconciler) FinalizeKind(ctx context.Context, pr *v1.PipelineRun) pkgreconciler.Event {
+func (r *Reconciler) FinalizeKind(ctx context.Context, pr *v1.PipelineRun) (result pkgreconciler.Event) { //nolint:ireturn
+	// MIGRATION: When the framework dispatches DoFinalizeKind (DeletionTimestamp is set) and
+	// finalization succeeds (returns nil), check if the finalizer was added via merge patch by the
+	// old controller version. SSA cannot remove finalizers it doesn't own, so we remove it via
+	// merge patch ourselves. This can be removed once all pre-SSA resources are deleted.
+	//
+	// The DeletionTimestamp guard is necessary because in Chains, ReconcileKind delegates to
+	// FinalizeKind, so FinalizeKind is called both from the DoReconcileKind path (no
+	// DeletionTimestamp) and the DoFinalizeKind path (DeletionTimestamp set). We must only
+	// remove the finalizer when the object is actually being deleted.
+	if !pr.DeletionTimestamp.IsZero() {
+		defer func() {
+			if result != nil {
+				return
+			}
+			if !r.isFinalizerOwnedByMergePatch(pr) {
+				return
+			}
+			logging.FromContext(ctx).Infof("Removing merge-patch finalizer on %s/%s for SSA migration",
+				pr.Namespace, pr.Name)
+			if err := r.removeFinalizerViaMergePatch(ctx, pr); err != nil {
+				logging.FromContext(ctx).Warnw("Failed to remove finalizer via merge patch",
+					zap.Error(err))
+				result = controller.NewRequeueAfter(10 * time.Second)
+			}
+		}()
+	}
+
 	// Check to make sure the PipelineRun is finished.
 	if !pr.IsDone() {
 		logging.FromContext(ctx).Infof("pipelinerun is still running")
@@ -121,4 +157,56 @@ func (r *Reconciler) trackTaskRun(tr *v1.TaskRun, pr *v1.PipelineRun) error {
 		Name:       tr.Name,
 	}
 	return r.Tracker.TrackReference(ref, pr)
+}
+
+// isFinalizerOwnedByMergePatch checks if the finalizer was added via merge patch (Update operation).
+// MIGRATION: This is a temporary migration feature to handle the upgrade scenario where
+// in-flight PipelineRuns have finalizers set via merge patch by the old controller version.
+// Kubernetes SSA treats (manager, Update) and (manager, Apply) as different owners, so we need
+// to detect and handle the old ownership pattern.
+// This function can be removed once all resources from the pre-SSA version are deleted.
+func (r *Reconciler) isFinalizerOwnedByMergePatch(pr *v1.PipelineRun) bool {
+	for _, mf := range pr.ManagedFields {
+		if mf.Operation == metav1.ManagedFieldsOperationUpdate {
+			raw := mf.FieldsV1.GetRawBytes()
+			if raw != nil {
+				if bytes.Contains(raw, []byte(`"f:finalizers"`)) &&
+					bytes.Contains(raw, []byte(`v:\"chains.tekton.dev/pipelinerun\"`)) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// removeFinalizerViaMergePatch removes the finalizer using merge patch.
+// MIGRATION: This is a temporary migration feature to handle the upgrade scenario where
+// in-flight PipelineRuns have finalizers set via merge patch by the old controller version.
+// This uses merge patch to remove finalizers that cannot be removed via SSA due to different
+// ownership (manager, Update) vs (manager, Apply).
+// This function can be removed once all resources from the pre-SSA version are deleted.
+func (r *Reconciler) removeFinalizerViaMergePatch(ctx context.Context, pr *v1.PipelineRun) error {
+	var newFinalizers []string
+	for _, f := range pr.Finalizers {
+		if f != pipelineRunFinalizerName {
+			newFinalizers = append(newFinalizers, f)
+		}
+	}
+
+	mergePatch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"finalizers":      newFinalizers,
+			"resourceVersion": pr.ResourceVersion,
+		},
+	}
+
+	patch, err := json.Marshal(mergePatch)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.Pipelineclientset.TektonV1().PipelineRuns(pr.Namespace).Patch(
+		ctx, pr.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	return err
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -329,3 +329,169 @@ func TestReconciler_handlePipelineRun(t *testing.T) {
 		})
 	}
 }
+
+func TestFinalizeKind_SSAMigration(t *testing.T) {
+	now := metav1.Now()
+	mergePatchFieldsV1 := metav1.NewFieldsV1(
+		`{"f:metadata":{"f:finalizers":{".":{},"v:\"chains.tekton.dev/pipelinerun\"":{}}}}`,
+	)
+	ssaFieldsV1 := metav1.NewFieldsV1(
+		`{"f:metadata":{"f:finalizers":{".":{},"v:\"chains.tekton.dev/pipelinerun\"":{}}}}`,
+	)
+
+	tests := []struct {
+		name                   string
+		pr                     *v1.PipelineRun
+		expectFinalizerRemoved bool
+	}{
+		{
+			name: "migration removes merge-patch finalizer on deletion",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "pipelinerun",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{pipelineRunFinalizerName, "other.finalizer"},
+					Annotations:       map[string]string{annotations.ChainsAnnotation: "true"},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Operation: metav1.ManagedFieldsOperationUpdate,
+							FieldsV1:  mergePatchFieldsV1,
+						},
+					},
+				},
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					},
+				},
+			},
+			expectFinalizerRemoved: true,
+		},
+		{
+			name: "migration skips when no DeletionTimestamp",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "pipelinerun",
+					Namespace:   "default",
+					Finalizers:  []string{pipelineRunFinalizerName},
+					Annotations: map[string]string{annotations.ChainsAnnotation: "true"},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Operation: metav1.ManagedFieldsOperationUpdate,
+							FieldsV1:  mergePatchFieldsV1,
+						},
+					},
+				},
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					},
+				},
+			},
+			expectFinalizerRemoved: false,
+		},
+		{
+			name: "migration skips when finalizer is SSA-owned",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "pipelinerun",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{pipelineRunFinalizerName},
+					Annotations:       map[string]string{annotations.ChainsAnnotation: "true"},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Operation: metav1.ManagedFieldsOperationApply,
+							FieldsV1:  ssaFieldsV1,
+						},
+					},
+				},
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					},
+				},
+			},
+			expectFinalizerRemoved: false,
+		},
+		{
+			name: "migration skips when no managed fields match",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "pipelinerun",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{pipelineRunFinalizerName},
+					Annotations:       map[string]string{annotations.ChainsAnnotation: "true"},
+				},
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					},
+				},
+			},
+			expectFinalizerRemoved: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			c := fakepipelineclient.Get(ctx)
+			tri := faketaskruninformer.Get(ctx)
+
+			// Create the object in the fake client (without DeletionTimestamp since
+			// the fake client does not allow creating objects with it set).
+			createObj := tt.pr.DeepCopy()
+			createObj.DeletionTimestamp = nil
+			if _, err := c.TektonV1().PipelineRuns(createObj.Namespace).Create(ctx, createObj, metav1.CreateOptions{}); err != nil {
+				t.Fatal(err)
+			}
+
+			r := &Reconciler{
+				PipelineRunSigner: &mocksigner.Signer{},
+				Pipelineclientset: c,
+				TaskRunLister:     tri.Lister(),
+				Tracker:           &rtesting.FakeTracker{},
+			}
+			ctx = config.ToContext(ctx, &config.Config{})
+
+			if err := r.FinalizeKind(ctx, tt.pr); err != nil {
+				t.Fatalf("FinalizeKind() error = %v", err)
+			}
+
+			got, err := c.TektonV1().PipelineRuns(tt.pr.Namespace).Get(ctx, tt.pr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Get() error = %v", err)
+			}
+
+			hasChainsFinalizer := false
+			for _, f := range got.Finalizers {
+				if f == pipelineRunFinalizerName {
+					hasChainsFinalizer = true
+				}
+			}
+
+			if tt.expectFinalizerRemoved && hasChainsFinalizer {
+				t.Errorf("expected chains finalizer to be removed, but it is still present: %v", got.Finalizers)
+			}
+			if !tt.expectFinalizerRemoved && !hasChainsFinalizer && len(tt.pr.Finalizers) > 0 {
+				t.Errorf("expected chains finalizer to be preserved, but it was removed: %v", got.Finalizers)
+			}
+
+			// For the positive case, verify other finalizers are preserved.
+			if tt.expectFinalizerRemoved {
+				hasOther := false
+				for _, f := range got.Finalizers {
+					if f == "other.finalizer" {
+						hasOther = true
+					}
+				}
+				if !hasOther {
+					t.Errorf("expected other.finalizer to be preserved, but got: %v", got.Finalizers)
+				}
+			}
+		})
+	}
+}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -14,7 +14,10 @@ limitations under the License.
 package taskrun
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"time"
 
 	signing "github.com/tektoncd/chains/pkg/chains"
 	"github.com/tektoncd/chains/pkg/chains/annotations"
@@ -22,6 +25,10 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	taskrunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/taskrun"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
@@ -29,6 +36,8 @@ import (
 const (
 	// SecretPath contains the path to the secrets volume that is mounted in.
 	SecretPath = "/etc/signing-secrets"
+
+	taskRunFinalizerName = "chains.tekton.dev/taskrun"
 )
 
 type Reconciler struct {
@@ -62,7 +71,34 @@ func removeOldFinalizerIfExists(tr *v1.TaskRun) {
 // We utilize finalizers to ensure that we get a crack at signing every taskrun
 // that we see flowing through the system.  If we don't add a finalizer, it could
 // get cleaned up before we see the final state and sign it.
-func (r *Reconciler) FinalizeKind(ctx context.Context, tr *v1.TaskRun) pkgreconciler.Event {
+func (r *Reconciler) FinalizeKind(ctx context.Context, tr *v1.TaskRun) (result pkgreconciler.Event) { //nolint:ireturn
+	// MIGRATION: When the framework dispatches DoFinalizeKind (DeletionTimestamp is set) and
+	// finalization succeeds (returns nil), check if the finalizer was added via merge patch by the
+	// old controller version. SSA cannot remove finalizers it doesn't own, so we remove it via
+	// merge patch ourselves. This can be removed once all pre-SSA resources are deleted.
+	//
+	// The DeletionTimestamp guard is necessary because in Chains, ReconcileKind delegates to
+	// FinalizeKind, so FinalizeKind is called both from the DoReconcileKind path (no
+	// DeletionTimestamp) and the DoFinalizeKind path (DeletionTimestamp set). We must only
+	// remove the finalizer when the object is actually being deleted.
+	if !tr.DeletionTimestamp.IsZero() {
+		defer func() {
+			if result != nil {
+				return
+			}
+			if !r.isFinalizerOwnedByMergePatch(tr) {
+				return
+			}
+			logging.FromContext(ctx).Infof("Removing merge-patch finalizer on %s/%s for SSA migration",
+				tr.Namespace, tr.Name)
+			if err := r.removeFinalizerViaMergePatch(ctx, tr); err != nil {
+				logging.FromContext(ctx).Warnw("Failed to remove finalizer via merge patch",
+					zap.Error(err))
+				result = controller.NewRequeueAfter(10 * time.Second)
+			}
+		}()
+	}
+
 	// Check to make sure the TaskRun is finished.
 	if !tr.IsDone() {
 		logging.FromContext(ctx).Infof("taskrun %s/%s is still running", tr.Namespace, tr.Name)
@@ -83,4 +119,56 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, tr *v1.TaskRun) pkgreconc
 	}
 	removeOldFinalizerIfExists(tr)
 	return nil
+}
+
+// isFinalizerOwnedByMergePatch checks if the finalizer was added via merge patch (Update operation).
+// MIGRATION: This is a temporary migration feature to handle the upgrade scenario where
+// in-flight TaskRuns have finalizers set via merge patch by the old controller version.
+// Kubernetes SSA treats (manager, Update) and (manager, Apply) as different owners, so we need
+// to detect and handle the old ownership pattern.
+// This function can be removed once all resources from the pre-SSA version are deleted.
+func (r *Reconciler) isFinalizerOwnedByMergePatch(tr *v1.TaskRun) bool {
+	for _, mf := range tr.ManagedFields {
+		if mf.Operation == metav1.ManagedFieldsOperationUpdate {
+			raw := mf.FieldsV1.GetRawBytes()
+			if raw != nil {
+				if bytes.Contains(raw, []byte(`"f:finalizers"`)) &&
+					bytes.Contains(raw, []byte(`v:\"chains.tekton.dev/taskrun\"`)) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// removeFinalizerViaMergePatch removes the finalizer using merge patch.
+// MIGRATION: This is a temporary migration feature to handle the upgrade scenario where
+// in-flight TaskRuns have finalizers set via merge patch by the old controller version.
+// This uses merge patch to remove finalizers that cannot be removed via SSA due to different
+// ownership (manager, Update) vs (manager, Apply).
+// This function can be removed once all resources from the pre-SSA version are deleted.
+func (r *Reconciler) removeFinalizerViaMergePatch(ctx context.Context, tr *v1.TaskRun) error {
+	var newFinalizers []string
+	for _, f := range tr.Finalizers {
+		if f != taskRunFinalizerName {
+			newFinalizers = append(newFinalizers, f)
+		}
+	}
+
+	mergePatch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"finalizers":      newFinalizers,
+			"resourceVersion": tr.ResourceVersion,
+		},
+	}
+
+	patch, err := json.Marshal(mergePatch)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.Pipelineclientset.TektonV1().TaskRuns(tr.Namespace).Patch(
+		ctx, tr.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	return err
 }

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -174,3 +174,166 @@ func TestReconciler_handleTaskRun(t *testing.T) {
 		})
 	}
 }
+
+func TestFinalizeKind_SSAMigration(t *testing.T) {
+	now := metav1.Now()
+	mergePatchFieldsV1 := metav1.NewFieldsV1(
+		`{"f:metadata":{"f:finalizers":{".":{},"v:\"chains.tekton.dev/taskrun\"":{}}}}`,
+	)
+	ssaFieldsV1 := metav1.NewFieldsV1(
+		`{"f:metadata":{"f:finalizers":{".":{},"v:\"chains.tekton.dev/taskrun\"":{}}}}`,
+	)
+
+	tests := []struct {
+		name                   string
+		tr                     *v1.TaskRun
+		expectFinalizerRemoved bool
+	}{
+		{
+			name: "migration removes merge-patch finalizer on deletion",
+			tr: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "taskrun",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{taskRunFinalizerName, "other.finalizer"},
+					Annotations:       map[string]string{annotations.ChainsAnnotation: "true"},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Operation: metav1.ManagedFieldsOperationUpdate,
+							FieldsV1:  mergePatchFieldsV1,
+						},
+					},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					},
+				},
+			},
+			expectFinalizerRemoved: true,
+		},
+		{
+			name: "migration skips when no DeletionTimestamp",
+			tr: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "taskrun",
+					Namespace:   "default",
+					Finalizers:  []string{taskRunFinalizerName},
+					Annotations: map[string]string{annotations.ChainsAnnotation: "true"},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Operation: metav1.ManagedFieldsOperationUpdate,
+							FieldsV1:  mergePatchFieldsV1,
+						},
+					},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					},
+				},
+			},
+			expectFinalizerRemoved: false,
+		},
+		{
+			name: "migration skips when finalizer is SSA-owned",
+			tr: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "taskrun",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{taskRunFinalizerName},
+					Annotations:       map[string]string{annotations.ChainsAnnotation: "true"},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Operation: metav1.ManagedFieldsOperationApply,
+							FieldsV1:  ssaFieldsV1,
+						},
+					},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					},
+				},
+			},
+			expectFinalizerRemoved: false,
+		},
+		{
+			name: "migration skips when no managed fields match",
+			tr: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "taskrun",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{taskRunFinalizerName},
+					Annotations:       map[string]string{annotations.ChainsAnnotation: "true"},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					},
+				},
+			},
+			expectFinalizerRemoved: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			c := fakepipelineclient.Get(ctx)
+
+			// Create the object in the fake client (without DeletionTimestamp since
+			// the fake client does not allow creating objects with it set).
+			createObj := tt.tr.DeepCopy()
+			createObj.DeletionTimestamp = nil
+			if _, err := c.TektonV1().TaskRuns(createObj.Namespace).Create(ctx, createObj, metav1.CreateOptions{}); err != nil {
+				t.Fatal(err)
+			}
+
+			r := &Reconciler{
+				TaskRunSigner:     &mocksigner.Signer{},
+				Pipelineclientset: c,
+			}
+			ctx = config.ToContext(ctx, &config.Config{})
+
+			if err := r.FinalizeKind(ctx, tt.tr); err != nil {
+				t.Fatalf("FinalizeKind() error = %v", err)
+			}
+
+			got, err := c.TektonV1().TaskRuns(tt.tr.Namespace).Get(ctx, tt.tr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Get() error = %v", err)
+			}
+
+			hasChainsFinalizer := false
+			for _, f := range got.Finalizers {
+				if f == taskRunFinalizerName {
+					hasChainsFinalizer = true
+				}
+			}
+
+			if tt.expectFinalizerRemoved && hasChainsFinalizer {
+				t.Errorf("expected chains finalizer to be removed, but it is still present: %v", got.Finalizers)
+			}
+			if !tt.expectFinalizerRemoved && !hasChainsFinalizer && len(tt.tr.Finalizers) > 0 {
+				t.Errorf("expected chains finalizer to be preserved, but it was removed: %v", got.Finalizers)
+			}
+
+			// For the positive case, verify other finalizers are preserved.
+			if tt.expectFinalizerRemoved {
+				hasOther := false
+				for _, f := range got.Finalizers {
+					if f == "other.finalizer" {
+						hasOther = true
+					}
+				}
+				if !hasOther {
+					t.Errorf("expected other.finalizer to be preserved, but got: %v", got.Finalizers)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add migration cleanup for switch to Server-Side Apply finalizers. It is required for inflight objects caught between the old versio (using merge patch) and the new version (using SSA patch). It could be removed once all versions using merge patch are out of support. Added unit tests for the migration logic.

Assisted-by: Claude Code

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
