### PR TITLE
fix(signing): aggregate no-signer-configured errors into MarkSigned decision

### DIFF
--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -172,7 +172,8 @@ func (o *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject)
 			signer, ok := signers[signerType]
 			if !ok {
 				logger.Warnf("No signer %s configured for %s", signerType, signableType.Type())
-				continue
+				merr = multierror.Append(merr, fmt.Errorf("no signer %s configured for %s", signerType, signableType.Type()))
+				break
 			}
 
 			if payloader.Wrap() {

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -83,11 +83,12 @@ func TestSigner_Sign(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		backends []*mockBackend
-		wantErr  bool
-		object   objects.TektonObject
-		config   *config.Config
+		name       string
+		backends   []*mockBackend
+		wantErr    bool
+		object     objects.TektonObject
+		config     *config.Config
+		secretPath string
 	}{
 		{
 			name: "taskrun single system",
@@ -143,6 +144,16 @@ func TestSigner_Sign(t *testing.T) {
 			object:  pro,
 			config:  pcfg,
 		},
+		{
+			name: "taskrun no signer configured",
+			backends: []*mockBackend{
+				{backendType: "foo"},
+			},
+			wantErr:    true,
+			object:     tro,
+			config:     tcfg,
+			secretPath: "./signing/x509/testdata/does-not-exist",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -152,9 +163,13 @@ func TestSigner_Sign(t *testing.T) {
 
 			ctx = config.ToContext(ctx, tt.config.DeepCopy())
 
+			secretPath := tt.secretPath
+			if secretPath == "" {
+				secretPath = "./signing/x509/testdata/"
+			}
 			ts := &ObjectSigner{
 				Backends:          fakeAllBackends(tt.backends),
-				SecretPath:        "./signing/x509/testdata/",
+				SecretPath:        secretPath,
 				Pipelineclientset: ps,
 			}
 


### PR DESCRIPTION
Motivation:
When no signer (e.g. no x509.pem/cosign.key) is configured for a
required signer type, ObjectSigner.Sign() logs "No signer %s
configured for %s" and continues, but never records this as a
failure. Since the aggregate `merr` stays nil, Sign() falls through
to annotations.MarkSigned(), which sets
chains.tekton.dev/signed=true even though nothing was signed. That
annotation is treated as terminal, so the TaskRun/PipelineRun is
never retried once a signer becomes available. This is the exact
scenario reported in #858: no signing key configured, yet Chains
marks the run as signed.

Note: user-visible behavior for legitimate `Signer: "none"`
configurations (intentional opt-out of signing for an artifact
type) is unchanged - Artifact.Enabled() short-circuits before the
signer lookup for that case, so this only affects the genuine
misconfiguration path.

Approach:
Append an error to the existing `merr` aggregate in the
"no signer configured" branch of ObjectSigner.Sign(), matching the
same multierror.Append pattern already used a few lines below for
storage failures. This makes Sign() return an error and take the
existing HandleRetry path instead of MarkSigned, so the resource is
retried on the next reconciliation rather than being permanently
marked signed.

Validation:
Added a table-driven case to TestSigner_Sign that points SecretPath
at a directory with no key material, reproducing the no-signer
scenario, and asserts the object is NOT marked signed. Verified the
new case fails without the fix (IsSigned()=true, wanted false) and
passes with it.

  go build ./...
  go test ./pkg/chains/...
  make golangci-lint PKG=./pkg/chains/...

All pass with zero failures and zero lint issues.

Fixes #858

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.