### PR TITLE
fix(release): stop duplicating GitHub release title

### DIFF
--- a/.tekton/release-patch.yaml
+++ b/.tekton/release-patch.yaml
@@ -68,6 +68,8 @@ spec:
       value: ""
     - name: releaseName
       value: ""
+    - name: draft
+      value: "false"
   timeouts:
     pipeline: 3h0m0s
   workspaces:

--- a/.tekton/release.yaml
+++ b/.tekton/release.yaml
@@ -77,6 +77,8 @@ spec:
       value: ""
     - name: releaseName
       value: ""
+    - name: draft
+      value: "false"
   timeouts:
     pipeline: 3h0m0s
   workspaces:

--- a/release/release-pipeline.yaml
+++ b/release/release-pipeline.yaml
@@ -69,8 +69,16 @@ spec:
       description: Previous release tag for changelog generation (e.g. v0.26.0). If empty, auto-detected from git tags.
       default: ""
     - name: releaseName
-      description: Release name (e.g. "Swallow Sparrow"). If empty, uses version tag.
+      description: |
+        Release name (e.g. "Swallow Sparrow"). If empty, the release title
+        is just "Tekton Chains release <versionTag>" with no extra name.
       default: ""
+    - name: draft
+      description: |
+        Whether to create the GitHub release as a draft for manual review.
+        Set to "true" to leave it as an unpublished draft instead of
+        publishing directly.
+      default: "false"
   workspaces:
     - name: workarea
       description: The workspace where the repo will be cloned.
@@ -503,10 +511,12 @@ spec:
               fi
               printf '%s' "${PREVIOUS}" > "$(results.previous-tag.path)"
 
-              # Use provided name or fall back to version
-              if [ -z "${NAME}" ]; then
-                NAME="Release ${VERSION}"
-              fi
+              # Leave release-name empty when none is given. The
+              # create-draft-release task only appends a quoted release
+              # name to the title when one is actually provided; synthesizing
+              # a fallback like "Release ${VERSION}" here would produce a
+              # duplicated, quoted title, e.g.:
+              #   Tekton Chains release v0.28.0 "Release v0.28.0"
               printf '%s' "${NAME}" > "$(results.release-name.path)"
 
     - name: create-draft-release
@@ -524,7 +534,7 @@ spec:
           - name: url
             value: https://github.com/tektoncd/plumbing
           - name: revision
-            value: 7abffd25eb2e578e6698a9ff13470d04906f79e6
+            value: 894710e292fcb6b17276af01a2bc318107eef8a7
           - name: pathInRepo
             value: tekton/resources/release/base/github_release_oci.yaml
       params:
@@ -540,6 +550,8 @@ spec:
           value: $(tasks.prepare-draft-release.results.previous-tag)
         - name: rekor-uuid
           value: $(tasks.wait-for-chains.results.rekor-uuid)
+        - name: draft
+          value: $(params.draft)
         - name: source-subpath
           value: git
         - name: release-subpath


### PR DESCRIPTION
# Changes

The `create-draft-release` task's `github_release_oci.yaml` pin was
still on the commit before tektoncd/plumbing#3519, so this pipeline
never picked up the upstream fix for the duplicated, quoted release
title.

This PR:

* Bumps the pinned plumbing revision to `main`, which includes that
  fix.
* Drops this pipeline's own `Release ${VERSION}` fallback name in
  `prepare-draft-release`: the plumbing task only avoids the
  duplicated title when `release-name` is empty, so synthesizing a
  non-empty fallback here defeated the fix, producing titles like:

  ```
  Tekton Chains release v0.28.0 "Release v0.28.0"
  ```

* Wires up the new `draft` param (default `"false"`) introduced by
  that same plumbing PR, so releases are published directly instead
  of being left as an unpublished draft that a maintainer has to
  manually publish.

/kind bug

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
Fix duplicated GitHub release titles and publish releases directly instead of leaving them as unpublished drafts.
```

Made with [Cursor](https://cursor.com)