### PR TITLE
fix(dependabot): remove unsupported semver cooldown fields for github-actions

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -59,6 +59,3 @@ ecosystems:
       - kind/misc
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,9 +41,6 @@ updates:
         - kind/misc
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.27.x
@@ -89,9 +86,6 @@ updates:
             - version-update:semver-minor
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.26.x
@@ -137,9 +131,6 @@ updates:
             - version-update:semver-minor
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.25.x
@@ -185,9 +176,6 @@ updates:
             - version-update:semver-minor
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.20.x
@@ -233,6 +221,3 @@ updates:
             - version-update:semver-minor
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3


### PR DESCRIPTION
## Summary

- The `semver-major-days`, `semver-minor-days`, and `semver-patch-days` properties under `cooldown` are not supported for the `github-actions` package ecosystem in Dependabot
- Removed those three fields from all `github-actions` entries in both `dependabot.config.yml` (the source template) and the generated `dependabot.yml`
- `gomod` entries are unaffected and retain all semver cooldown fields

## Test plan

- [ ] Verify the Dependabot config validation passes (no more schema errors)
- [ ] Confirm `github-actions` entries only have `default-days` under `cooldown`
- [ ] Confirm `gomod` entries still have all semver cooldown fields

Made with [Cursor](https://cursor.com)