### PR TITLE
ci(dependabot): group github-actions bumps across all branches

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -57,5 +57,9 @@ ecosystems:
       - dependencies
       - release-note-none
       - kind/misc
+    groups:
+      all:
+        patterns:
+          - "*"
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,10 @@ updates:
         - dependencies
         - release-note-none
         - kind/misc
+      groups:
+        all:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -84,6 +88,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -129,6 +137,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -174,6 +186,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -219,5 +235,9 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Add `groups` configuration to the `github-actions` ecosystem in the
dependabot config so that action version bumps are grouped into a single
PR instead of creating individual PRs for each action. This is applied
to main and all release branches via the generator, matching the pattern
already used for `gomod` updates.

Reference: tektoncd/pipeline and tektoncd/cli use the same approach.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```