### PR TITLE
chore: switch base image to ghcr.io/tektoncd/plumbing/static-base

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,2 @@
 ---
-# The default base image, cgr.dev/chainguard/static, no longer provides all the platforms the Chains
-# controller claims support for.
-defaultBaseImage: ghcr.io/wolfi-dev/static:alpine
+defaultBaseImage: ghcr.io/tektoncd/plumbing/static-base@sha256:e150c89001e336b6a0200a6bac766a7b455e5573bf91c6c37f3ef8cf2fdccf0a


### PR DESCRIPTION
# Changes

Switch `defaultBaseImage` in `.ko.yaml` to the Tekton-maintained static base image
(`ghcr.io/tektoncd/plumbing/static-base`), built and published from
[tektoncd/plumbing](https://github.com/tektoncd/plumbing/tree/main/tekton/images/static-base).

This image:
- Supports all four target architectures (amd64, arm64, s390x, ppc64le)
- Is rebuilt daily from Alpine packages via apko
- Includes CA certs, timezone data, and nonroot user (UID 65532)
- Is ~300KB per arch

Related: tektoncd/pipeline#9557, tektoncd/plumbing#3434

Replaces `ghcr.io/wolfi-dev/static:alpine`.

# Submitter Checklist

- [x] Has Docs included if any changes are user facing
- [x] Has Tests included if any functionality added or changed
- [x] Follows the commit message standard
- [x] Meets the Tekton contributor standards

/kind cleanup

# Release Notes

``` release-note
NONE
```