### PR TITLE
chore(deps): bump Go from 1.26.4 to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/chains
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes
Bump the Go toolchain version from 1.26.4 to 1.26.5 to
remediate stdlib CVEs
**CVEs fixed by this change:**
- **CVE-2026-39822** (Important) — stdlib, fixed in Go 1.26.5
- **CVE-2026-42505** (Moderate) — stdlib, fixed in Go 1.26.5

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
