### PR TITLE
Update reusable-e2e.yaml to remove ko version

### DIFF
--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -45,8 +45,6 @@ jobs:
         go-version-file: "go.mod"
 
     - uses: ko-build/setup-ko@61b4d1d396f5b2e7d6bb6fefdce3dc38d1a13445 # v0.10
-      with:
-        version: v0.18.1
 
     - name: Install mirror, kind, knative + sigstore
       uses: sigstore/scaffolding/actions/setup@8bd68672d418e5bd1b0ee1f2e2981874c3a30967  # v0.7.33

--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -25,6 +25,9 @@ jobs:
       GO111MODULE: 'on'
       GOFLAGS: -ldflags=-s -ldflags=-w
       KO_DOCKER_REPO: registry.local:5000/knative
+      # registry.local:5000 is a plain-HTTP KinD registry; tell ko to skip TLS
+      # so that both image pushes and SBOM writes (ko >=v0.19) use plain HTTP.
+      KO_FLAGS: --insecure-registry
       KOCACHE: ~/ko
       SIGSTORE_SCAFFOLDING_RELEASE_VERSION: "v0.7.31"
       TEKTON_PIPELINES_RELEASE: "https://infra.tekton.dev/tekton-releases/pipeline/previous/${{ inputs.pipelines-release }}/release.yaml"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -61,7 +61,7 @@ function install_pipeline_crd() {
 
 function install_chains() {
   echo ">> Deploying Tekton Chains"
-  ko apply -f config/ || fail_test "Tekton Chains installation failed"
+  ko apply ${KO_FLAGS:-} -f config/ || fail_test "Tekton Chains installation failed"
 
   # Wait for pods to be running in the namespaces we are deploying to
   wait_until_pods_running ${namespace} || fail_test "Tekton Chains did not come up"


### PR DESCRIPTION
Removed version specification for ko-build/setup-ko action.

The latest release has https://github.com/ko-build/ko/pull/1694

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
