### PR TITLE
fix: exclude generated and non-library code from codecov coverage

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -8,13 +8,17 @@ coverage:
       default: false
 
 ignore:
+  # Auto-generated deepcopy code.
   - "**/zz_generated*.go"
-  - "vendor/**"
-  - "test/**"
-  - "config/**"
-  - "docs/**"
-  - "hack/**"
-  - "cmd/**"
-  - "examples/**"
-  - "images/**"
-  - "release/**"
+  - "**/fake/**"
+  # Entry-point binaries.
+  - "cmd"
+  - "vendor"
+  - "test"
+  - "pkg/test/"
+  - "config"
+  - "docs"
+  - "hack"
+  - "examples"
+  - "images"
+  - "release"

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -49,7 +49,11 @@ jobs:
       - name: Generate coverage
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/chains
         run: |
-          go test -coverprofile=coverage.txt -covermode=atomic ./... || true
+          PACKAGES=$(go list ./... | grep -vE '/cmd(/|$)|/vendor(/|$)|/hack(/|$)|/test(/|$)|/config(/|$)|/docs(/|$)|/examples(/|$)|/images(/|$)|/release(/|$)|/fake(/|$)')
+          COVERPKG=$(echo $PACKAGES | tr ' ' ',')
+          go test -coverprofile=coverage_raw.txt -covermode=atomic -coverpkg="$COVERPKG" $PACKAGES
+          grep -vE 'zz_generated\.deepcopy\.go' coverage_raw.txt > coverage.txt
+          rm -f coverage_raw.txt
           echo "Generated coverage profile"
 
       - name: Archive coverage results
@@ -66,6 +70,7 @@ jobs:
           flags: unit-tests
           use_oidc: true
           fail_ci_if_error: true
+          disable_search: true
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Codecov reports low coverage because it includes auto-generated code, vendored deps, CLI entry points, and test infrastructure in the denominator. Filter these out so coverage reflects actual library code. Mirrors the approach proven in tektoncd/triggers#2101.

- Replace bare `go test ./...` with filtered package list + `-coverpkg`
- Strip zz_generated.deepcopy.go from profile
- Add `disable_search: true` to codecov upload step
- Use bare directory names in .codecov.yaml

<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
