### PR TITLE
fix(x509): support ed25519 private keys in the x509 signer

### DIFF
--- a/pkg/chains/signing/x509/x509.go
+++ b/pkg/chains/signing/x509/x509.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	cx509 "crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -190,11 +191,16 @@ func x509Signer(ctx context.Context, privateKey []byte) (*Signer, error) {
 	if err != nil {
 		return nil, err
 	}
-	ecdsaKey, ok := pk.(*ecdsa.PrivateKey)
-	if !ok {
-		return nil, fmt.Errorf("unsupported private key type %T, only ECDSA keys are supported", pk)
+
+	var signer signature.SignerVerifier
+	switch key := pk.(type) {
+	case *ecdsa.PrivateKey:
+		signer, err = signature.LoadECDSASignerVerifier(key, crypto.SHA256)
+	case ed25519.PrivateKey:
+		signer, err = signature.LoadED25519SignerVerifier(key)
+	default:
+		return nil, fmt.Errorf("unsupported private key type %T, only ECDSA and ed25519 keys are supported", pk)
 	}
-	signer, err := signature.LoadECDSASignerVerifier(ecdsaKey, crypto.SHA256)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chains/signing/x509/x509_test.go
+++ b/pkg/chains/signing/x509/x509_test.go
@@ -51,6 +51,38 @@ const ed25519Priv = `-----BEGIN PRIVATE KEY-----
 MC4CAQAwBQYDK2VwBCIEIGQn0bJwshjwuVdnd/FylMk3Gvb89aGgH49bQpgzCY0n
 -----END PRIVATE KEY-----`
 
+// Generated with:
+// openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out rsa_private.pem
+// openssl pkcs8 -topk8 -nocrypt -in rsa_private.pem
+const rsaPriv = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDb+UnAxxs/VcaD
+jd5PvjVqzfiiomvZqB25+ZnA8FIyIoCoUKwSvanNRHPTVxbNR5luxuhnOJtD88U7
+s31KHSyjshU9BGIxRP4qxhhk3toq8TnkWlttY4wLd0T/lZxsK1fTIjhvPBtJKMU+
+85Bpc9ZVXR93dQMjWa7prQIKhXVKpj9kQkTyf1sOSkxb0VOQPYdNLzwap+YDOCo0
+0GxYjApjZic6kOM5/+dvEwb0NeTt3sz/YoUjobX5b/RtwYVVM625vhJ9fhTZygG/
+oPbloOKOqf+qj47f6uynLC4VWkWsT7kK8S3VUYfNH4XrJQxs/98lAdh45KLtHKPw
+Pfquf9MtAgMBAAECggEASacpBjbEjUrTmqXMW4f1C8tmZlIa6XhsZ6JG1H7DDs1V
+pcXJL8c4jSXP4GIHHPnNynUoSLN/7Vs4XXqGR2QIV9EfYlxO4m9W6QyGC3RAuWMm
+vqpwdWqA8C/htvApvWAv2l5ZZglKm47eqGrWHjDugYuaJx3TTKlRMyW+CrbP5Iux
+kLR68t+NTVhZNKmqQiUSaUjnuWtumzRJY8oMsFytpo3J58CgETypa6n+OyiEQDn4
+Eco3MvxE7a37S0q4MMh2DrT+4f4q6Aj917i47u1DRRquczBcOxOrtlBDvP33a9G7
+yrH4QAoTFP8frwvf7dScHsP083EziccWDkAX6zkpYwKBgQD5KuPI1h/WDjKgSkvQ
+35ecgmPMeywgCvljDAGn0y1Jl/4Pm/KeJka17XsUrUhD/klZPP4HOZ6KXdaY4Jfv
+V1D2gjp8t8h16B1sK0VFzgPk/Jm3W7ozADpffbeUaXZru7tQmxsJkl8Xi/RheOxJ
+wO6WkZHLFx98IxC8JoF3pRWiZwKBgQDiAXapVkjlf+O0MyI7IwhW5lvHC/AKI+nd
+D+IfUi4KS6e9BjcAap+JjFVZs/5q5QXw9xSGcJnvbXutxcFw2hpsm9aDmiWVcf5F
++MxzaR+iMJYQviTgoyX+MPmFG0cZByV7teDIL1gECXKgK+EBsnLTgvtAmSd7Ovgg
+inBhm+tpSwKBgC/ogD2odhyZRECvqF4z75nHNFsnv7c1hPf3YgYbw5Rn5hCoQoEI
+CQaH7+ds3f080muXH5zSBlrCajWg0XXSix2qsoYybBfHloiq1Tnzv6nyq7emqmmN
+/KtJp9egY4WZZg28lPlFLIWBgm6PapdPwlAvEyJCgupCb8BNgw03L663AoGANIAS
+iJO6q1ViF+Io+YPR1B3/A+YKBNEC6o9d/9ifSVT5yjc/X6FlHhazXPsrBrnc/3Tm
+F7TgjXXpXRyrKwP/T2uEEV4ljOnGH4sEM2sgJhUTRyBkgKplkP7fd8Q2Z+H5GxvM
+87PLxmRLdFm9Ex/Y/LlYlFD/kujH6wc9w+7saLECgYBS7gyUzNIR8W1aOLSyDhuZ
+j8OliPAI7kZr5666L2QlTPEwXAcWJZtNbnsglOnLxJrcHQggfBZJzGROUbYlwVSq
+3OSli8BsO9UXcxqUZknKT24PB+OfBKmXLXcblj/170SRoA/LdjR1mLPqgmysSorU
+B5NAMHSj1ynwROhQdRnLUg==
+-----END PRIVATE KEY-----`
+
 // Generated with RS256 algorithm (required for cosign v2.6.0+)
 // openssl genrsa -out private.pem 2048
 // python3 -c "import jwt; import time; private_key = open('/tmp/private.pem').read(); payload = {'iat': int(time.time()), 'exp': int(time.time()) + 3600 * 24 * 365 * 10, 'iss': 'user123'}; print(jwt.encode(payload, private_key, algorithm='RS256'))"
@@ -218,7 +250,6 @@ func TestSigner_SignECDSA(t *testing.T) {
 }
 
 func TestSigner_SignED25519(t *testing.T) {
-	t.Skip("skip test until ed25519 signing is implemented")
 	ctx := logtesting.TestContextWithLogger(t)
 	d := t.TempDir()
 	p := filepath.Join(d, "x509.pem")
@@ -276,8 +307,8 @@ func TestNewSignerUnsupportedX509KeyType(t *testing.T) {
 	ctx := logtesting.TestContextWithLogger(t)
 	d := t.TempDir()
 	p := filepath.Join(d, "x509.pem")
-	// ed25519 keys are a valid PKCS8 key but not supported by the x509 signer.
-	if err := os.WriteFile(p, []byte(ed25519Priv), 0644); err != nil {
+	// RSA keys are a valid PKCS8 key but not supported by the x509 signer.
+	if err := os.WriteFile(p, []byte(rsaPriv), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/clients.go
+++ b/test/clients.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
@@ -86,10 +87,11 @@ func newClients(t *testing.T, configPath, clusterName string) *clients {
 }
 
 type setupOpts struct {
-	useCosignSigner bool
-	registry        bool
-	kanikoTaskImage string
-	ns              string
+	useCosignSigner  bool
+	useEd25519Signer bool
+	registry         bool
+	kanikoTaskImage  string
+	ns               string
 }
 
 func setup(ctx context.Context, t *testing.T, opts setupOpts) (*clients, string, func()) {
@@ -197,7 +199,7 @@ func createRegistry(ctx context.Context, t *testing.T, namespace string, kubeCli
 }
 
 type secret struct {
-	x509priv   *signature.ECDSASignerVerifier
+	x509priv   signature.SignerVerifier
 	cosignPriv signature.SignerVerifier
 }
 
@@ -213,19 +215,37 @@ func setupSecret(ctx context.Context, t *testing.T, c kubernetes.Interface, opts
 	}
 
 	// x509
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	b, err := x509.MarshalPKCS8PrivateKey(priv)
-	if err != nil {
-		t.Fatal(err)
-	}
-	s.StringData["x509.pem"] = string(pem.EncodeToMemory(&pem.Block{Bytes: b, Type: "PRIVATE KEY"}))
+	var x509Priv signature.SignerVerifier
+	if opts.useEd25519Signer {
+		_, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := x509.MarshalPKCS8PrivateKey(priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.StringData["x509.pem"] = string(pem.EncodeToMemory(&pem.Block{Bytes: b, Type: "PRIVATE KEY"}))
 
-	x509Priv, err := signature.LoadECDSASignerVerifier(priv, crypto.SHA256)
-	if err != nil {
-		t.Fatal(err)
+		x509Priv, err = signature.LoadED25519SignerVerifier(priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := x509.MarshalPKCS8PrivateKey(priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.StringData["x509.pem"] = string(pem.EncodeToMemory(&pem.Block{Bytes: b, Type: "PRIVATE KEY"}))
+
+		x509Priv, err = signature.LoadECDSASignerVerifier(priv, crypto.SHA256)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// cosign

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -145,6 +145,7 @@ func TestRekor(t *testing.T) {
 		name      string
 		cm        map[string]string
 		getObject func(ns string) objects.TektonObject
+		opts      setupOpts
 	}{
 		{
 			name: "taskrun",
@@ -178,12 +179,28 @@ func TestRekor(t *testing.T) {
 			},
 			getObject: getPipelineRunObject,
 		},
+		{
+			// Covers the x509 signer's ed25519 key path (see #1868): the
+			// signing-secrets x509.pem is an ed25519 key instead of ECDSA.
+			name: "taskrun-ed25519",
+			cm: map[string]string{
+				"artifacts.taskrun.format":  "in-toto",
+				"artifacts.taskrun.signer":  "x509",
+				"artifacts.taskrun.storage": "tekton",
+				"artifacts.oci.format":      "simplesigning",
+				"artifacts.oci.signer":      "x509",
+				"artifacts.oci.storage":     "tekton",
+				"transparency.enabled":      "true",
+			},
+			getObject: getTaskRunObject,
+			opts:      setupOpts{useEd25519Signer: true},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := logtesting.TestContextWithLogger(t)
-			c, ns, cleanup := setup(ctx, t, setupOpts{})
+			c, ns, cleanup := setup(ctx, t, test.opts)
 			t.Cleanup(cleanup)
 
 			// Setup the right config.
@@ -470,7 +487,11 @@ func TestOCIStorage(t *testing.T) {
 		t.Fatal("object never signed")
 	}
 
-	publicKey, err := cryptoutils.MarshalPublicKeyToPEM(c.secret.x509priv.Public())
+	x509PubKey, err := c.secret.x509priv.PublicKey()
+	if err != nil {
+		t.Error(err)
+	}
+	publicKey, err := cryptoutils.MarshalPublicKeyToPEM(x509PubKey)
 	if err != nil {
 		t.Error(err)
 	}
@@ -537,7 +558,11 @@ func TestMultiBackendStorage(t *testing.T) {
 
 			createdObj := tekton.CreateObject(t, ctx, c.PipelineClient, test.getObject(ns))
 
-			publicKey, err := cryptoutils.MarshalPublicKeyToPEM(c.secret.x509priv.Public())
+			x509PubKey, err := c.secret.x509priv.PublicKey()
+			if err != nil {
+				t.Error(err)
+			}
+			publicKey, err := cryptoutils.MarshalPublicKeyToPEM(x509PubKey)
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

The x509 signer's docs (`docs/signing.md`) state that the private key stored
in the `x509.pem` secret may be of type `ed25519` or `ecdsa`, but
`x509Signer()` only ever handled `*ecdsa.PrivateKey`. Any other PKCS8 key
type — including ed25519 — was rejected with
`unsupported private key type ..., only ECDSA keys are supported` (this used
to be an unchecked type assertion that panicked the controller; a prior fix
turned that into a graceful error, but ed25519 keys still could not be used
to sign at all, even though the docs say they should work).

This replaces the single `pk.(*ecdsa.PrivateKey)` assertion with a type
switch that also handles `ed25519.PrivateKey` via
`signature.LoadED25519SignerVerifier` (from the already-vendored
`github.com/sigstore/sigstore/pkg/signature` package used elsewhere in this
file). Any other key type still falls through to the existing descriptive
error, now mentioning both supported types.

The `TestSigner_SignED25519` test, previously skipped with
`t.Skip("skip test until ed25519 signing is implemented")`, is un-skipped
and now passes. `TestNewSignerUnsupportedX509KeyType` (which exercises the
"unsupported key type" error path) was switched from an ed25519 key to a
freshly generated RSA key, since ed25519 is no longer unsupported.

This is scoped to the `x509.pem` load path only; the `cosign.key` path
(`cosignSigner`) already supports ed25519 via cosign's own key loader and is
unaffected.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The x509 signer now supports ed25519 private keys (in addition to ECDSA), matching the documented behavior. Previously, an ed25519 `x509.pem` signing key was rejected with an "unsupported private key type" error.
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #1189