### PR TITLE
fix(storage): skip docdb watcher reconfiguration on empty file read

### DIFF
--- a/pkg/chains/storage/docdb/docdb.go
+++ b/pkg/chains/storage/docdb/docdb.go
@@ -152,6 +152,10 @@ func WatchBackend(ctx context.Context, cfg config.Config, watcherStop chan bool)
 					}
 				}
 
+				if updatedEnv == "" {
+					continue
+				}
+
 				if updatedEnv != os.Getenv("MONGO_SERVER_URL") {
 					logger.Info("Mongo server url has been updated, reconfiguring backend...")
 


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
Fix flaky `TestWatchBackend` that fails intermittently in the release pipeline but passes locally.

  ### Problem
`os.WriteFile` is not atomic — it truncates the file (`O_TRUNC`) writing new content. When the fsnotify watcher goroutine reads the file during this truncation window, it gets an empty string. This causes:

  1. `MONGO_SERVER_URL` env var set to `""`
  2. `docstore.OpenCollection` fails: "MONGO_SERVER_URL environment
     variable is not set"
  3. Watcher sends `nil` to the unbuffered `backendChan` and **blocks**
  4. Subsequent fsnotify events can never be processed — deadlock

The race is timing-dependent: on a fast local machine the watcher processes events before the next file write starts; on a busy CI node the truncation window is wide enough to hit.

  ### Fix

Skip reconfiguration when the file read returns an empty value. An empty `MONGO_SERVER_URL` is never a valid configuration — reconfiguring with it always fails. In production, Kubernetes secret mounts use atomic symlink swaps (`..data`), so transient empty reads don't occur; this guard makes the watcher robust to non-atomic writes without changing any valid production behavior.
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```

/kind bug