### PR TITLE
fix(release): apply project-specific OCI labels to images for Chains

### DIFF
--- a/release/publish.yaml
+++ b/release/publish.yaml
@@ -158,6 +158,9 @@ spec:
 
       ko resolve \
         --image-label=org.opencontainers.image.source=https://$(params.package) \
+          --image-label=org.opencontainers.image.url=https://$(params.package) \
+          --image-label=org.opencontainers.image.title=chains \
+          --image-label=org.opencontainers.image.description=Tekton\ Chains \
         --platform=$(params.platforms) \
         -t $(params.versionTag) \
         ${KO_EXTRA_ARGS} -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.yaml
@@ -166,6 +169,9 @@ spec:
       # This is currently the case for `cri-o` (and most likely others)
       ko resolve \
         --image-label=org.opencontainers.image.source=https://$(params.package) \
+          --image-label=org.opencontainers.image.url=https://$(params.package) \
+          --image-label=org.opencontainers.image.title=chains \
+          --image-label=org.opencontainers.image.description=Tekton\ Chains \
         --platform=$(params.platforms) \
         ${KO_EXTRA_ARGS} -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.notags.yaml
 


### PR DESCRIPTION
# Changes

Fixes tektoncd/plumbing#3435

This updates the `release/publish.yaml` task to explicitly pass project-specific OCI image labels (`url`, `title`, and `description`) to the `ko resolve` commands. This prevents the published Chains images from incorrectly inheriting OCI metadata from their base images.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```