### PR TITLE
fix(x509): return errors instead of panicking on unusable key material

### DIFF
--- a/pkg/chains/signing/x509/x509.go
+++ b/pkg/chains/signing/x509/x509.go
@@ -180,6 +180,9 @@ func x509Signer(ctx context.Context, privateKey []byte) (*Signer, error) {
 	logger.Info("Found x509 key...")
 
 	p, _ := pem.Decode(privateKey)
+	if p == nil {
+		return nil, fmt.Errorf("failed to decode PEM block from x509 private key")
+	}
 	if p.Type != "PRIVATE KEY" {
 		return nil, fmt.Errorf("expected private key, found object of type %s", p.Type)
 	}
@@ -187,7 +190,11 @@ func x509Signer(ctx context.Context, privateKey []byte) (*Signer, error) {
 	if err != nil {
 		return nil, err
 	}
-	signer, err := signature.LoadECDSASignerVerifier(pk.(*ecdsa.PrivateKey), crypto.SHA256)
+	ecdsaKey, ok := pk.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("unsupported private key type %T, only ECDSA keys are supported", pk)
+	}
+	signer, err := signature.LoadECDSASignerVerifier(ecdsaKey, crypto.SHA256)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chains/signing/x509/x509_test.go
+++ b/pkg/chains/signing/x509/x509_test.go
@@ -223,3 +223,38 @@ func TestSigner_SignED25519(t *testing.T) {
 		t.Error("invalid signature")
 	}
 }
+
+func TestNewSignerMalformedX509Key(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+	d := t.TempDir()
+	p := filepath.Join(d, "x509.pem")
+	if err := os.WriteFile(p, []byte("this is not a PEM block"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := NewSigner(ctx, d, config.Config{})
+	if err == nil {
+		t.Fatal("expected an error for a key file without a PEM block, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to decode PEM block") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewSignerUnsupportedX509KeyType(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+	d := t.TempDir()
+	p := filepath.Join(d, "x509.pem")
+	// ed25519 keys are a valid PKCS8 key but not supported by the x509 signer.
+	if err := os.WriteFile(p, []byte(ed25519Priv), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := NewSigner(ctx, d, config.Config{})
+	if err == nil {
+		t.Fatal("expected an error for an unsupported key type, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported private key type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
# Changes

While reading through the x509 signer I noticed two spots where a bad signing secret takes down the controller with a panic instead of a normal error.

In `x509Signer`, the result of `pem.Decode` is used without a nil check. When the `x509.pem` secret does not contain a valid PEM block (an empty file, base64 without the PEM headers, etc.), `pem.Decode` returns nil and the next line dereferences it, so the process crashes with a nil pointer panic. Right below that, the parsed key is asserted to `*ecdsa.PrivateKey` unconditionally, which panics for any other PKCS8 key type such as an ed25519 key (the ed25519 signing test is currently skipped, so this path isn't otherwise exercised).

Both now return a descriptive error, so a misconfigured signing secret shows up as a normal failure rather than a crash. I added a couple of tests covering a malformed PEM file and an unsupported key type, and I confirmed the existing x509 tests still pass along with `go vet`.

# Release Notes

```release-note
Fixed a panic in the x509 signer when the configured private key is not a valid PEM block or is not an ECDSA key; these now return an error.
```