### PR TITLE
fix(ci): pin ko binary to v0.18.1 for release-v0.20.x e2e tests

### DIFF
--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -58,6 +58,8 @@ jobs:
         go-version-file: "src/github.com/tektoncd/chains/go.mod"
 
     - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+      with:
+        version: v0.18.1
 
     - name: Install tkn cli
       run: |


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
  Pin ko binary version to v0.18.1 in the e2e workflow for
  release-v0.20.x.

  ### Problem

  The `setup-ko` action had no `version:` input, so it defaulted to
  `latest-release`. ko v0.19.1 introduced a security change that
  rejects kodata symlinks resolving outside the kodata root:

  kodata symlink "HEAD" resolves to ".git/HEAD" which is outside
  the kodata root

  This breaks `ko apply` because `cmd/controller/kodata/HEAD` and
  `cmd/controller/kodata/refs` are symlinks into `.git/` for version
  embedding. All e2e tests fail since the controller image can't be
  built.
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```

