### PR TITLE
Fix: TaskRuns stuck blocked from deletion due to old chains finaliser

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -37,7 +37,8 @@ const (
 	// SecretPath contains the path to the secrets volume that is mounted in.
 	SecretPath = "/etc/signing-secrets"
 
-	taskRunFinalizerName = "chains.tekton.dev/taskrun"
+	taskRunFinalizerName    = "chains.tekton.dev/taskrun"
+	oldTaskRunFinalizerName = "chains.tekton.dev"
 )
 
 type Reconciler struct {
@@ -53,18 +54,6 @@ var _ taskrunreconciler.Finalizer = (*Reconciler)(nil)
 // This is the main entrypoint for chains business logic.
 func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgreconciler.Event {
 	return r.FinalizeKind(ctx, tr)
-}
-
-// 01-Jul-2025; this is a temp solution util we consider the old finalizer name no longer used.
-// removeOldFinalizerIfExists removes the old finalizer from the TaskRun if it exists.
-func removeOldFinalizerIfExists(tr *v1.TaskRun) {
-	const oldFinalizerName = "chains.tekton.dev"
-	for i, f := range tr.ObjectMeta.Finalizers {
-		if f == oldFinalizerName {
-			tr.ObjectMeta.Finalizers = append(tr.ObjectMeta.Finalizers[:i], tr.ObjectMeta.Finalizers[i+1:]...)
-			break
-		}
-	}
 }
 
 // FinalizeKind implements taskrunreconciler.Finalizer
@@ -110,14 +99,12 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, tr *v1.TaskRun) (result p
 	// Check to see if it has already been signed.
 	if annotations.Reconciled(ctx, r.Pipelineclientset, obj) {
 		logging.FromContext(ctx).Infof("taskrun %s/%s has been reconciled", tr.Namespace, tr.Name)
-		removeOldFinalizerIfExists(tr)
 		return nil
 	}
 
 	if err := r.TaskRunSigner.Sign(ctx, obj); err != nil {
 		return err
 	}
-	removeOldFinalizerIfExists(tr)
 	return nil
 }
 
@@ -133,7 +120,8 @@ func (r *Reconciler) isFinalizerOwnedByMergePatch(tr *v1.TaskRun) bool {
 			raw := mf.FieldsV1.GetRawBytes()
 			if raw != nil {
 				if bytes.Contains(raw, []byte(`"f:finalizers"`)) &&
-					bytes.Contains(raw, []byte(`v:\"chains.tekton.dev/taskrun\"`)) {
+					(bytes.Contains(raw, []byte(`v:\"chains.tekton.dev/taskrun\"`)) ||
+						bytes.Contains(raw, []byte(`v:\"chains.tekton.dev\"`))) {
 					return true
 				}
 			}
@@ -151,7 +139,7 @@ func (r *Reconciler) isFinalizerOwnedByMergePatch(tr *v1.TaskRun) bool {
 func (r *Reconciler) removeFinalizerViaMergePatch(ctx context.Context, tr *v1.TaskRun) error {
 	var newFinalizers []string
 	for _, f := range tr.Finalizers {
-		if f != taskRunFinalizerName {
+		if f != taskRunFinalizerName && f != oldTaskRunFinalizerName {
 			newFinalizers = append(newFinalizers, f)
 		}
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -180,6 +180,9 @@ func TestFinalizeKind_SSAMigration(t *testing.T) {
 	mergePatchFieldsV1 := metav1.NewFieldsV1(
 		`{"f:metadata":{"f:finalizers":{".":{},"v:\"chains.tekton.dev/taskrun\"":{}}}}`,
 	)
+	mergePatchFieldsV1Old := metav1.NewFieldsV1(
+		`{"f:metadata":{"f:finalizers":{".":{},"v:\"chains.tekton.dev\"":{}}}}`,
+	)
 	ssaFieldsV1 := metav1.NewFieldsV1(
 		`{"f:metadata":{"f:finalizers":{".":{},"v:\"chains.tekton.dev/taskrun\"":{}}}}`,
 	)
@@ -278,6 +281,62 @@ func TestFinalizeKind_SSAMigration(t *testing.T) {
 			},
 			expectFinalizerRemoved: false,
 		},
+		{
+			name: "migration removes old merge-patch finalizer on deletion",
+			tr: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "taskrun",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{oldTaskRunFinalizerName, "other.finalizer"},
+					Annotations:       map[string]string{annotations.ChainsAnnotation: "true"},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Operation: metav1.ManagedFieldsOperationUpdate,
+							FieldsV1:  mergePatchFieldsV1Old,
+						},
+						{
+							Operation: metav1.ManagedFieldsOperationApply,
+							FieldsV1:  ssaFieldsV1,
+						},
+					},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					},
+				},
+			},
+			expectFinalizerRemoved: true,
+		},
+		{
+			name: "migration removes old merge-patch finalizer on deletion together with new one",
+			tr: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "taskrun",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{taskRunFinalizerName, oldTaskRunFinalizerName, "other.finalizer"},
+					Annotations:       map[string]string{annotations.ChainsAnnotation: "true"},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Operation: metav1.ManagedFieldsOperationUpdate,
+							FieldsV1:  mergePatchFieldsV1Old,
+						},
+						{
+							Operation: metav1.ManagedFieldsOperationApply,
+							FieldsV1:  ssaFieldsV1,
+						},
+					},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+					},
+				},
+			},
+			expectFinalizerRemoved: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -309,13 +368,17 @@ func TestFinalizeKind_SSAMigration(t *testing.T) {
 			}
 
 			hasChainsFinalizer := false
+			hasOldChainsFinalizer := false
 			for _, f := range got.Finalizers {
 				if f == taskRunFinalizerName {
 					hasChainsFinalizer = true
 				}
+				if f == oldTaskRunFinalizerName {
+					hasOldChainsFinalizer = true
+				}
 			}
 
-			if tt.expectFinalizerRemoved && hasChainsFinalizer {
+			if tt.expectFinalizerRemoved && (hasChainsFinalizer || hasOldChainsFinalizer) {
 				t.Errorf("expected chains finalizer to be removed, but it is still present: %v", got.Finalizers)
 			}
 			if !tt.expectFinalizerRemoved && !hasChainsFinalizer && len(tt.tr.Finalizers) > 0 {


### PR DESCRIPTION
Chains v.0.27.0 started to use Service-Side-Apply mechanism to manage finalisers. SSA mechanism cannot modify finalisers previously added by merge patch method. As a result, deletion of TaskRuns that were triggered before the Chains update and got old finalisers is blocked forever.

This change is updating the existing `removeFinalizerViaMergePatch` to also cleanup the old finaliser and allow future deletion of a TaskRun.

Fixes: #1755

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Fixes: Unblocked TaskRun deletions stuck on legacy finalizers after updating to v0.27.0.
```
