### PR TITLE
fix(release): bump pinned ko image for go 1.26.4

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -63,3 +63,18 @@ ecosystems:
           - "*"
     cooldown:
       default-days: 7
+  - package-ecosystem: docker
+    directory: /release
+    schedule:
+      interval: weekly
+    labels:
+      - ok-to-test
+      - dependencies
+      - release-note-none
+      - kind/misc
+    groups:
+      all:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,21 @@ updates:
                 - '*'
       cooldown:
         default-days: 7
+    - package-ecosystem: docker
+      directory: /release
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - release-note-none
+        - kind/misc
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.27.x
@@ -94,6 +109,27 @@ updates:
                 - '*'
       cooldown:
         default-days: 7
+    - package-ecosystem: docker
+      directory: /release
+      target-branch: release-v0.27.x
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - release-note-none
+        - kind/misc
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.26.x
@@ -124,6 +160,27 @@ updates:
         semver-patch-days: 3
     - package-ecosystem: github-actions
       directory: /
+      target-branch: release-v0.26.x
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - release-note-none
+        - kind/misc
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
+    - package-ecosystem: docker
+      directory: /release
       target-branch: release-v0.26.x
       schedule:
         interval: weekly
@@ -173,6 +230,27 @@ updates:
         semver-patch-days: 3
     - package-ecosystem: github-actions
       directory: /
+      target-branch: release-v0.25.x
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - release-note-none
+        - kind/misc
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
+    - package-ecosystem: docker
+      directory: /release
       target-branch: release-v0.25.x
       schedule:
         interval: weekly
@@ -222,6 +300,27 @@ updates:
         semver-patch-days: 3
     - package-ecosystem: github-actions
       directory: /
+      target-branch: release-v0.20.x
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - release-note-none
+        - kind/misc
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
+    - package-ecosystem: docker
+      directory: /release
       target-branch: release-v0.20.x
       schedule:
         interval: weekly

--- a/release/publish.yaml
+++ b/release/publish.yaml
@@ -109,7 +109,7 @@ spec:
 
 
   - name: run-ko
-    image: ghcr.io/tektoncd/plumbing/ko@sha256:f84dda0237cdaf9a6c2f15a56a380bd97ac2d5a554714818d7500056d2c7d449
+    image: ghcr.io/tektoncd/plumbing/ko@sha256:ce22d9774f8d4594847af63cd7d654dc15ae8a21634c6279b3720122a7977c31
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -169,7 +169,7 @@ spec:
       sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/release.yaml
       sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/release.notags.yaml
   - name: koparse
-    image: ghcr.io/tektoncd/plumbing/koparse@sha256:939dad5cf7c613b6b54387dfceca51e9a0f367e3cc5fbd04c7012af6c38e0717
+    image: ghcr.io/tektoncd/plumbing/koparse@sha256:54e552e06f53bc1eee6dc0ff03b9c8737dd07d466cf302c208c580dba05db49c
     script: |
       set -ex
 


### PR DESCRIPTION
# Changes

The patch-release pipeline runs `ko resolve` inside the pinned
`ghcr.io/tektoncd/plumbing/ko` image, which bakes in a specific Go
toolchain. `go.mod` requires `go 1.26.4`, but the pinned `ko` image in
`release/publish.yaml` still shipped `GOLANG_VERSION=1.26.3`. Since
`GOTOOLCHAIN=local`, `ko resolve` refused to auto-fetch the newer
toolchain and the release failed with:

```
go: go.mod requires go >= 1.26.4 (running go 1.26.3; GOTOOLCHAIN=local)
```

This mirrors how `tektoncd/pipeline` avoids this class of failure: it
has a `docker` Dependabot ecosystem entry for its `/tekton` directory
that keeps the pinned `ko`/`koparse` image digests continuously
up to date. Chains had no such entry, so the pinned digests could
silently drift behind `go.mod`.

- Bump `ko` and `koparse` image digests in `release/publish.yaml` to
  versions shipping `GOLANG_VERSION=1.26.4` (verified via
  `crane config`).
- Add a `docker` package-ecosystem entry for `/release` in
  `.github/dependabot.config.yml` and regenerate
  `.github/dependabot.yml` via `./hack/generate-dependabot.sh`, so
  Dependabot keeps these pinned image digests in sync with `go.mod`
  going forward.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```

Made with [Cursor](https://cursor.com)