### PR TITLE
fix(signing): make KMS OIDC fallback test environment-independent

### DIFF
--- a/pkg/chains/signing/kms/kms.go
+++ b/pkg/chains/signing/kms/kms.go
@@ -39,7 +39,7 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-const defaultOIDCTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint:gosec // Not a credential, this is the path to read the K8s SA token file from
+var defaultOIDCTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint:gosec // Not a credential, this is the path to read the K8s SA token file from
 
 // Signer exposes methods to sign payloads using a KMS
 type Signer struct {

--- a/pkg/chains/signing/kms/kms_test.go
+++ b/pkg/chains/signing/kms/kms_test.go
@@ -215,6 +215,10 @@ func TestOIDCTokenEndToEnd(t *testing.T) {
 // TestOIDCTokenFallbackToDefaultPath proves that when oidc.path/role are set
 // but no token-path is given, the code tries the default K8s SA token path.
 func TestOIDCTokenFallbackToDefaultPath(t *testing.T) {
+	orig := defaultOIDCTokenPath
+	defaultOIDCTokenPath = t.TempDir() + "/nonexistent-sa-token"
+	t.Cleanup(func() { defaultOIDCTokenPath = orig })
+
 	cfg := config.KMSSigner{
 		Auth: config.KMSAuth{
 			OIDC: config.KMSAuthOIDC{


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
Fix `TestOIDCTokenFallbackToDefaultPath` failing in the release pipeline while passing locally.

  ### Problem

  The test verifies that when `oidc.path` and `oidc.role` are configured
  but no explicit `tokenPath` is given, `NewSigner` falls back to the
  default Kubernetes service account token path
  (`/var/run/secrets/kubernetes.io/serviceaccount/token`) and errors
  because the file doesn't exist.

  On developer machines this works, but in the release pipeline the tests
  run inside a Kubernetes pod where that file **does** exist (auto-mounted
  by K8s). So `os.ReadFile` succeeds, the OIDC block completes, and the
  error surfaces later from `kms.Get()` with an empty `KMSRef`:

```
  no kms provider found for key reference: : parsing input key resource id:
  expected format: [plugin name]://[key ref], got:
```

  This doesn't match the test's `assert.Contains` checks for
  `"reading OIDC token"`, causing the failure.

  ### Fix

  - Change `defaultOIDCTokenPath` from `const` to `var` (unexported, no
    API impact) so tests can override it.
  - In the test, override it to `t.TempDir() + "/nonexistent-sa-token"` —
    a path guaranteed not to exist in any environment — and restore the
    original via `t.Cleanup`.
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```

/kind bug