### PR TITLE
ci(coverage): add Codecov integration with OIDC auth

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,20 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default: false
+
+ignore:
+  - "**/zz_generated*.go"
+  - "vendor/**"
+  - "test/**"
+  - "config/**"
+  - "docs/**"
+  - "hack/**"
+  - "cmd/**"
+  - "examples/**"
+  - "images/**"
+  - "release/**"

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Harden runner
@@ -48,7 +49,7 @@ jobs:
       - name: Generate coverage
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/chains
         run: |
-          go test -cover -coverprofile=coverage.txt ./... || true
+          go test -coverprofile=coverage.txt -covermode=atomic ./... || true
           echo "Generated coverage profile"
 
       - name: Archive coverage results
@@ -56,6 +57,15 @@ jobs:
         with:
           name: code-coverage
           path: ${{ github.workspace }}/src/github.com/tektoncd/chains/coverage.txt
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
+        continue-on-error: true
+        with:
+          files: ${{ github.workspace }}/src/github.com/tektoncd/chains/coverage.txt
+          flags: unit-tests
+          use_oidc: true
+          fail_ci_if_error: true
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
Chains unit tests run in CI but coverage data is ephemeral — it exists  only as a GitHub Actions artifact with a PR delta comment. There's no historical trend, no per-package breakdown, and no way to detect slow coverage erosion across releases.

This PR adds Codecov integration so coverage is tracked continuously on the [Codecov dashboard](https://app.codecov.io/gh/tektoncd/chains).

  **How it works:**
  - The existing `go-coverage` workflow already generates a coverage profile — this PR adds a `codecov/codecov-action` upload step alongside it
  - Authentication uses GitHub Actions OIDC (`use_oidc: true` + `id-token: write`), so no `CODECOV_TOKEN` secret is needed
  - Coverage generation switches to `-covermode=atomic` for accuracy under concurrent tests
  - Upload failures show as a yellow warning but never block CI (`continue-on-error: true` + `fail_ci_if_error: true`)
  - The existing PR comment via `go-coverage-report` is preserved

  **`.codecov.yaml` configuration:**
  - `target: auto` with 5% threshold — PRs fail only on significant overall coverage regression
  - Patch-level gating disabled — PRs aren't blocked for uncovered lines in the diff itself
  - Excludes non-production paths: generated code, vendor, test, config, docs, hack, cmd, examples, images, release
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
