### PR TITLE
(feat)Support native Tekton Artifacts API in SLSA provenance

### DIFF
--- a/docs/slsa-provenance.md
+++ b/docs/slsa-provenance.md
@@ -417,6 +417,61 @@ spec:
 
 Chains Will read `first-ARTIFACT_OUTPUTS` and `second-IMAGE_URL/second-IMAGE_DIGEST` from the StepAction and classify them as a `subject`.
 
+## Native Tekton Artifacts API
+This is a native, structured way to declare build inputs and outputs using the
+[Tekton Artifacts API (TEP-0147)](https://github.com/tektoncd/community/blob/main/teps/0147-tekton-artifacts-phase1.md).
+This is an alternative to type hinting that provides richer, more explicit
+artifact declarations.
+### Prerequisites
+The Artifacts API is gated behind a feature flag in Tekton Pipelines: "enable-artifacts"
+### How it works:
+Instead of writing to specially named results, steps write a structured JSON file to $(step.artifacts.path). The Tekton Pipelines controller reads this file and populates status.artifacts and status.steps[].inputs/outputs on the TaskRun.
+
+Chains then maps these artifacts into the SLSA provenance. 
+Example TaskRun: 
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: build-with-artifacts
+spec:
+  taskSpec:
+    steps:
+      - name: build-and-push
+        image: gcr.io/kaniko-project/executor
+        script: |
+          #!/usr/bin/env bash
+          # Build and push the image
+          buildah push myimage quay.io/myorg/myapp --digestfile /tmp/digest.txt
+          DIGEST=$(cat /tmp/digest.txt)
+
+          # Declare artifacts
+          cat > $(step.artifacts.path) << EOF
+          {
+            "inputs": [
+              {
+                "name": "source-code",
+                "values": [{
+                  "uri": "git+https://github.com/myorg/myrepo.git",
+                  "digest": {"sha256": "7f2f...."}
+                }]
+              }
+            ],
+            "outputs": [
+              {
+                "name": "container-image",
+                "values": [{
+                  "uri": "quay.io/myorg/myapp",
+                  "digest": {"sha256": "${DIGEST}"}
+                }],
+                "buildOutput": true
+              }
+            ]
+          }
+          EOF
+```
+If a TaskRun uses both type hinting and native artifacts, Chains will include artifacts from both sources. Duplicates are removed automatically.
 
 ## Besides inputs/outputs
 

--- a/pkg/chains/formats/slsa/internal/material/material.go
+++ b/pkg/chains/formats/slsa/internal/material/material.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/artifact"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/slsaconfig"
 	"github.com/tektoncd/chains/pkg/chains/objects"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"knative.dev/pkg/logging"
 )
 
@@ -240,6 +241,38 @@ func FromStepActionsResults(ctx context.Context, tro *objects.TaskRunObjectV1) (
 	sms := artifacts.RetrieveMaterialsFromStructuredResults(ctx, tro.GetStepResults())
 	mats = artifact.AppendMaterials(mats, sms...)
 	return
+}
+
+// FromNativeArtifactInputs converts native Tekton Artifact inputs (TEP-0147) into provenance materials.
+func FromNativeArtifactInputs(_ context.Context, tro *objects.TaskRunObjectV1) []common.ProvenanceMaterial {
+	var mats []common.ProvenanceMaterial
+
+	addInputs := func(inputs []v1.Artifact) {
+		for _, input := range inputs {
+			for _, val := range input.Values {
+				if val.Uri == "" || len(val.Digest) == 0 {
+					continue
+				}
+				digestSet := common.DigestSet{}
+				for algo, hex := range val.Digest {
+					// Turns {Algorithm("sha256"): "abc123"} To {"sha256": "abc123"}
+					digestSet[string(algo)] = hex
+				}
+				mats = artifact.AppendMaterials(mats, common.ProvenanceMaterial{
+					URI:    val.Uri,
+					Digest: digestSet,
+				})
+			}
+		}
+	}
+	if arts := tro.GetArtifacts(); arts != nil {
+		addInputs(arts.Inputs)
+	} else {
+		for _, step := range tro.GetStepArtifacts() {
+			addInputs(step.Inputs)
+		}
+	}
+	return mats
 }
 
 // FromPipelineParamsAndResults extracts type hinted params and results and adds the url and digest to materials.

--- a/pkg/chains/formats/slsa/internal/material/material_test.go
+++ b/pkg/chains/formats/slsa/internal/material/material_test.go
@@ -715,3 +715,153 @@ func createProWithPipelineParamAndTaskResult() *objects.PipelineRunObjectV1 {
 	pro.Status.PipelineSpec.Tasks = []v1.PipelineTask{{Name: pipelineTaskName}}
 	return pro
 }
+
+func TestFromNativeArtifactInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		tro  *objects.TaskRunObjectV1
+		want []common.ProvenanceMaterial
+	}{
+		{
+			name: "no artifacts",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{},
+				},
+			}),
+			want: nil,
+		},
+		{
+			name: "taskrun-level artifact inputs",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Artifacts: &v1.Artifacts{
+							Inputs: []v1.Artifact{
+								{
+									Name: "source",
+									Values: []v1.ArtifactValue{
+										{Uri: "git+https://github.com/org/repo.git", Digest: map[v1.Algorithm]string{"sha1": "abc123def456abc123def456abc123def456abc1"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			want: []common.ProvenanceMaterial{
+				{
+					URI:    "git+https://github.com/org/repo.git",
+					Digest: common.DigestSet{"sha1": "abc123def456abc123def456abc123def456abc1"},
+				},
+			},
+		},
+		{
+			name: "step-level artifact inputs",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Steps: []v1.StepState{
+							{
+								Name: "clone",
+								Inputs: []v1.TaskRunStepArtifact{
+									{
+										Name: "base-image",
+										Values: []v1.ArtifactValue{
+											{Uri: "registry.redhat.io/ubi9", Digest: map[v1.Algorithm]string{"sha256": "05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			want: []common.ProvenanceMaterial{
+				{
+					URI:    "registry.redhat.io/ubi9",
+					Digest: common.DigestSet{"sha256": "05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"},
+				},
+			},
+		},
+		{
+			name: "skips values with empty uri",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Artifacts: &v1.Artifacts{
+							Inputs: []v1.Artifact{
+								{
+									Name: "incomplete",
+									Values: []v1.ArtifactValue{
+										{Uri: "", Digest: map[v1.Algorithm]string{"sha256": "abc"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			want: nil,
+		},
+		{
+			// When Status.Artifacts is present, only the aggregate is read (Pipelines
+			// merges step artifacts into it). Step inputs must not be double-counted.
+			name: "prefers aggregate when present",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Artifacts: &v1.Artifacts{
+							Inputs: []v1.Artifact{
+								{
+									Name: "source",
+									Values: []v1.ArtifactValue{
+										{Uri: "git+https://github.com/org/repo.git", Digest: map[v1.Algorithm]string{"sha1": "abc123def456abc123def456abc123def456abc1"}},
+									},
+								},
+								{
+									Name: "config",
+									Values: []v1.ArtifactValue{
+										{Uri: "https://example.com/config.yaml", Digest: map[v1.Algorithm]string{"sha256": "05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"}},
+									},
+								},
+							},
+						},
+						Steps: []v1.StepState{
+							{
+								Name: "fetch",
+								Inputs: []v1.TaskRunStepArtifact{
+									{
+										Name: "config",
+										Values: []v1.ArtifactValue{
+											{Uri: "https://example.com/config.yaml", Digest: map[v1.Algorithm]string{"sha256": "05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			want: []common.ProvenanceMaterial{
+				{
+					URI:    "git+https://github.com/org/repo.git",
+					Digest: common.DigestSet{"sha1": "abc123def456abc123def456abc123def456abc1"},
+				},
+				{
+					URI:    "https://example.com/config.yaml",
+					Digest: common.DigestSet{"sha256": "05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := logtesting.TestContextWithLogger(t)
+			got := FromNativeArtifactInputs(ctx, tc.tro)
+			if diff := cmp.Diff(tc.want, got, compare.MaterialsCompareOption()); diff != "" {
+				t.Errorf("FromNativeArtifactInputs(): -want +got: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/chains/formats/slsa/internal/resolved_dependencies/resolved_dependencies.go
+++ b/pkg/chains/formats/slsa/internal/resolved_dependencies/resolved_dependencies.go
@@ -239,6 +239,7 @@ func taskDependencies(ctx context.Context, opts ResolveOptions, tro *objects.Tas
 	}
 
 	mats = material.FromTaskParamsAndResults(ctx, tro)
+	mats = append(mats, material.FromNativeArtifactInputs(ctx, tro)...)
 	// convert materials to resolved dependencies
 	resolvedDependencies = append(resolvedDependencies, ConvertMaterialsToResolvedDependencies(mats, InputResultName)...)
 

--- a/pkg/chains/formats/slsa/v2alpha4/internal/taskrun/taskrun.go
+++ b/pkg/chains/formats/slsa/v2alpha4/internal/taskrun/taskrun.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	intoto "github.com/in-toto/attestation/go/v1"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/extract"
 	"github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/artifact"
 	builddefinition "github.com/tektoncd/chains/pkg/chains/formats/slsa/internal/build_definition"
@@ -66,8 +67,43 @@ func ByProducts(tro *objects.TaskRunObjectV1) ([]*intoto.ResourceDescriptor, err
 		return nil, err
 	}
 	byProd = append(byProd, res...)
+	byProd = append(byProd, byProductsFromNativeArtifacts(tro)...)
 
 	return byProd, nil
+}
+
+func byProductsFromNativeArtifacts(tro *objects.TaskRunObjectV1) []*intoto.ResourceDescriptor {
+	var byProds []*intoto.ResourceDescriptor
+
+	addNonBuildOutputs := func(outputs []v1.Artifact) {
+		for _, output := range outputs {
+			if output.BuildOutput {
+				continue
+			}
+			for _, val := range output.Values {
+				if val.Uri == "" || len(val.Digest) == 0 {
+					continue
+				}
+				digestSet := common.DigestSet{}
+				for algo, hex := range val.Digest {
+					digestSet[string(algo)] = hex
+				}
+				byProds = append(byProds, &intoto.ResourceDescriptor{
+					Name:   val.Uri,
+					Digest: digestSet,
+				})
+			}
+		}
+	}
+
+	if arts := tro.GetArtifacts(); arts != nil {
+		addNonBuildOutputs(arts.Outputs)
+	} else {
+		for _, step := range tro.GetStepArtifacts() {
+			addNonBuildOutputs(step.Outputs)
+		}
+	}
+	return byProds
 }
 
 // SubjectDigests returns the subjects detected in the given TaskRun. It takes into account taskrun and step results.
@@ -81,6 +117,7 @@ func SubjectDigests(ctx context.Context, tro *objects.TaskRunObjectV1) []*intoto
 
 	taskSubjects := extract.SubjectsFromBuildArtifact(ctx, tro.GetResults())
 	subjects = artifact.AppendSubjects(subjects, taskSubjects...)
+	subjects = artifact.AppendSubjects(subjects, subjectsFromNativeArtifacts(tro)...)
 
 	return subjects
 }
@@ -93,4 +130,39 @@ func getObjectResults(tresults []v1.TaskRunResult) (res []objects.Result) {
 		})
 	}
 	return
+}
+
+// subjectsFromNativeArtifacts add native artifact outputs (where BuildOutput=true) as subjects
+func subjectsFromNativeArtifacts(tro *objects.TaskRunObjectV1) []*intoto.ResourceDescriptor {
+	var subjects []*intoto.ResourceDescriptor
+
+	addOutputSubjects := func(outputs []v1.Artifact) {
+		for _, output := range outputs {
+			if !output.BuildOutput {
+				continue
+			}
+			for _, val := range output.Values {
+				if val.Uri == "" || len(val.Digest) == 0 {
+					continue
+				}
+				digestSet := common.DigestSet{}
+				for algo, hex := range val.Digest {
+					digestSet[string(algo)] = hex
+				}
+				subjects = artifact.AppendSubjects(subjects, &intoto.ResourceDescriptor{
+					Name:   val.Uri,
+					Digest: digestSet,
+				})
+			}
+		}
+	}
+
+	if arts := tro.GetArtifacts(); arts != nil {
+		addOutputSubjects(arts.Outputs)
+	} else {
+		for _, step := range tro.GetStepArtifacts() {
+			addOutputSubjects(step.Outputs)
+		}
+	}
+	return subjects
 }

--- a/pkg/chains/formats/slsa/v2alpha4/internal/taskrun/taskrun_test.go
+++ b/pkg/chains/formats/slsa/v2alpha4/internal/taskrun/taskrun_test.go
@@ -202,6 +202,187 @@ func getStruct(t *testing.T, data map[string]any) *structpb.Struct {
 	return protoStruct
 }
 
+func TestSubjectsFromNativeArtifacts(t *testing.T) {
+	tests := []struct {
+		name string
+		tro  *objects.TaskRunObjectV1
+		want []*intoto.ResourceDescriptor
+	}{
+		{
+			name: "no artifacts",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{},
+				},
+			}),
+			want: nil,
+		},
+		{
+			name: "taskrun-level build output becomes subject",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Artifacts: &v1.Artifacts{
+							Outputs: []v1.Artifact{
+								{
+									Name:        "built-image",
+									BuildOutput: true,
+									Values: []v1.ArtifactValue{
+										{Uri: "gcr.io/test/image", Digest: map[v1.Algorithm]string{"sha256": "d31cc8328054de2bd93735f9cbf0ccfb6e0ee8f4c4225da7d8f8cb3900eaf466"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			want: []*intoto.ResourceDescriptor{
+				{
+					Name:   "gcr.io/test/image",
+					Digest: common.DigestSet{"sha256": "d31cc8328054de2bd93735f9cbf0ccfb6e0ee8f4c4225da7d8f8cb3900eaf466"},
+				},
+			},
+		},
+		{
+			name: "non-build output is excluded from subjects",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Artifacts: &v1.Artifacts{
+							Outputs: []v1.Artifact{
+								{
+									Name:        "cache",
+									BuildOutput: false,
+									Values: []v1.ArtifactValue{
+										{Uri: "gcr.io/test/cache", Digest: map[v1.Algorithm]string{"sha256": "d31cc8328054de2bd93735f9cbf0ccfb6e0ee8f4c4225da7d8f8cb3900eaf466"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			want: nil,
+		},
+		{
+			name: "step-level build output becomes subject",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Steps: []v1.StepState{
+							{
+								Name: "build",
+								Outputs: []v1.TaskRunStepArtifact{
+									{
+										Name:        "step-image",
+										BuildOutput: true,
+										Values: []v1.ArtifactValue{
+											{Uri: "gcr.io/test/step-image", Digest: map[v1.Algorithm]string{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			want: []*intoto.ResourceDescriptor{
+				{
+					Name:   "gcr.io/test/step-image",
+					Digest: common.DigestSet{"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := subjectsFromNativeArtifacts(tt.tro)
+			if d := cmp.Diff(tt.want, got, cmp.Options{protocmp.Transform()}); d != "" {
+				t.Errorf("subjectsFromNativeArtifacts() (-want, +got):\n%s", d)
+			}
+		})
+	}
+}
+
+func TestByProductsFromNativeArtifacts(t *testing.T) {
+	tests := []struct {
+		name string
+		tro  *objects.TaskRunObjectV1
+		want []*intoto.ResourceDescriptor
+	}{
+		{
+			name: "no artifacts",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{},
+				},
+			}),
+			want: nil,
+		},
+		{
+			name: "step non-build output becomes byproduct",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Steps: []v1.StepState{
+							{
+								Name: "build",
+								Outputs: []v1.TaskRunStepArtifact{
+									{
+										Name:        "cache-layer",
+										BuildOutput: false,
+										Values: []v1.ArtifactValue{
+											{Uri: "gcr.io/test/cache", Digest: map[v1.Algorithm]string{"sha256": "d31cc8328054de2bd93735f9cbf0ccfb6e0ee8f4c4225da7d8f8cb3900eaf466"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			want: []*intoto.ResourceDescriptor{
+				{
+					Name:   "gcr.io/test/cache",
+					Digest: common.DigestSet{"sha256": "d31cc8328054de2bd93735f9cbf0ccfb6e0ee8f4c4225da7d8f8cb3900eaf466"},
+				},
+			},
+		},
+		{
+			name: "build output is excluded from byproducts",
+			tro: objects.NewTaskRunObjectV1(&v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Steps: []v1.StepState{
+							{
+								Name: "build",
+								Outputs: []v1.TaskRunStepArtifact{
+									{
+										Name:        "built-image",
+										BuildOutput: true,
+										Values: []v1.ArtifactValue{
+											{Uri: "gcr.io/test/image", Digest: map[v1.Algorithm]string{"sha256": "d31cc8328054de2bd93735f9cbf0ccfb6e0ee8f4c4225da7d8f8cb3900eaf466"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := byProductsFromNativeArtifacts(tt.tro)
+			if d := cmp.Diff(tt.want, got, cmp.Options{protocmp.Transform()}); d != "" {
+				t.Errorf("byProductsFromNativeArtifacts() (-want, +got):\n%s", d)
+			}
+		})
+	}
+}
+
 func getPredicateStruct(t *testing.T, slsaPredicate *slsa.Provenance) *structpb.Struct {
 	t.Helper()
 	predicateJSON, err := protojson.Marshal(slsaPredicate)

--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -84,6 +84,8 @@ type TektonObject interface {
 	IsRemote() bool
 	GetStartTime() *time.Time
 	GetCompletitionTime() *time.Time
+	GetArtifacts() *v1.Artifacts
+	GetStepArtifacts() []StepArtifacts
 }
 
 func NewTektonObject(i interface{}) (TektonObject, error) {
@@ -262,6 +264,34 @@ func (tro *TaskRunObjectV1) GetCompletitionTime() *time.Time {
 	return utc
 }
 
+// StepArtifacts holds the native Tekton Artifacts (TEP-0147) declared by a single step.
+type StepArtifacts struct {
+	StepName string
+	Inputs   []v1.TaskRunStepArtifact
+	Outputs  []v1.TaskRunStepArtifact
+}
+
+// GetArtifacts returns the task-level native artifacts from the TaskRun status.
+func (tro *TaskRunObjectV1) GetArtifacts() *v1.Artifacts {
+	return tro.Status.Artifacts
+}
+
+// GetStepArtifacts returns per-step native artifacts from the TaskRun status.
+func (tro *TaskRunObjectV1) GetStepArtifacts() []StepArtifacts {
+	var stepArts []StepArtifacts
+	for _, step := range tro.Status.Steps {
+		if len(step.Inputs) == 0 && len(step.Outputs) == 0 {
+			continue
+		}
+		stepArts = append(stepArts, StepArtifacts{
+			StepName: step.Name,
+			Inputs:   step.Inputs,
+			Outputs:  step.Outputs,
+		})
+	}
+	return stepArts
+}
+
 // PipelineRunObjectV1 extends v1.PipelineRun with additional functions.
 type PipelineRunObjectV1 struct {
 	// The base PipelineRun
@@ -436,4 +466,14 @@ func (pro *PipelineRunObjectV1) GetExecutedTasks() (tro []*TaskRunObjectV1) {
 	}
 
 	return
+}
+
+// GetArtifacts returns nil; PipelineRun-level native artifacts are not yet supported.
+func (pro *PipelineRunObjectV1) GetArtifacts() *v1.Artifacts {
+	return nil
+}
+
+// GetStepArtifacts returns nil; PipelineRun-level native artifacts are not yet supported.
+func (pro *PipelineRunObjectV1) GetStepArtifacts() []StepArtifacts {
+	return nil
 }

--- a/pkg/chains/objects/objects_test.go
+++ b/pkg/chains/objects/objects_test.go
@@ -394,6 +394,80 @@ func TestPipelineRunIsRemote(t *testing.T) {
 	assert.Equal(t, true, pro.IsRemote())
 }
 
+func TestTaskRun_GetArtifacts(t *testing.T) {
+	t.Run("returns nil when no artifacts", func(t *testing.T) {
+		tr := NewTaskRunObjectV1(getTaskRun())
+		assert.Nil(t, tr.GetArtifacts())
+	})
+
+	t.Run("returns artifacts when present", func(t *testing.T) {
+		tr := NewTaskRunObjectV1(getTaskRun())
+		tr.Status.Artifacts = &v1.Artifacts{
+			Inputs: []v1.Artifact{
+				{
+					Name:   "source",
+					Values: []v1.ArtifactValue{{Uri: "git+https://github.com/org/repo", Digest: map[v1.Algorithm]string{"sha1": "abc123"}}},
+				},
+			},
+			Outputs: []v1.Artifact{
+				{
+					Name:        "image",
+					BuildOutput: true,
+					Values:      []v1.ArtifactValue{{Uri: "gcr.io/test/image", Digest: map[v1.Algorithm]string{"sha256": "def456"}}},
+				},
+			},
+		}
+		got := tr.GetArtifacts()
+		assert.NotNil(t, got)
+		assert.Len(t, got.Inputs, 1)
+		assert.Equal(t, "source", got.Inputs[0].Name)
+		assert.Len(t, got.Outputs, 1)
+		assert.Equal(t, "image", got.Outputs[0].Name)
+		assert.True(t, got.Outputs[0].BuildOutput)
+	})
+}
+
+func TestTaskRun_GetStepArtifacts(t *testing.T) {
+	t.Run("returns nil when steps have no artifacts", func(t *testing.T) {
+		tr := NewTaskRunObjectV1(getTaskRun())
+		got := tr.GetStepArtifacts()
+		assert.Nil(t, got)
+	})
+
+	t.Run("returns step artifacts when present", func(t *testing.T) {
+		tr := NewTaskRunObjectV1(getTaskRun())
+		tr.Status.Steps = []v1.StepState{
+			{
+				Name: "build",
+				Inputs: []v1.TaskRunStepArtifact{
+					{Name: "base-image", Values: []v1.ArtifactValue{{Uri: "registry.redhat.io/ubi9", Digest: map[v1.Algorithm]string{"sha256": "aaa111"}}}},
+				},
+				Outputs: []v1.TaskRunStepArtifact{
+					{Name: "built-image", BuildOutput: true, Values: []v1.ArtifactValue{{Uri: "gcr.io/test/app", Digest: map[v1.Algorithm]string{"sha256": "bbb222"}}}},
+				},
+			},
+			{
+				Name: "no-artifacts",
+			},
+		}
+		got := tr.GetStepArtifacts()
+		assert.Len(t, got, 1)
+		assert.Equal(t, "build", got[0].StepName)
+		assert.Len(t, got[0].Inputs, 1)
+		assert.Len(t, got[0].Outputs, 1)
+	})
+}
+
+func TestPipelineRun_GetArtifacts(t *testing.T) {
+	pro := NewPipelineRunObjectV1(getPipelineRun())
+	assert.Nil(t, pro.GetArtifacts())
+}
+
+func TestPipelineRun_GetStepArtifacts(t *testing.T) {
+	pro := NewPipelineRunObjectV1(getPipelineRun())
+	assert.Nil(t, pro.GetStepArtifacts())
+}
+
 func TestTaskRunIsRemote(t *testing.T) {
 	tro := NewTaskRunObjectV1(getTaskRun())
 	tro.Spec.TaskRef = &v1.TaskRef{

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1099,3 +1099,123 @@ func TestRemoteStepActionProvenance(t *testing.T) {
 		}
 	}
 }
+
+func TestNativeArtifactsProvenance(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+	c, ns, cleanup := setup(ctx, t, setupOpts{})
+	t.Cleanup(cleanup)
+
+	resetConfig := setConfigMap(ctx, t, c, map[string]string{
+		"artifacts.taskrun.format":  "slsa/v2alpha4",
+		"artifacts.taskrun.signer":  "x509",
+		"artifacts.taskrun.storage": "tekton",
+		"artifacts.oci.signer":      "x509",
+		"artifacts.oci.storage":     "tekton",
+	})
+	t.Cleanup(resetConfig)
+
+	resetPipelinesConfig := setupPipelinesFeatureFlags(ctx, t, c, map[string]string{
+		"enable-artifacts": "true",
+	})
+	t.Cleanup(resetPipelinesConfig)
+
+	tr, err := taskRunFromFile("testdata/native-artifacts/taskrun.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tro := objects.NewTaskRunObjectV1(tr)
+	tro.Namespace = ns
+
+	createdTro := tekton.CreateObject(t, ctx, c.PipelineClient, tro)
+
+	if got := waitForCondition(ctx, t, c.PipelineClient, createdTro, done, time.Minute); got == nil {
+		t.Fatal("object never done")
+	}
+
+	signedObj := waitForCondition(ctx, t, c.PipelineClient, createdTro, signed, 2*time.Minute)
+	if signedObj == nil {
+		t.Fatal("object never signed")
+	}
+
+	payloadKey := fmt.Sprintf("chains.tekton.dev/payload-taskrun-%s", signedObj.GetUID())
+	body := signedObj.GetAnnotations()[payloadKey]
+	bodyBytes, err := base64.StdEncoding.DecodeString(body)
+	if err != nil {
+		t.Fatalf("error decoding payload: %v", err)
+	}
+
+	var statement intoto.Statement
+	if err := json.Unmarshal(bodyBytes, &statement); err != nil {
+		t.Fatalf("error unmarshaling statement: %v", err)
+	}
+
+	t.Logf("Statement subject count: %d", len(statement.Subject))
+	for _, s := range statement.Subject {
+		t.Logf("  Subject: %s %v", s.Name, s.Digest)
+	}
+
+	if len(statement.Subject) == 0 {
+		t.Error("expected at least one subject in the provenance statement")
+	}
+
+	// Verify legacy type-hinted subject is present
+	legacyDigest := "586789aa031fafc7d78a5393cdc772e0b55107ea54bb8bcf3f2cdac6c6da51ee"
+	foundLegacy := false
+	for _, s := range statement.Subject {
+		if s.Digest["sha256"] == legacyDigest {
+			foundLegacy = true
+			break
+		}
+	}
+	if !foundLegacy {
+		t.Errorf("legacy type-hinted subject sha256:%s not found in subjects", legacyDigest)
+	}
+	// Verify native build output appears as subject
+	nativeSubjectDigest := "d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"
+	foundNativeSubject := false
+	for _, s := range statement.Subject {
+		if s.Digest["sha256"] == nativeSubjectDigest {
+			foundNativeSubject = true
+			break
+		}
+	}
+	if !foundNativeSubject {
+		t.Errorf("native build output sha256:%s not found in subjects", nativeSubjectDigest)
+	}
+	// Unmarshal predicate to check resolvedDependencies and byProducts
+	predicateBytes, err := protojson.Marshal(statement.Predicate)
+	if err != nil {
+		t.Fatalf("failed to marshal predicate: %v", err)
+	}
+	var pred slsa1.Provenance
+	if err := protojson.Unmarshal(predicateBytes, &pred); err != nil {
+		t.Fatalf("failed to unmarshal predicate: %v", err)
+	}
+	// Verify native input appears in resolvedDependencies
+	wantInputURI := "git+https://github.com/test/repo.git"
+	wantInputDigest := "b35cacccfdb1e24dc497d15571c23e14580b8536e3bd1f65c3ad5a76012e3860"
+	foundInput := false
+	for _, rd := range pred.GetBuildDefinition().GetResolvedDependencies() {
+		if rd.GetUri() == wantInputURI && rd.GetDigest()["sha256"] == wantInputDigest {
+			foundInput = true
+			break
+		}
+	}
+	if !foundInput {
+		t.Errorf("native input %s@sha256:%s not found in resolvedDependencies", wantInputURI, wantInputDigest)
+	}
+	// Verify non-build output appears in byProducts
+	wantByProductURI := "gcr.io/test/sbom"
+	wantByProductDigest := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	foundByProduct := false
+	for _, bp := range pred.GetRunDetails().GetByproducts() {
+		if bp.GetName() == wantByProductURI && bp.GetDigest()["sha256"] == wantByProductDigest {
+			foundByProduct = true
+			break
+		}
+	}
+	if !foundByProduct {
+		t.Errorf("native non-build output %s@sha256:%s not found in byProducts", wantByProductURI, wantByProductDigest)
+	}
+	verifySignature(ctx, t, c, signedObj)
+}

--- a/test/testdata/native-artifacts/taskrun.json
+++ b/test/testdata/native-artifacts/taskrun.json
@@ -1,0 +1,36 @@
+{
+  "apiVersion": "tekton.dev/v1",
+  "kind": "TaskRun",
+  "metadata": {
+    "generateName": "native-artifacts-",
+    "annotations": {
+      "chains.tekton.dev/rekor": "true"
+    }
+  },
+  "spec": {
+    "taskSpec": {
+      "results": [
+        {
+          "name": "IMAGE_URL",
+          "type": "string"
+        },
+        {
+          "name": "IMAGE_DIGEST",
+          "type": "string"
+        }
+      ],
+      "steps": [
+        {
+          "name": "build",
+          "image": "bash:latest",
+          "script": "#!/usr/bin/env bash\necho -n \"gcr.io/native/image\" | tee $(results.IMAGE_URL.path)\necho -n \"sha256:586789aa031fafc7d78a5393cdc772e0b55107ea54bb8bcf3f2cdac6c6da51ee\" | tee $(results.IMAGE_DIGEST.path)\n"
+        },
+        {
+          "name": "declare-artifacts",
+          "image": "bash:latest",
+          "script": "#!/usr/bin/env bash\ncat > $(step.artifacts.path) << 'EOF'\n{\"inputs\":[{\"name\":\"source-repo\",\"values\":[{\"uri\":\"git+https://github.com/test/repo.git\",\"digest\":{\"sha256\":\"b35cacccfdb1e24dc497d15571c23e14580b8536e3bd1f65c3ad5a76012e3860\"}}]}],\"outputs\":[{\"name\":\"build-image\",\"values\":[{\"uri\":\"gcr.io/test/native-image\",\"digest\":{\"sha256\":\"d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6\"}}],\"buildOutput\":true},{\"name\":\"sbom-report\",\"values\":[{\"uri\":\"gcr.io/test/sbom\",\"digest\":{\"sha256\":\"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2\"}}],\"buildOutput\":false}]}\nEOF\n"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION


<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
Today, Chains generates SLSA provenance for TaskRuns by extracting input and output artifacts from type-hinted results -specially named results like *IMAGE_URL, *IMAGE_DIGEST, CHAINS-GIT_COMMIT, and *ARTIFACT_OUTPUTS. If a result name doesn't match the expected pattern, Chains silently ignores it.

This PR is wiring the Tekton native artifact API ([TEP-0147](https://github.com/tektoncd/community/blob/main/teps/0147-tekton-artifacts-phase1.md))  into Chains' SLSA provenance generation.
This allows steps to explicitly declare their inputs and outputs by writing a JSON file to $(step.artifacts.path). The Pipelines controller then populates `status.artifacts` and `status.steps[].inputs/outputs` on the TaskRun with structured data including URIs, digests, and a buildOutput flag.
### Artifact mapping
| Artifact field | `buildOutput` | SLSA provenance field |
|---|---|---|
| `inputs[].values` | n/a | `resolvedDependencies` |
| `outputs[].values` | `true` | `subject` |
| `outputs[].values` | `false` | `byproducts` |

This does not replace type-hinting, but adds the ability of chains to fetch inputs and outputs, without forcing the user to exactly match naming convetions.

**Tested on a kind cluster
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Chains now supports the native Tekton Artifacts API (TEP-0147) for SLSA provenance generation. Task authors can declare build inputs and outputs via `$(step.artifacts.path)` as an alternative to type-hinted results, with no naming conventions required.
```
