### PR TITLE
Move lcarva to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,7 +6,6 @@ approvers:
 - enarha
 - infernus01
 - jkhelil
-- lcarva
 - PuneetPunamiya
 - vdemeester
 - wlynch
@@ -18,7 +17,6 @@ reviewers:
 - enarha
 - infernus01
 - jkhelil
-- lcarva
 - ngelman1
 - PuneetPunamiya
 - vdemeester
@@ -34,3 +32,4 @@ emeritus_approvers:
 - chuangw6
 - chitrangpatel
 - priyawadhwa
+- lcarva


### PR DESCRIPTION
Since I have not been involved with the Tekton community recently, and I expect that to continue, I'd like to step down and have my access revoked in the interest of good security hygiene. No sense in keeping permissions I'm not using.

I'm happy to keep my name under emeritus_approvers so folks can more easily ping me if needed.
