### PR TITLE
fix(storage): drop imagePullSecrets from OCI auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -259,7 +259,7 @@ require (
 	github.com/google/cel-go v0.29.2 // indirect
 	github.com/google/certificate-transparency-go v1.3.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20250225234217-098045d5e61f // indirect
+	github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20260602200943-e4a78951c3eb // indirect
 	github.com/google/go-github/v73 v73.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/licenseclassifier v0.0.0-20210722185704-3043a050f148 // indirect

--- a/go.sum
+++ b/go.sum
@@ -701,8 +701,8 @@ github.com/google/go-containerregistry v0.21.9 h1:F+D4uZ3iA3DLMJLfhaqMdHJbzeqm/2
 github.com/google/go-containerregistry v0.21.9/go.mod h1:dP5XNKcL7kMFF/TB3LfvWmVhAcv7iqkHb3oDK8aauTo=
 github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20260414223304-7a662782a11f h1:31syNEUHTz7kt9AmH9SyXgV+Y6LMd62ZjaEcPWCy9z0=
 github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20260414223304-7a662782a11f/go.mod h1:iMEl9wsO8BHbAcfXcIFCN03G1odxdJXkdAaskB4pHxg=
-github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20250225234217-098045d5e61f h1:GJRzEBoJv/A/E7JbTekq1Q0jFtAfY7TIxUFAK89Mmic=
-github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20250225234217-098045d5e61f/go.mod h1:ZT74/OE6eosKneM9/LQItNxIMBV6CI5S46EXAnvkTBI=
+github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20260602200943-e4a78951c3eb h1:QhDOscbI+rYixXLhmwuh6njYVCZh4/JxgFkuIAuExNM=
+github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20260602200943-e4a78951c3eb/go.mod h1:SI3a2hhldl+pBd4Rf6Ruu95JCBs4lH4XjyVj1UHGnto=
 github.com/google/go-github/v73 v73.0.0 h1:aR+Utnh+Y4mMkS+2qLQwcQ/cF9mOTpdwnzlaw//rG24=
 github.com/google/go-github/v73 v73.0.0/go.mod h1:fa6w8+/V+edSU0muqdhCVY7Beh1M8F1IlQPZIANKIYw=
 github.com/google/go-licenses v1.6.0 h1:MM+VCXf0slYkpWO0mECvdYDVCxZXIQNal5wqUIXEZ/A=

--- a/pkg/chains/storage/oci/legacy.go
+++ b/pkg/chains/storage/oci/legacy.go
@@ -53,6 +53,20 @@ type Backend struct {
 	getAuthenticator func(ctx context.Context, obj objects.TektonObject, client kubernetes.Interface) (remote.Option, error)
 }
 
+// k8schainOptions builds the options used to resolve registry credentials for
+// the ServiceAccount running obj. IgnorePullSecrets is set because Chains only
+// ever pushes signatures/attestations, never pulls: honoring imagePullSecrets
+// here can pick a read-only credential over a push-capable one from the
+// ServiceAccount's mounted secrets when both target the same registry.
+func k8schainOptions(obj objects.TektonObject) k8schain.Options {
+	return k8schain.Options{
+		Namespace:          obj.GetNamespace(),
+		ServiceAccountName: obj.GetServiceAccountName(),
+		UseMountSecrets:    true,
+		IgnorePullSecrets:  true,
+	}
+}
+
 // NewStorageBackend returns a new OCI StorageBackend that stores signatures in an OCI registry
 func NewStorageBackend(ctx context.Context, client kubernetes.Interface, cfg config.Config) *Backend {
 	return &Backend{
@@ -60,12 +74,7 @@ func NewStorageBackend(ctx context.Context, client kubernetes.Interface, cfg con
 
 		client: client,
 		getAuthenticator: func(ctx context.Context, obj objects.TektonObject, client kubernetes.Interface) (remote.Option, error) {
-			kc, err := k8schain.New(ctx, client,
-				k8schain.Options{
-					Namespace:          obj.GetNamespace(),
-					ServiceAccountName: obj.GetServiceAccountName(),
-					UseMountSecrets:    true,
-				})
+			kc, err := k8schain.New(ctx, client, k8schainOptions(obj))
 			if err != nil {
 				return nil, errors.Wrapf(err, "creating new keychain from serviceaccount %s/%s", obj.GetNamespace(), obj.GetServiceAccountName())
 			}

--- a/pkg/chains/storage/oci/legacy_test.go
+++ b/pkg/chains/storage/oci/legacy_test.go
@@ -18,7 +18,10 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewRepo(t *testing.T) {
@@ -55,4 +58,24 @@ func TestNewRepo(t *testing.T) {
 			assert.Equal(t, repo.Name(), test.expectedRepoName)
 		}
 	})
+}
+
+// TestK8schainOptions_IgnoresImagePullSecrets guards against regressing to the
+// bug reported in https://github.com/tektoncd/chains/issues/1336: if the
+// ServiceAccount running the TaskRun/PipelineRun has both imagePullSecrets and
+// mounted secrets for the same registry, Chains must not let the read-only
+// imagePullSecret shadow the push-capable mounted secret.
+func TestK8schainOptions_IgnoresImagePullSecrets(t *testing.T) {
+	tr := &v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-taskrun", Namespace: "my-namespace"},
+		Spec:       v1.TaskRunSpec{ServiceAccountName: "my-sa"},
+	}
+	obj := objects.NewTaskRunObjectV1(tr)
+
+	opts := k8schainOptions(obj)
+
+	assert.Equal(t, "my-namespace", opts.Namespace)
+	assert.Equal(t, "my-sa", opts.ServiceAccountName)
+	assert.True(t, opts.UseMountSecrets)
+	assert.True(t, opts.IgnorePullSecrets, "chains only pushes artifacts, so imagePullSecrets must be ignored in favor of the ServiceAccount's mounted (push-capable) secrets")
 }

--- a/vendor/github.com/google/go-containerregistry/pkg/authn/kubernetes/keychain.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/authn/kubernetes/keychain.go
@@ -59,6 +59,11 @@ type Options struct {
 	// Namespace) containing credential data to use for the image pull.
 	ImagePullSecrets []string
 
+	// IgnorePullSecrets determines whether image pull secrets should be ignored.
+	// This is useful for push-only workflows that only want mount secrets from
+	// the ServiceAccount.
+	IgnorePullSecrets bool
+
 	// UseMountSecrets determines whether or not mount secrets in the ServiceAccount
 	// should be considered. Mount secrets are those listed under the `.secrets`
 	// attribute of the ServiceAccount resource. Ignored if ServiceAccountName is set
@@ -85,15 +90,17 @@ func New(ctx context.Context, client kubernetes.Interface, opt Options) (authn.K
 
 	// First, fetch all of the explicitly declared pull secrets
 	var pullSecrets []corev1.Secret
-	for _, name := range opt.ImagePullSecrets {
-		ps, err := client.CoreV1().Secrets(opt.Namespace).Get(ctx, name, metav1.GetOptions{})
-		if k8serrors.IsNotFound(err) {
-			logs.Warn.Printf("secret %s/%s not found; ignoring", opt.Namespace, name)
-			continue
-		} else if err != nil {
-			return nil, err
+	if !opt.IgnorePullSecrets {
+		for _, name := range opt.ImagePullSecrets {
+			ps, err := client.CoreV1().Secrets(opt.Namespace).Get(ctx, name, metav1.GetOptions{})
+			if k8serrors.IsNotFound(err) {
+				logs.Warn.Printf("secret %s/%s not found; ignoring", opt.Namespace, name)
+				continue
+			} else if err != nil {
+				return nil, err
+			}
+			pullSecrets = append(pullSecrets, *ps)
 		}
-		pullSecrets = append(pullSecrets, *ps)
 	}
 
 	// Second, fetch all of the pull secrets attached to our service account,
@@ -107,15 +114,17 @@ func New(ctx context.Context, client kubernetes.Interface, opt Options) (authn.K
 			return nil, err
 		}
 		if sa != nil {
-			for _, localObj := range sa.ImagePullSecrets {
-				ps, err := client.CoreV1().Secrets(opt.Namespace).Get(ctx, localObj.Name, metav1.GetOptions{})
-				if k8serrors.IsNotFound(err) {
-					logs.Warn.Printf("secret %s/%s not found; ignoring", opt.Namespace, localObj.Name)
-					continue
-				} else if err != nil {
-					return nil, err
+			if !opt.IgnorePullSecrets {
+				for _, localObj := range sa.ImagePullSecrets {
+					ps, err := client.CoreV1().Secrets(opt.Namespace).Get(ctx, localObj.Name, metav1.GetOptions{})
+					if k8serrors.IsNotFound(err) {
+						logs.Warn.Printf("secret %s/%s not found; ignoring", opt.Namespace, localObj.Name)
+						continue
+					} else if err != nil {
+						return nil, err
+					}
+					pullSecrets = append(pullSecrets, *ps)
 				}
-				pullSecrets = append(pullSecrets, *ps)
 			}
 
 			if opt.UseMountSecrets {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1200,8 +1200,8 @@ github.com/google/go-containerregistry/pkg/v1/types
 # github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20260414223304-7a662782a11f
 ## explicit; go 1.25.0
 github.com/google/go-containerregistry/pkg/authn/k8schain
-# github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20250225234217-098045d5e61f
-## explicit; go 1.23.0
+# github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20260602200943-e4a78951c3eb
+## explicit; go 1.26.0
 github.com/google/go-containerregistry/pkg/authn/kubernetes
 # github.com/google/go-github/v73 v73.0.0
 ## explicit; go 1.23.0


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

When a TaskRun/PipelineRun's ServiceAccount has both `imagePullSecrets`
and mounted `secrets` targeting the same OCI registry, the vendored
go-containerregistry keychain consolidates both sets and returns the
first match, which is always the read-only `imagePullSecrets`
credential. The OCI storage backend (`pkg/chains/storage/oci/legacy.go`,
still the active auth path wired in `pkg/chains/storage/storage.go`
despite its "Deprecated" doc-comment on the `Backend` type) only ever
pushes signed attestations, so resolving a read-only credential makes
the push fail with an auth error even though a push-capable credential
is available in `secrets`.

This addresses the ServiceAccount-level case described in the issue;
the PodTemplate-level case was already fixed in a prior, separate
change.

**Approach**
- Bump the vendored `github.com/google/go-containerregistry`
  `pkg/authn/kubernetes` module to the commit that merged upstream's
  `IgnorePullSecrets` option
  (https://github.com/google/go-containerregistry/pull/2315), which
  lets the keychain skip both the ServiceAccount's `imagePullSecrets`
  and any explicit pull secrets.
- Set `IgnorePullSecrets: true` when building the k8schain options used
  by the OCI backend, since this keychain is only ever used to push,
  never to pull.

**Validation**
- `go build ./...` passes.
- `make test-unit` passes for all packages.
- `make golangci-lint PKG=./pkg/chains/storage/oci/...` reports 0 issues.
- Added `TestK8schainOptions_IgnoresImagePullSecrets`, confirmed to fail
  if `IgnorePullSecrets: true` is removed and to pass with the fix,
  asserting the OCI backend's k8schain options are built with
  `IgnorePullSecrets` set.
- Not run: no live cluster is available in this environment, so the fix
  was not reproduced end-to-end against a real registry. Correctness
  instead relies on the upstream library's own test coverage for
  `IgnorePullSecrets` plus the added unit test confirming this backend
  threads the option through.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
When 'oci' is configured as the storage option for signed artifacts,
the tekton-chains-controller no longer uses the ServiceAccount's
`imagePullSecrets` to authenticate with the target OCI registry when
that ServiceAccount also has push-capable `secrets` for the same
registry.
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #1336